### PR TITLE
Converted to Context instead of Connection - Fixes #43

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Unreleased
+
+- Converted all `connection` function names and parameter names
+  over to `context`. Aliases were implemented for old `connection`
+  function and parameter names to reduce possibility of breakage.
+
 ## 2.0.1.173
 
 - Added support for CosmosDB Emulator.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Daniel Scott-Raynsford
+Copyright (c) 2018 Daniel Scott-Raynsford
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ This module supports the following:
 
 - Windows PowerShell 5.x:
   - **AzureRM.Profile** and **AzureRM.Resources** PowerShell modules
-    are required if using `New-CosmosDbConnection -ResourceGroup $resourceGroup`
+    are required if using `New-CosmosDbContext -ResourceGroup $resourceGroup`
 
 or:
 
 - PowerShell Core 6.x:
   - **AzureRM.NetCore.Profile** and **AzureRM.NetCore.Resources** PowerShell
-    modules are required if using `New-CosmosDbConnection -ResourceGroup $resourceGroup`
+    modules are required if using `New-CosmosDbContext -ResourceGroup $resourceGroup`
 
 ## Installation
 
@@ -49,16 +49,16 @@ Install-Module -Name CosmosDB
 
 ## Quick Start
 
-The easiest way to use this module is to first create a connection
-object using the `New-CosmosDbConnection` cmdlet which you can then
+The easiest way to use this module is to first create a context
+object using the `New-CosmosDbContext` cmdlet which you can then
 use to pass to the other CosmosDB cmdlets in the module.
 
-To create the connection object you will either need access to the
+To create the context object you will either need access to the
 primary primary or secondary keys from your CosmosDB account or allow
 the CosmosDB module to retrieve the keys directly from the Azure
 management portal for you.
 
-### Create a Connection specifying the Key Manually
+### Create a Context specifying the Key Manually
 
 First convert your key into a secure string:
 
@@ -66,19 +66,21 @@ First convert your key into a secure string:
 $primaryKey = ConvertTo-SecureString -String 'GFJqJesi2Rq910E0G7P4WoZkzowzbj23Sm9DUWFX0l0P8o16mYyuaZBN00Nbtj9F1QQnumzZKSGZwknXGERrlA==' -AsPlainText -Force
 ```
 
-Use the key secure string, Azure CosmosDB account name and database to create a connection variable:
+Use the key secure string, Azure CosmosDB account name and database to
+create a context variable:
 
 ```powershell
-$cosmosDbConnection = New-CosmosDbConnection -Account 'MyAzureCosmosDB' -Database 'MyDatabase' -Key $primaryKey
+$cosmosDbContext = New-CosmosDbContext -Account 'MyAzureCosmosDB' -Database 'MyDatabase' -Key $primaryKey
 ```
 
 ### Use CosmosDB Module to Retrieve Key from Azure Management Portal
 
-To create a connection object so that CosmosDB retrieves the primary or
-secondary key from the Azure Management Portal, use the following command:
+To create a context object so that the CosmosDB module retrieves the
+primary or secondary key from the Azure Management Portal, use the
+following command:
 
 ```powershell
-$cosmosDbConnection = New-CosmosDbConnection -Account 'MyAzureCosmosDB' -Database 'MyDatabase' -ResourceGroup 'MyCosmosDbResourceGroup' -MasterKeyType 'SecondaryMasterKey'
+$cosmosDbContext = New-CosmosDbContext -Account 'MyAzureCosmosDB' -Database 'MyDatabase' -ResourceGroup 'MyCosmosDbResourceGroup' -MasterKeyType 'SecondaryMasterKey'
 ```
 
 _Note: if PowerShell is not connected to Azure then an interactive
@@ -87,15 +89,15 @@ an account that doesn't contain the CosmosDB you wish to connect to then
 you will first need to connect to the correct account using the
 `Add-AzureRmAccount` cmdlet._
 
-### Create a Connection to a CosmosDB Emulator
+### Create a Context for a CosmosDB Emulator
 
 Microsoft provides a [CosmosDB emulator](https://docs.microsoft.com/en-us/azure/cosmos-db/local-emulator) that
 you can run locally to enable testing and debugging scenarios. To create
-a connection to a CosmosDB emulator installed on the localhost use the
+a context for a CosmosDB emulator installed on the localhost use the
 following command:
 
 ```powershell
-$cosmosDbConnection = New-CosmosDbConnection -Emulator -Database 'MyDatabase'
+$cosmosDbContext = New-CosmosDbContext -Emulator -Database 'MyDatabase'
 ```
 
 ### Working with Databases
@@ -103,13 +105,13 @@ $cosmosDbConnection = New-CosmosDbConnection -Emulator -Database 'MyDatabase'
 Get a list of databases in the CosmosDB account:
 
 ```powershell
-Get-CosmosDbDatabase -Connection $cosmosDbConnection
+Get-CosmosDbDatabase -Context $cosmosDbContext
 ```
 
 Get the specified database from the CosmosDB account:
 
 ```powershell
-Get-CosmosDbDatabase -Connection $cosmosDbConnection -Id 'MyDatabase'
+Get-CosmosDbDatabase -Context $cosmosDbContext -Id 'MyDatabase'
 ```
 
 ### Working with Collections
@@ -117,25 +119,26 @@ Get-CosmosDbDatabase -Connection $cosmosDbConnection -Id 'MyDatabase'
 Get a list of collections in a database:
 
 ```powershell
-Get-CosmosDbCollection -Connection $cosmosDbConnection
+Get-CosmosDbCollection -Context $cosmosDbContext
 ```
 
-Create a collection in the database with the partition key 'account' and the offer throughput of 50000 RU/s:
+Create a collection in the database with the partition key 'account' and
+the offer throughput of 50000 RU/s:
 
 ```powershell
-New-CosmosDbCollection -Connection $cosmosDbConnection -Id 'MyNewCollection' -PartitionKey 'account' -OfferThroughput 50000
+New-CosmosDbCollection -Context $cosmosDbContext -Id 'MyNewCollection' -PartitionKey 'account' -OfferThroughput 50000
 ```
 
 Get a specified collection from a database:
 
 ```powershell
-Get-CosmosDbCollection -Connection $cosmosDbConnection -Id 'MyNewCollection'
+Get-CosmosDbCollection -Context $cosmosDbContext -Id 'MyNewCollection'
 ```
 
 Delete a collection from the database:
 
 ```powershell
-Remove-CosmosDbCollection -Connection $cosmosDbConnection -Id 'MyNewCollection'
+Remove-CosmosDbCollection -Context $cosmosDbContext -Id 'MyNewCollection'
 ```
 
 ### Working with Documents
@@ -151,7 +154,7 @@ Create 10 new documents in a collection in the database:
     `"more`": `"Some other string`"
 }
 "@
-    New-CosmosDbDocument -Connection $cosmosDbConnection -CollectionId 'MyNewCollection' -DocumentBody $document
+    New-CosmosDbDocument -Context $cosmosDbContext -CollectionId 'MyNewCollection' -DocumentBody $document
 }
 ```
 
@@ -159,7 +162,7 @@ Get the first 5 documents from the collection in the database:
 
 ```powershell
 $resultHeaders = ''
-$documents = Get-CosmosDbDocument -Connection $cosmosDbConnection -CollectionId 'MyNewCollection' -MaxItemCount 5 -ResultHeaders $resultHeaders
+$documents = Get-CosmosDbDocument -Context $cosmosDbContext -CollectionId 'MyNewCollection' -MaxItemCount 5 -ResultHeaders $resultHeaders
 $continuationToken = $resultHeaders.value.'x-ms-continuation'
 ```
 
@@ -168,7 +171,7 @@ the continuation token found in the headers from the previous
 request:
 
 ```powershell
-$documents = Get-CosmosDbDocument -Connection $cosmosDbConnection -CollectionId 'MyNewCollection' -MaxItemCount 5 -ContinuationToken $continuationToken
+$documents = Get-CosmosDbDocument -Context $cosmosDbContext -CollectionId 'MyNewCollection' -MaxItemCount 5 -ContinuationToken $continuationToken
 ```
 
 Replace the content of a document in a collection in the database:
@@ -181,21 +184,21 @@ $newDocument = @"
     `"more`": `"Another new string`"
 }
 "@
-Set-CosmosDbDocument -Connection $cosmosDbConnection -CollectionId 'MyNewCollection' -Id $documents[0].id -DocumentBody $newDocument
+Set-CosmosDbDocument -Context $cosmosDbContext -CollectionId 'MyNewCollection' -Id $documents[0].id -DocumentBody $newDocument
 ```
 
 Return a document with a specific Id from a collection in
 the database:
 
 ```powershell
-Get-CosmosDbDocument -Connection $cosmosDbConnection -CollectionId 'MyNewCollection' -Id $documents[0].id
+Get-CosmosDbDocument -Context $cosmosDbContext -CollectionId 'MyNewCollection' -Id $documents[0].id
 ```
 
 Querying a collection in a database:
 
 ```powershell
 $query = "SELECT * FROM customers c WHERE (c.id = 'user@contoso.com')"
-Get-CosmosDbDocument -Connection $cosmosDbConnection -CollectionId 'MyNewCollection' -Query $query
+Get-CosmosDbDocument -Context $cosmosDbContext -CollectionId 'MyNewCollection' -Query $query
 ```
 
 Querying a collection in a database using a parameterized query:
@@ -205,13 +208,13 @@ $query = "SELECT * FROM customers c WHERE (c.id = @id)"
 $queryParameters = @(
     @{ name = "@id"; value="user@contoso.com"; }
 )
-Get-CosmosDbDocument -Connection $cosmosDbConnection -CollectionId 'MyNewCollection' -Query $query -QueryParameters $queryParameters
+Get-CosmosDbDocument -Context $cosmosDbContext -CollectionId 'MyNewCollection' -Query $query -QueryParameters $queryParameters
 ```
 
 Delete a document from a collection in the database:
 
 ```powershell
-Remove-CosmosDbDocument -Connection $cosmosDbConnection -CollectionId 'MyNewCollection' -Id $documents[0].id
+Remove-CosmosDbDocument -Context $cosmosDbContext -CollectionId 'MyNewCollection' -Id $documents[0].id
 ```
 
 ### Working with Attachments
@@ -219,31 +222,31 @@ Remove-CosmosDbDocument -Connection $cosmosDbConnection -CollectionId 'MyNewColl
 Create an attachment on a document in a collection:
 
 ```powershell
-New-CosmosDbAttachment -Connection $cosmosDbConnection -CollectionId 'MyNewCollection' -DocumentId $documents[0].id -Id 'image_1' -ContentType 'image/jpg' -Media 'www.bing.com'
+New-CosmosDbAttachment -Context $cosmosDbContext -CollectionId 'MyNewCollection' -DocumentId $documents[0].id -Id 'image_1' -ContentType 'image/jpg' -Media 'www.bing.com'
 ```
 
 Get _all_ attachments for a document in a collection:
 
 ```powershell
-Get-CosmosDbAttachment -Connection $cosmosDbConnection -CollectionId 'MyNewCollection' -DocumentId $documents[0].id
+Get-CosmosDbAttachment -Context $cosmosDbContext -CollectionId 'MyNewCollection' -DocumentId $documents[0].id
 ```
 
 Get an attachment by Id for a document in a collection:
 
 ```powershell
-Get-CosmosDbAttachment -Connection $cosmosDbConnection -CollectionId 'MyNewCollection' -DocumentId $documents[0].id -Id 'image_1'
+Get-CosmosDbAttachment -Context $cosmosDbContext -CollectionId 'MyNewCollection' -DocumentId $documents[0].id -Id 'image_1'
 ```
 
 Rename an attachment for a document in a collection:
 
 ```powershell
-Set-CosmosDbAttachment -Connection $cosmosDbConnection -CollectionId 'MyNewCollection' -DocumentId $documents[0].id -Id 'image_1' -NewId 'Image_2'
+Set-CosmosDbAttachment -Context $cosmosDbContext -CollectionId 'MyNewCollection' -DocumentId $documents[0].id -Id 'image_1' -NewId 'Image_2'
 ```
 
 Delete an attachment from a document in collection:
 
 ```powershell
-Remove-CosmosDbAttachment -Connection $cosmosDbConnection -CollectionId 'MyNewCollection' -Id $documents[0].id -Id 'Image_2'
+Remove-CosmosDbAttachment -Context $cosmosDbContext -CollectionId 'MyNewCollection' -Id $documents[0].id -Id 'Image_2'
 ```
 
 ### Working with Users
@@ -251,19 +254,19 @@ Remove-CosmosDbAttachment -Connection $cosmosDbConnection -CollectionId 'MyNewCo
 Get a list of users in the database:
 
 ```powershell
-Get-CosmosDbUser -Connection $cosmosDbConnection
+Get-CosmosDbUser -Context $cosmosDbContext
 ```
 
 Create a user in the database:
 
 ```powershell
-New-CosmosDbUser -Connection $cosmosDbConnection -Id 'MyApplication'
+New-CosmosDbUser -Context $cosmosDbContext -Id 'MyApplication'
 ```
 
 Delete a user from the database:
 
 ```powershell
-Remove-CosmosDbUser -Connection $cosmosDbConnection -Id 'MyApplication'
+Remove-CosmosDbUser -Context $cosmosDbContext -Id 'MyApplication'
 ```
 
 ### Working with Permissions
@@ -271,20 +274,20 @@ Remove-CosmosDbUser -Connection $cosmosDbConnection -Id 'MyApplication'
 Get a list of permissions for a user in the database:
 
 ```powershell
-Get-CosmosDbPermission -Connection $cosmosDbConnection -UserId 'MyApplication'
+Get-CosmosDbPermission -Context $cosmosDbContext -UserId 'MyApplication'
 ```
 
 Create a permission for a user in the database with read access to a collection:
 
 ```powershell
 $collectionId = Get-CosmosDbCollectionResourcePath -Database 'MyDatabase' -Id 'MyNewCollection'
-New-CosmosDbPermission -Connection $cosmosDbConnection -UserId 'MyApplication' -Id 'r_mynewcollection' -Resource $$collectionId -PermissionMode Read
+New-CosmosDbPermission -Context $cosmosDbContext -UserId 'MyApplication' -Id 'r_mynewcollection' -Resource $$collectionId -PermissionMode Read
 ```
 
 Remove a permission for a user from the database:
 
 ```powershell
-Remove-CosmosDbPermission -Connection $cosmosDbConnection -UserId 'MyApplication' -Id 'r_mynewcollection'
+Remove-CosmosDbPermission -Context $cosmosDbContext -UserId 'MyApplication' -Id 'r_mynewcollection'
 ```
 
 ### Working with Triggers
@@ -292,7 +295,7 @@ Remove-CosmosDbPermission -Connection $cosmosDbConnection -UserId 'MyApplication
 Get a list of triggers for a collection in the database:
 
 ```powershell
-Get-CosmosDbTrigger -Connection $cosmosDbConnection -CollectionId 'MyNewCollection'
+Get-CosmosDbTrigger -Context $cosmosDbContext -CollectionId 'MyNewCollection'
 ```
 
 Create a trigger for a collection in the database that executes after all operations:
@@ -329,7 +332,7 @@ function updateMetadata() {
     }
 }
 '@
-New-CosmosDbTrigger -Connection $cosmosDbConnection -CollectionId 'MyNewCollection' -Id 'MyTrigger' -TriggerBody $Body -TriggerOperation All -TriggerType Post
+New-CosmosDbTrigger -Context $cosmosDbContext -CollectionId 'MyNewCollection' -Id 'MyTrigger' -TriggerBody $Body -TriggerOperation All -TriggerType Post
 ```
 
 Update an existing trigger for a collection in the database to execute before
@@ -367,13 +370,13 @@ function updateMetadata() {
     }
 }
 '@
-New-CosmosDbTrigger -Connection $cosmosDbConnection -CollectionId 'MyNewCollection' -Id 'MyTrigger' -Body $Body -TriggerOperation All -TriggerType Pre
+New-CosmosDbTrigger -Context $cosmosDbContext -CollectionId 'MyNewCollection' -Id 'MyTrigger' -Body $Body -TriggerOperation All -TriggerType Pre
 ```
 
 Remove a trigger for a collection from the database:
 
 ```powershell
-Remove-CosmosDbTrigger -Connection $cosmosDbConnection -CollectionId 'MyNewCollection' -Id 'MyTrigger'
+Remove-CosmosDbTrigger -Context $cosmosDbContext -CollectionId 'MyNewCollection' -Id 'MyTrigger'
 ```
 
 ### Working with Stored procedures
@@ -381,7 +384,7 @@ Remove-CosmosDbTrigger -Connection $cosmosDbConnection -CollectionId 'MyNewColle
 Get a list of stored procedures for a collection in the database:
 
 ```powershell
-Get-CosmosDbStoredProcedure -Connection $cosmosDbConnection -CollectionId 'MyNewCollection'
+Get-CosmosDbStoredProcedure -Context $cosmosDbContext -CollectionId 'MyNewCollection'
 ```
 
 Create a stored procedure for a collection in the database:
@@ -395,7 +398,7 @@ function () {
     response.setBody("Hello, World");
 }
 '@
-New-CosmosDbStoredProcedure -Connection $cosmosDbConnection -CollectionId 'MyNewCollection' -Id 'spHelloWorld' -StoredProcedureBody $Body
+New-CosmosDbStoredProcedure -Context $cosmosDbContext -CollectionId 'MyNewCollection' -Id 'spHelloWorld' -StoredProcedureBody $Body
 ```
 
 Update an existing stored procedure for a collection in the database:
@@ -409,19 +412,19 @@ function (personToGreet) {
     response.setBody("Hello, " + personToGreet);
 }
 '@
-New-CosmosDbStoredProcedure -Connection $cosmosDbConnection -CollectionId 'MyNewCollection' -Id 'spHelloWorld' -StoredProcedureBody $Body
+New-CosmosDbStoredProcedure -Context $cosmosDbContext -CollectionId 'MyNewCollection' -Id 'spHelloWorld' -StoredProcedureBody $Body
 ```
 
 Execute a stored procedure for a collection from the database:
 
 ```powershell
-Invoke-CosmosDbStoredProcedure -Connection $cosmosDbConnection -CollectionId 'MyNewCollection' -Id 'spHelloWorld' -StoredProcedureParameters @('PowerShell')
+Invoke-CosmosDbStoredProcedure -Context $cosmosDbContext -CollectionId 'MyNewCollection' -Id 'spHelloWorld' -StoredProcedureParameters @('PowerShell')
 ```
 
 Remove a stored procedure for a collection from the database:
 
 ```powershell
-Remove-CosmosDbStoredProcedure -Connection $cosmosDbConnection -CollectionId 'MyNewCollection' -Id 'spHelloWorld'
+Remove-CosmosDbStoredProcedure -Context $cosmosDbContext -CollectionId 'MyNewCollection' -Id 'spHelloWorld'
 ```
 
 ### Working with User Defined Functions
@@ -429,7 +432,7 @@ Remove-CosmosDbStoredProcedure -Connection $cosmosDbConnection -CollectionId 'My
 Get a list of user defined functions for a collection in the database:
 
 ```powershell
-Get-CosmosDbUserDefinedFunction -Connection $cosmosDbConnection -CollectionId 'MyNewCollection'
+Get-CosmosDbUserDefinedFunction -Context $cosmosDbContext -CollectionId 'MyNewCollection'
 ```
 
 Create a user defined function for a collection in the database:
@@ -446,7 +449,7 @@ function tax(income) {
         return income * 0.4;
 }
 '@
-New-CosmosDbUserDefinedFunction -Connection $cosmosDbConnection -CollectionId 'MyNewCollection' -Id 'udfTax' -UserDefinedFunctionBody $Body
+New-CosmosDbUserDefinedFunction -Context $cosmosDbContext -CollectionId 'MyNewCollection' -Id 'udfTax' -UserDefinedFunctionBody $Body
 ```
 
 Update an existing user defined function for a collection in the database:
@@ -463,13 +466,13 @@ function tax(income) {
         return income * 0.4;
 }
 '@
-New-CosmosDbUserDefinedFunction -Connection $cosmosDbConnection -CollectionId 'MyNewCollection' -Id 'udfTax' -Body $Body
+New-CosmosDbUserDefinedFunction -Context $cosmosDbContext -CollectionId 'MyNewCollection' -Id 'udfTax' -Body $Body
 ```
 
 Remove a user defined function for a collection from the database:
 
 ```powershell
-Remove-CosmosDbUserDefinedFunction -Connection $cosmosDbConnection -CollectionId 'MyNewCollection' -Id 'udfTax'
+Remove-CosmosDbUserDefinedFunction -Context $cosmosDbContext -CollectionId 'MyNewCollection' -Id 'udfTax'
 ```
 
 ## Contributing

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## What is New in CosmosDB Unreleased
+
+February 24, 2018
+
+- Converted all `connection` function names and parameter names
+  over to `context`. Aliases were implemented for old `connection`
+  function and parameter names to reduce possibility of breakage.
+
 ## What is New in CosmosDB 2.0.1
 
 January 27, 2018

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,14 +22,14 @@ install:
 build_script:
     - ps: |
         # Update AppVeyor Build Version by pulling from Manifest
-        $ManifestPath = Join-Path -Path $ENV:APPVEYOR_BUILD_FOLDER -ChildPath 'src/CosmosDB.psd1'
-        $ManifestContent = Get-Content -Path $ManifestPath -Raw
-        $Regex = '(?<=ModuleVersion\s+=\s+'')(?<ModuleVersion>.*)(?='')'
-        $Matches = @([regex]::matches($ManifestContent, $Regex, 'IgnoreCase'))
+        $manifestPath = Join-Path -Path $ENV:APPVEYOR_BUILD_FOLDER -ChildPath 'src/CosmosDB.psd1'
+        $manifestContent = Get-Content -Path $manifestPath -Raw
+        $regex = '(?<=ModuleVersion\s+=\s+'')(?<ModuleVersion>.*)(?='')'
+        $matches = @([regex]::matches($manifestContent, $regex, 'IgnoreCase'))
         $version = $null
-        if ($Matches)
+        if ($matches)
         {
-            $version = $Matches[0].Value
+            $version = $matches[0].Value
         }
 
         # Determine the new version number
@@ -48,14 +48,21 @@ build_script:
         Update-AppveyorBuild -Version $newVersion
 
         # Set the new version number in the Module Manifest
-        $manifestContent = $ManifestContent -replace '(?<=ModuleVersion\s+=\s+'')(?<ModuleVersion>.*)(?='')', $newVersion
-        Set-Content -Path $ManifestPath -Value $ManifestContent -NoNewLine
+        $manifestContent = $manifestContent -replace '(?<=ModuleVersion\s+=\s+'')(?<ModuleVersion>.*)(?='')', $newVersion
+        $manifestContent = $manifestContent -replace '## What is New in CosmosDB Unreleased', "## What is New in CosmosDB $newVersion"
+        Set-Content -Path $manifestPath -Value $manifestContent -NoNewLine
 
         # Set the new version number in the CHANGELOG.md
         $changeLogPath = Join-Path -Path $ENV:APPVEYOR_BUILD_FOLDER -ChildPath 'CHANGELOG.md'
         $changeLogContent = Get-Content -Path $changeLogPath -Raw
         $changeLogContent = $changeLogContent -replace '# Unreleased', "# $newVersion"
         Set-Content -Path $changeLogPath -Value $changeLogContent -NoNewLine
+
+        # Set the new version number in the RELEASENOTES.md
+        $releaseNotesPath = Join-Path -Path $ENV:APPVEYOR_BUILD_FOLDER -ChildPath 'RELEASENOTES.md'
+        $releaseNotesContent = Get-Content -Path $releaseNotesPath -Raw
+        $releaseNotesContent = $releaseNotesContent -replace '## What is New in CosmosDB Unreleased', "## What is New in CosmosDB $newVersion"
+        Set-Content -Path $releaseNotesPath -Value $releaseNotesContent -NoNewLine
 
 #---------------------------------#
 #      test configuration         #

--- a/docs/ConvertTo-CosmosDbTokenDateString.md
+++ b/docs/ConvertTo-CosmosDbTokenDateString.md
@@ -24,7 +24,7 @@ by the Authorization Token and in the request header.
 ## EXAMPLES
 
 ### Example 1
-```
+```powershell
 PS C:\> {{ Add example code here }}
 ```
 
@@ -48,7 +48,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/Get-CosmosDbAttachment.md
+++ b/docs/Get-CosmosDbAttachment.md
@@ -5,30 +5,30 @@ online version:
 schema: 2.0.0
 ---
 
-# Set-CosmosDbDocument
+# Get-CosmosDbAttachment
 
 ## SYNOPSIS
-Update a document from a CosmosDB collection.
+Return the attachments for a CosmosDB document.
 
 ## SYNTAX
 
 ### Context (Default)
 ```
-Set-CosmosDbDocument -Context <Context> [-Database <String>] [-Key <SecureString>] -CollectionId <String>
- -Id <String> -DocumentBody <String> [-IndexingDirective <String>] [-PartitionKey <String>]
- [<CommonParameters>]
+Get-CosmosDbAttachment -Context <Context> [-Key <SecureString>] [-KeyType <String>] [-Database <String>]
+ -CollectionId <String> -DocumentId <String> [-Id <String>] [<CommonParameters>]
 ```
 
 ### Account
 ```
-Set-CosmosDbDocument -Account <String> [-Database <String>] [-Key <SecureString>] [-KeyType <String>]
- -CollectionId <String> -Id <String> -DocumentBody <String> [-IndexingDirective <String>]
- [-PartitionKey <String>] [<CommonParameters>]
+Get-CosmosDbAttachment -Account <String> [-Key <SecureString>] [-KeyType <String>] [-Database <String>]
+ -CollectionId <String> -DocumentId <String> [-Id <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-This cmdlet will update an existing document in a CosmosDB
-collection.
+This cmdlet will return the attachments for a specified document
+in a CosmosDB database.
+If an Id is specified then only the
+specified permission will be returned.
 
 ## EXAMPLES
 
@@ -43,7 +43,7 @@ PS C:\> {{ Add example code here }}
 
 ### -Context
 This is an object containing the context information of
-the CosmosDB database that will be deleted.
+the CosmosDB database that will be accessed.
 It should be created
 by \`New-CosmosDbContext\`.
 
@@ -74,21 +74,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Database
-The name of the database to access in the CosmosDB account.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -Key
 The key to be used to access this CosmosDB.
 
@@ -109,7 +94,7 @@ The type of key that will be used to access ths CosmosDB.
 
 ```yaml
 Type: String
-Parameter Sets: Account
+Parameter Sets: (All)
 Aliases:
 
 Required: False
@@ -119,8 +104,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Database
+The name of the database to access in the CosmosDB account.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -CollectionId
-This is the Id of the collection to update the document for.
+This is the Id of the collection to get the attachments for.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DocumentId
+This is the Id of the document to get the attachments for.
 
 ```yaml
 Type: String
@@ -135,58 +150,7 @@ Accept wildcard characters: False
 ```
 
 ### -Id
-This is the Id of the document to update.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -DocumentBody
-This is the body of the document to update.
-It must be
-formatted as a JSON string and contain the Id value of the
-document to create.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -IndexingDirective
-Include includes the document in the indexing path while
-Exclude omits the document from indexing.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -PartitionKey
-The partition key value for the document to be deleted.
-Required if and must be specified only if the collection is
-created with a partitionKey definition.
+This is the Id of the attachment to retrieve.
 
 ```yaml
 Type: String

--- a/docs/Get-CosmosDbAttachmentResourcePath.md
+++ b/docs/Get-CosmosDbAttachmentResourcePath.md
@@ -5,20 +5,21 @@ online version:
 schema: 2.0.0
 ---
 
-# Get-CosmosDbPermissionResourcePath
+# Get-CosmosDbAttachmentResourcePath
 
 ## SYNOPSIS
-Return the resource path for a permission object.
+Return the resource path for an attachment object.
 
 ## SYNTAX
 
 ```
-Get-CosmosDbPermissionResourcePath [-Database] <String> [-UserId] <String> [-Id] <String> [<CommonParameters>]
+Get-CosmosDbAttachmentResourcePath [-Database] <String> [-CollectionId] <String> [-DocumentId] <String>
+ [-Id] <String> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-This cmdlet returns the resource identifier for a
-permission object.
+This cmdlet returns the resource identifier for an
+attachment object.
 
 ## EXAMPLES
 
@@ -32,7 +33,7 @@ PS C:\> {{ Add example code here }}
 ## PARAMETERS
 
 ### -Database
-This is the database containing the permission.
+This is the database containing the attachment.
 
 ```yaml
 Type: String
@@ -46,8 +47,8 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -UserId
-This is the Id of the user containing the permission.
+### -CollectionId
+This is the Id of the collection containing the attachment.
 
 ```yaml
 Type: String
@@ -61,8 +62,8 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Id
-This is the Id of the permission.
+### -DocumentId
+This is the Id of the document containing the attachment.
 
 ```yaml
 Type: String
@@ -71,6 +72,21 @@ Aliases:
 
 Required: True
 Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Id
+This is the Id of the attachment.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 4
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/Get-CosmosDbCollection.md
+++ b/docs/Get-CosmosDbCollection.md
@@ -12,9 +12,9 @@ Return the collections in a CosmosDB database.
 
 ## SYNTAX
 
-### Connection (Default)
+### Context (Default)
 ```
-Get-CosmosDbCollection -Connection <Connection> [-Key <SecureString>] [-KeyType <String>] [-Database <String>]
+Get-CosmosDbCollection -Context <Context> [-Key <SecureString>] [-KeyType <String>] [-Database <String>]
  [-Id <String>] [<CommonParameters>]
 ```
 
@@ -32,7 +32,7 @@ Id will be returned, otherwise all collections will be returned.
 ## EXAMPLES
 
 ### Example 1
-```
+```powershell
 PS C:\> {{ Add example code here }}
 ```
 
@@ -40,16 +40,16 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
-### -Connection
-This is an object containing the connection information of
+### -Context
+This is an object containing the context information of
 the CosmosDB database that will be accessed.
 It should be created
-by \`New-CosmosDbConnection\`.
+by \`New-CosmosDbContext\`.
 
 ```yaml
-Type: Connection
-Parameter Sets: Connection
-Aliases:
+Type: Context
+Parameter Sets: Context
+Aliases: Connection
 
 Required: True
 Position: Named
@@ -136,7 +136,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/Get-CosmosDbCollectionResourcePath.md
+++ b/docs/Get-CosmosDbCollectionResourcePath.md
@@ -23,7 +23,7 @@ object.
 ## EXAMPLES
 
 ### Example 1
-```
+```powershell
 PS C:\> {{ Add example code here }}
 ```
 
@@ -62,7 +62,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/Get-CosmosDbDatabase.md
+++ b/docs/Get-CosmosDbDatabase.md
@@ -12,9 +12,9 @@ Return the databases in a CosmosDB account.
 
 ## SYNTAX
 
-### Connection (Default)
+### Context (Default)
 ```
-Get-CosmosDbDatabase -Connection <Connection> [-Key <SecureString>] [-KeyType <String>] [-Id <String>]
+Get-CosmosDbDatabase -Context <Context> [-Key <SecureString>] [-KeyType <String>] [-Id <String>]
  [<CommonParameters>]
 ```
 
@@ -32,7 +32,7 @@ Id will be returned, otherwise all databases will be returned.
 ## EXAMPLES
 
 ### Example 1
-```
+```powershell
 PS C:\> {{ Add example code here }}
 ```
 
@@ -40,18 +40,18 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
-### -Connection
-This is an object containing the connection information of
+### -Context
+This is an object containing the context information of
 the CosmosDB database that will be accessed.
 It should be created
-by \`New-CosmosDbConnection\`.
+by \`New-CosmosDbContext\`.
 
-If the connection contains a database it will be ignored.
+If the context contains a database it will be ignored.
 
 ```yaml
-Type: Connection
-Parameter Sets: Connection
-Aliases:
+Type: Context
+Parameter Sets: Context
+Aliases: Connection
 
 Required: True
 Position: Named
@@ -121,7 +121,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/Get-CosmosDbDatabaseResourcePath.md
+++ b/docs/Get-CosmosDbDatabaseResourcePath.md
@@ -23,7 +23,7 @@ object.
 ## EXAMPLES
 
 ### Example 1
-```
+```powershell
 PS C:\> {{ Add example code here }}
 ```
 
@@ -47,7 +47,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/Get-CosmosDbDocument.md
+++ b/docs/Get-CosmosDbDocument.md
@@ -12,9 +12,9 @@ Return the documents for a CosmosDB database collection.
 
 ## SYNTAX
 
-### Connection (Default)
+### Context (Default)
 ```
-Get-CosmosDbDocument -Connection <Connection> [-Key <SecureString>] [-KeyType <String>] [-Database <String>]
+Get-CosmosDbDocument -Context <Context> [-Key <SecureString>] [-KeyType <String>] [-Database <String>]
  -CollectionId <String> [-Id <String>] [-MaxItemCount <Int32>] [-ContinuationToken <String>]
  [-ConsistencyLevel <String>] [-SessionToken <String>] [-PartitionKeyRangeId <String>] [-Query <String>]
  [-QueryParameters <Hashtable[]>] [-QueryEnableCrossPartition <Boolean>] [-ResultHeaders <PSReference>]
@@ -39,7 +39,7 @@ the specified documents will be returned.
 ## EXAMPLES
 
 ### Example 1
-```
+```powershell
 PS C:\> {{ Add example code here }}
 ```
 
@@ -47,16 +47,16 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
-### -Connection
-This is an object containing the connection information of
+### -Context
+This is an object containing the context information of
 the CosmosDB database that will be accessed.
 It should be created
-by \`New-CosmosDbConnection\`.
+by \`New-CosmosDbContext\`.
 
 ```yaml
-Type: Connection
-Parameter Sets: Connection
-Aliases:
+Type: Context
+Parameter Sets: Context
+Aliases: Connection
 
 Required: True
 Position: Named
@@ -301,7 +301,9 @@ Accept wildcard characters: False
 
 ### -ResultHeaders
 This is a reference variable that will be used to return the
-hashtable that contains any headers returned by the request.```yaml
+hashtable that contains any headers returned by the request.
+
+```yaml
 Type: PSReference
 Parameter Sets: (All)
 Aliases:
@@ -314,7 +316,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/Get-CosmosDbDocumentResourcePath.md
+++ b/docs/Get-CosmosDbDocumentResourcePath.md
@@ -24,7 +24,7 @@ document object.
 ## EXAMPLES
 
 ### Example 1
-```
+```powershell
 PS C:\> {{ Add example code here }}
 ```
 
@@ -79,7 +79,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/Get-CosmosDbPermission.md
+++ b/docs/Get-CosmosDbPermission.md
@@ -12,9 +12,9 @@ Return the permissions for a CosmosDB database user.
 
 ## SYNTAX
 
-### Connection (Default)
+### Context (Default)
 ```
-Get-CosmosDbPermission -Connection <Connection> [-Key <SecureString>] [-KeyType <String>] [-Database <String>]
+Get-CosmosDbPermission -Context <Context> [-Key <SecureString>] [-KeyType <String>] [-Database <String>]
  -UserId <String> [-Id <String>] [-TokenExpiry <Int32>] [<CommonParameters>]
 ```
 
@@ -33,7 +33,7 @@ specified permission will be returned.
 ## EXAMPLES
 
 ### Example 1
-```
+```powershell
 PS C:\> {{ Add example code here }}
 ```
 
@@ -41,16 +41,16 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
-### -Connection
-This is an object containing the connection information of
+### -Context
+This is an object containing the context information of
 the CosmosDB database that will be accessed.
 It should be created
-by \`New-CosmosDbConnection\`.
+by \`New-CosmosDbContext\`.
 
 ```yaml
-Type: Connection
-Parameter Sets: Connection
-Aliases:
+Type: Context
+Parameter Sets: Context
+Aliases: Connection
 
 Required: True
 Position: Named
@@ -151,11 +151,14 @@ Accept wildcard characters: False
 
 ### -TokenExpiry
 This is the number of seconds that the resource token for each
-permission will expire in. If not specified the default value
+permission will expire in.
+If not specified the default value
 of 3600 seconds (1 hour) is used.
 
 The minimum token expiry is 600 seconds and the maximum token
-expiry is 18000 seconds.```yaml
+expiry is 18000 seconds.
+
+```yaml
 Type: Int32
 Parameter Sets: (All)
 Aliases:
@@ -168,7 +171,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/Get-CosmosDbStoredProcedure.md
+++ b/docs/Get-CosmosDbStoredProcedure.md
@@ -12,10 +12,10 @@ Return the stored procedures for a CosmosDB database collection.
 
 ## SYNTAX
 
-### Connection (Default)
+### Context (Default)
 ```
-Get-CosmosDbStoredProcedure -Connection <Connection> [-Key <SecureString>] [-KeyType <String>]
- [-Database <String>] -CollectionId <String> [-Id <String>] [<CommonParameters>]
+Get-CosmosDbStoredProcedure -Context <Context> [-Key <SecureString>] [-KeyType <String>] [-Database <String>]
+ -CollectionId <String> [-Id <String>] [<CommonParameters>]
 ```
 
 ### Account
@@ -33,7 +33,7 @@ the specified stored procedures will be returned.
 ## EXAMPLES
 
 ### Example 1
-```
+```powershell
 PS C:\> {{ Add example code here }}
 ```
 
@@ -41,16 +41,16 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
-### -Connection
-This is an object containing the connection information of
+### -Context
+This is an object containing the context information of
 the CosmosDB database that will be accessed.
 It should be created
-by \`New-CosmosDbConnection\`.
+by \`New-CosmosDbContext\`.
 
 ```yaml
-Type: Connection
-Parameter Sets: Connection
-Aliases:
+Type: Context
+Parameter Sets: Context
+Aliases: Connection
 
 Required: True
 Position: Named
@@ -150,7 +150,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/Get-CosmosDbStoredProcedureResourcePath.md
+++ b/docs/Get-CosmosDbStoredProcedureResourcePath.md
@@ -24,7 +24,7 @@ stored procedure object.
 ## EXAMPLES
 
 ### Example 1
-```
+```powershell
 PS C:\> {{ Add example code here }}
 ```
 
@@ -78,7 +78,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/Get-CosmosDbTrigger.md
+++ b/docs/Get-CosmosDbTrigger.md
@@ -12,9 +12,9 @@ Return the triggers for a CosmosDB database collection.
 
 ## SYNTAX
 
-### Connection (Default)
+### Context (Default)
 ```
-Get-CosmosDbTrigger -Connection <Connection> [-Key <SecureString>] [-KeyType <String>] [-Database <String>]
+Get-CosmosDbTrigger -Context <Context> [-Key <SecureString>] [-KeyType <String>] [-Database <String>]
  -CollectionId <String> [-Id <String>] [<CommonParameters>]
 ```
 
@@ -33,7 +33,7 @@ specified trigger will be returned.
 ## EXAMPLES
 
 ### Example 1
-```
+```powershell
 PS C:\> {{ Add example code here }}
 ```
 
@@ -41,16 +41,16 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
-### -Connection
-This is an object containing the connection information of
+### -Context
+This is an object containing the context information of
 the CosmosDB database that will be accessed.
 It should be created
-by \`New-CosmosDbConnection\`.
+by \`New-CosmosDbContext\`.
 
 ```yaml
-Type: Connection
-Parameter Sets: Connection
-Aliases:
+Type: Context
+Parameter Sets: Context
+Aliases: Connection
 
 Required: True
 Position: Named
@@ -150,7 +150,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/Get-CosmosDbTriggerResourcePath.md
+++ b/docs/Get-CosmosDbTriggerResourcePath.md
@@ -24,7 +24,7 @@ trigger object.
 ## EXAMPLES
 
 ### Example 1
-```
+```powershell
 PS C:\> {{ Add example code here }}
 ```
 
@@ -78,7 +78,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/Get-CosmosDbUri.md
+++ b/docs/Get-CosmosDbUri.md
@@ -23,7 +23,7 @@ This cmdlet returns the root URI of the CosmosDB.
 ## EXAMPLES
 
 ### Example 1
-```
+```powershell
 PS C:\> {{ Add example code here }}
 ```
 
@@ -63,7 +63,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/Get-CosmosDbUser.md
+++ b/docs/Get-CosmosDbUser.md
@@ -12,9 +12,9 @@ Return the users in a CosmosDB database.
 
 ## SYNTAX
 
-### Connection (Default)
+### Context (Default)
 ```
-Get-CosmosDbUser -Connection <Connection> [-Database <String>] [-Key <SecureString>] [-Id <String>]
+Get-CosmosDbUser -Context <Context> [-Database <String>] [-Key <SecureString>] [-Id <String>]
  [<CommonParameters>]
 ```
 
@@ -32,7 +32,7 @@ Id will be returned, otherwise all users will be returned.
 ## EXAMPLES
 
 ### Example 1
-```
+```powershell
 PS C:\> {{ Add example code here }}
 ```
 
@@ -40,16 +40,16 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
-### -Connection
-This is an object containing the connection information of
+### -Context
+This is an object containing the context information of
 the CosmosDB database that will be accessed.
 It should be created
-by \`New-CosmosDbConnection\`.
+by \`New-CosmosDbContext\`.
 
 ```yaml
-Type: Connection
-Parameter Sets: Connection
-Aliases:
+Type: Context
+Parameter Sets: Context
+Aliases: Connection
 
 Required: True
 Position: Named
@@ -136,7 +136,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/Get-CosmosDbUserDefinedFunction.md
+++ b/docs/Get-CosmosDbUserDefinedFunction.md
@@ -12,9 +12,9 @@ Return the user defined functions for a CosmosDB database collection.
 
 ## SYNTAX
 
-### Connection (Default)
+### Context (Default)
 ```
-Get-CosmosDbUserDefinedFunction -Connection <Connection> [-Key <SecureString>] [-KeyType <String>]
+Get-CosmosDbUserDefinedFunction -Context <Context> [-Key <SecureString>] [-KeyType <String>]
  [-Database <String>] -CollectionId <String> [-Id <String>] [<CommonParameters>]
 ```
 
@@ -33,7 +33,7 @@ the specified user defined functions will be returned.
 ## EXAMPLES
 
 ### Example 1
-```
+```powershell
 PS C:\> {{ Add example code here }}
 ```
 
@@ -41,16 +41,16 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
-### -Connection
-This is an object containing the connection information of
+### -Context
+This is an object containing the context information of
 the CosmosDB database that will be accessed.
 It should be created
-by \`New-CosmosDbConnection\`.
+by \`New-CosmosDbContext\`.
 
 ```yaml
-Type: Connection
-Parameter Sets: Connection
-Aliases:
+Type: Context
+Parameter Sets: Context
+Aliases: Connection
 
 Required: True
 Position: Named
@@ -150,7 +150,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/Get-CosmosDbUserDefinedFunctionResourcePath.md
+++ b/docs/Get-CosmosDbUserDefinedFunctionResourcePath.md
@@ -24,7 +24,7 @@ user defined function object.
 ## EXAMPLES
 
 ### Example 1
-```
+```powershell
 PS C:\> {{ Add example code here }}
 ```
 
@@ -78,7 +78,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/Get-CosmosDbUserResourcePath.md
+++ b/docs/Get-CosmosDbUserResourcePath.md
@@ -23,7 +23,7 @@ object.
 ## EXAMPLES
 
 ### Example 1
-```
+```powershell
 PS C:\> {{ Add example code here }}
 ```
 
@@ -62,7 +62,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/Invoke-CosmosDbRequest.md
+++ b/docs/Invoke-CosmosDbRequest.md
@@ -13,9 +13,9 @@ Rest API request to CosmosDB.
 
 ## SYNTAX
 
-### Connection (Default)
+### Context (Default)
 ```
-Invoke-CosmosDbRequest -Connection <Connection> [-Database <String>] [-Key <SecureString>] [-KeyType <String>]
+Invoke-CosmosDbRequest -Context <Context> [-Database <String>] [-Key <SecureString>] [-KeyType <String>]
  [-Method <String>] -ResourceType <String> [-ResourcePath <String>] [-Body <String>] [-ApiVersion <String>]
  [-Headers <Hashtable>] [-UseWebRequest] [-ContentType <String>] [<CommonParameters>]
 ```
@@ -33,7 +33,7 @@ Invoke-CosmosDbRequest -Account <String> [-Database <String>] [-Key <SecureStrin
 ## EXAMPLES
 
 ### Example 1
-```
+```powershell
 PS C:\> {{ Add example code here }}
 ```
 
@@ -41,16 +41,16 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
-### -Connection
-This is an object containing the connection information of
+### -Context
+This is an object containing the context information of
 the CosmosDB database that will be accessed.
 It should be created
-by \`New-CosmosDbConnection\`.
+by \`New-CosmosDbContext\`.
 
 ```yaml
-Type: Connection
-Parameter Sets: Connection
-Aliases:
+Type: Context
+Parameter Sets: Context
+Aliases: Connection
 
 Required: True
 Position: Named
@@ -75,7 +75,7 @@ Accept wildcard characters: False
 ```
 
 ### -Database
-If specified will override the value in the connection.
+If specified will override the value in the context.
 If an empty database is specified then no dbs will be specified
 in the Rest API URI which will allow working with database
 objects.
@@ -239,7 +239,9 @@ Accept wildcard characters: False
 
 ### -ContentType
 This parameter allows the ContentType to be overridden
-which can be required for some types of requests.```yaml
+which can be required for some types of requests.
+
+```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
@@ -252,7 +254,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/Invoke-CosmosDbStoredProcedure.md
+++ b/docs/Invoke-CosmosDbStoredProcedure.md
@@ -12,9 +12,9 @@ Execute a new stored procedure for a collection in a CosmosDB database.
 
 ## SYNTAX
 
-### Connection (Default)
+### Context (Default)
 ```
-Invoke-CosmosDbStoredProcedure -Connection <Connection> [-KeyType <String>] [-Key <SecureString>]
+Invoke-CosmosDbStoredProcedure -Context <Context> [-KeyType <String>] [-Key <SecureString>]
  [-Database <String>] -CollectionId <String> -Id <String> [-StoredProcedureParameter <String[]>]
  [<CommonParameters>]
 ```
@@ -32,7 +32,7 @@ in a CosmosDB.
 ## EXAMPLES
 
 ### Example 1
-```
+```powershell
 PS C:\> {{ Add example code here }}
 ```
 
@@ -40,16 +40,16 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
-### -Connection
-This is an object containing the connection information of
+### -Context
+This is an object containing the context information of
 the CosmosDB database that will be deleted.
 It should be created
-by \`New-CosmosDbConnection\`.
+by \`New-CosmosDbContext\`.
 
 ```yaml
-Type: Connection
-Parameter Sets: Connection
-Aliases:
+Type: Context
+Parameter Sets: Context
+Aliases: Connection
 
 Required: True
 Position: Named
@@ -165,7 +165,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/New-CosmosDbAttachment.md
+++ b/docs/New-CosmosDbAttachment.md
@@ -5,30 +5,29 @@ online version:
 schema: 2.0.0
 ---
 
-# Set-CosmosDbDocument
+# New-CosmosDbAttachment
 
 ## SYNOPSIS
-Update a document from a CosmosDB collection.
+Create a new attachment for a document in a CosmosDB database.
 
 ## SYNTAX
 
 ### Context (Default)
 ```
-Set-CosmosDbDocument -Context <Context> [-Database <String>] [-Key <SecureString>] -CollectionId <String>
- -Id <String> -DocumentBody <String> [-IndexingDirective <String>] [-PartitionKey <String>]
- [<CommonParameters>]
+New-CosmosDbAttachment -Context <Context> [-KeyType <String>] [-Key <SecureString>] [-Database <String>]
+ -CollectionId <String> -DocumentId <String> [-Id <String>] [-ContentType <String>] [-Media <String>]
+ [-Slug <String>] [<CommonParameters>]
 ```
 
 ### Account
 ```
-Set-CosmosDbDocument -Account <String> [-Database <String>] [-Key <SecureString>] [-KeyType <String>]
- -CollectionId <String> -Id <String> -DocumentBody <String> [-IndexingDirective <String>]
- [-PartitionKey <String>] [<CommonParameters>]
+New-CosmosDbAttachment -Account <String> [-KeyType <String>] [-Key <SecureString>] [-Database <String>]
+ -CollectionId <String> -DocumentId <String> [-Id <String>] [-ContentType <String>] [-Media <String>]
+ [-Slug <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-This cmdlet will update an existing document in a CosmosDB
-collection.
+This cmdlet will create a attachment for a document in a CosmosDB.
 
 ## EXAMPLES
 
@@ -74,8 +73,8 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Database
-The name of the database to access in the CosmosDB account.
+### -KeyType
+The type of key that will be used to access ths CosmosDB.
 
 ```yaml
 Type: String
@@ -84,7 +83,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: Master
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -104,23 +103,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -KeyType
-The type of key that will be used to access ths CosmosDB.
+### -Database
+The name of the database to access in the CosmosDB account.
 
 ```yaml
 Type: String
-Parameter Sets: Account
+Parameter Sets: (All)
 Aliases:
 
 Required: False
 Position: Named
-Default value: Master
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -CollectionId
-This is the Id of the collection to update the document for.
+This is the Id of the collection to create the attachment in.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DocumentId
+This is the Id of the document to create the attachment on.
 
 ```yaml
 Type: String
@@ -135,41 +149,13 @@ Accept wildcard characters: False
 ```
 
 ### -Id
-This is the Id of the document to update.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -DocumentBody
-This is the body of the document to update.
-It must be
-formatted as a JSON string and contain the Id value of the
-document to create.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -IndexingDirective
-Include includes the document in the indexing path while
-Exclude omits the document from indexing.
+Not Required to be set when attaching raw media.
+This is a user
+settable property.
+It is the unique name that identifies the
+attachment, i.e.
+no two attachments will share the same id.
+The id must not exceed 255 characters.
 
 ```yaml
 Type: String
@@ -183,10 +169,45 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -PartitionKey
-The partition key value for the document to be deleted.
-Required if and must be specified only if the collection is
-created with a partitionKey definition.
+### -ContentType
+Not Required to be set when attaching raw media.
+This is a user
+settable property.
+It notes the content type of the attachment.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Media
+Not Required to be set when attaching raw media.
+This is the
+URL link or file path where the attachment resides.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Slug
+The name of the attachment.
+This is only required when raw media
+is submitted to the Azure Cosmos DB attachment storage.
 
 ```yaml
 Type: String

--- a/docs/New-CosmosDbAuthorizationToken.md
+++ b/docs/New-CosmosDbAuthorizationToken.md
@@ -28,7 +28,7 @@ other parameters in the header of the request that is passed.
 ## EXAMPLES
 
 ### Example 1
-```
+```powershell
 PS C:\> {{ Add example code here }}
 ```
 
@@ -150,7 +150,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/New-CosmosDbCollection.md
+++ b/docs/New-CosmosDbCollection.md
@@ -12,9 +12,9 @@ Create a new collection in a CosmosDB database.
 
 ## SYNTAX
 
-### Connection (Default)
+### Context (Default)
 ```
-New-CosmosDbCollection -Connection <Connection> [-Key <SecureString>] [-KeyType <String>] [-Database <String>]
+New-CosmosDbCollection -Context <Context> [-Key <SecureString>] [-KeyType <String>] [-Database <String>]
  -Id <String> [-OfferThroughput <Int32>] [-OfferType <String>] [-PartitionKey <String>] [<CommonParameters>]
 ```
 
@@ -30,7 +30,7 @@ This cmdlet will create a collection in a CosmosDB.
 ## EXAMPLES
 
 ### Example 1
-```
+```powershell
 PS C:\> {{ Add example code here }}
 ```
 
@@ -38,16 +38,16 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
-### -Connection
-This is an object containing the connection information of
+### -Context
+This is an object containing the context information of
 the CosmosDB database that will be deleted.
 It should be created
-by \`New-CosmosDbConnection\`.
+by \`New-CosmosDbContext\`.
 
 ```yaml
-Type: Connection
-Parameter Sets: Connection
-Aliases:
+Type: Context
+Parameter Sets: Context
+Aliases: Connection
 
 Required: True
 Position: Named
@@ -185,7 +185,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/New-CosmosDbContext.md
+++ b/docs/New-CosmosDbContext.md
@@ -5,34 +5,34 @@ online version:
 schema: 2.0.0
 ---
 
-# New-CosmosDbConnection
+# New-CosmosDbContext
 
 ## SYNOPSIS
-Create a connection object containing the information required
+Create a context object containing the information required
 to connect to a CosmosDB.
 
 ## SYNTAX
 
-### Connection (Default)
+### Context (Default)
 ```
-New-CosmosDbConnection -Account <String> [-Database <String>] -Key <SecureString> [-KeyType <String>]
+New-CosmosDbContext -Account <String> [-Database <String>] -Key <SecureString> [-KeyType <String>]
  [<CommonParameters>]
 ```
 
 ### Azure
 ```
-New-CosmosDbConnection -Account <String> [-Database <String>] -ResourceGroup <String> [-MasterKeyType <String>]
+New-CosmosDbContext -Account <String> [-Database <String>] -ResourceGroup <String> [-MasterKeyType <String>]
  [<CommonParameters>]
 ```
 
 ### Emulator
 ```
-New-CosmosDbConnection [-Database <String>] [-Emulator] [-Port <Int16>] [<CommonParameters>]
+New-CosmosDbContext [-Database <String>] [-Emulator] [-Port <Int16>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 This cmdlet is used to simplify the calling of the CosmosDB
-cmdlets by providing all the connection information in an
+cmdlets by providing all the context information in an
 object that can be passed to the CosmosDB cmdlets.
 
 It can also retrieve the CosmosDB primary or secondary key
@@ -41,7 +41,7 @@ from Azure Resource Manager.
 ## EXAMPLES
 
 ### Example 1
-```
+```powershell
 PS C:\> {{ Add example code here }}
 ```
 
@@ -54,7 +54,7 @@ The account name of the CosmosDB to access.
 
 ```yaml
 Type: String
-Parameter Sets: Connection, Azure
+Parameter Sets: Context, Azure
 Aliases:
 
 Required: True
@@ -84,7 +84,7 @@ The key to be used to access this CosmosDB.
 
 ```yaml
 Type: SecureString
-Parameter Sets: Connection
+Parameter Sets: Context
 Aliases:
 
 Required: True
@@ -99,7 +99,7 @@ The type of key that will be used to access ths CosmosDB.
 
 ```yaml
 Type: String
-Parameter Sets: Connection
+Parameter Sets: Context
 Aliases:
 
 Required: False
@@ -142,8 +142,10 @@ Accept wildcard characters: False
 ```
 
 ### -Emulator
-Using this switch creates a connection to a CosmosDB
-emulator installed onto the local host.```yaml
+Using this switch creates a context for a CosmosDB emulator
+installed onto the local host.
+
+```yaml
 Type: SwitchParameter
 Parameter Sets: Emulator
 Aliases:
@@ -157,7 +159,9 @@ Accept wildcard characters: False
 
 ### -Port
 This is the port the CosmosDB emulator is installed onto.
-If not specified it will use the default port of 8081.```yaml
+If not specified it will use the default port of 8081.
+
+```yaml
 Type: Int16
 Parameter Sets: Emulator
 Aliases:
@@ -170,7 +174,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/New-CosmosDbDatabase.md
+++ b/docs/New-CosmosDbDatabase.md
@@ -12,9 +12,9 @@ Create a new database in a CosmosDB account.
 
 ## SYNTAX
 
-### Connection (Default)
+### Context (Default)
 ```
-New-CosmosDbDatabase -Connection <Connection> [-Key <SecureString>] [-KeyType <String>] -Id <String>
+New-CosmosDbDatabase -Context <Context> [-Key <SecureString>] [-KeyType <String>] -Id <String>
  [<CommonParameters>]
 ```
 
@@ -30,7 +30,7 @@ This cmdlet will create a database in CosmosDB.
 ## EXAMPLES
 
 ### Example 1
-```
+```powershell
 PS C:\> {{ Add example code here }}
 ```
 
@@ -38,16 +38,16 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
-### -Connection
-This is an object containing the connection information of
+### -Context
+This is an object containing the context information of
 the CosmosDB database that will be deleted.
 It should be created
-by \`New-CosmosDbConnection\`.
+by \`New-CosmosDbContext\`.
 
 ```yaml
-Type: Connection
-Parameter Sets: Connection
-Aliases:
+Type: Context
+Parameter Sets: Context
+Aliases: Connection
 
 Required: True
 Position: Named
@@ -117,7 +117,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/New-CosmosDbDocument.md
+++ b/docs/New-CosmosDbDocument.md
@@ -12,9 +12,9 @@ Create a new document for a collection in a CosmosDB database.
 
 ## SYNTAX
 
-### Connection (Default)
+### Context (Default)
 ```
-New-CosmosDbDocument -Connection <Connection> [-KeyType <String>] [-Key <SecureString>] [-Database <String>]
+New-CosmosDbDocument -Context <Context> [-KeyType <String>] [-Key <SecureString>] [-Database <String>]
  -CollectionId <String> -DocumentBody <String> [-IndexingDirective <String>] [<CommonParameters>]
 ```
 
@@ -30,7 +30,7 @@ This cmdlet will create a document for a collection in a CosmosDB.
 ## EXAMPLES
 
 ### Example 1
-```
+```powershell
 PS C:\> {{ Add example code here }}
 ```
 
@@ -38,16 +38,16 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
-### -Connection
-This is an object containing the connection information of
+### -Context
+This is an object containing the context information of
 the CosmosDB database that will be deleted.
 It should be created
-by \`New-CosmosDbConnection\`.
+by \`New-CosmosDbContext\`.
 
 ```yaml
-Type: Connection
-Parameter Sets: Connection
-Aliases:
+Type: Context
+Parameter Sets: Context
+Aliases: Connection
 
 Required: True
 Position: Named
@@ -172,7 +172,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/New-CosmosDbPermission.md
+++ b/docs/New-CosmosDbPermission.md
@@ -12,9 +12,9 @@ Create a new permission for a user in a CosmosDB database.
 
 ## SYNTAX
 
-### Connection (Default)
+### Context (Default)
 ```
-New-CosmosDbPermission -Connection <Connection> [-KeyType <String>] [-Key <SecureString>] [-Database <String>]
+New-CosmosDbPermission -Context <Context> [-KeyType <String>] [-Key <SecureString>] [-Database <String>]
  -UserId <String> -Id <String> -Resource <String> [-PermissionMode <String>] [<CommonParameters>]
 ```
 
@@ -30,7 +30,7 @@ This cmdlet will create a permission for a user in a CosmosDB.
 ## EXAMPLES
 
 ### Example 1
-```
+```powershell
 PS C:\> {{ Add example code here }}
 ```
 
@@ -38,16 +38,16 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
-### -Connection
-This is an object containing the connection information of
+### -Context
+This is an object containing the context information of
 the CosmosDB database that will be deleted.
 It should be created
-by \`New-CosmosDbConnection\`.
+by \`New-CosmosDbContext\`.
 
 ```yaml
-Type: Connection
-Parameter Sets: Connection
-Aliases:
+Type: Context
+Parameter Sets: Context
+Aliases: Connection
 
 Required: True
 Position: Named
@@ -178,7 +178,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/New-CosmosDbStoredProcedure.md
+++ b/docs/New-CosmosDbStoredProcedure.md
@@ -12,10 +12,10 @@ Create a new stored procedure for a collection in a CosmosDB database.
 
 ## SYNTAX
 
-### Connection (Default)
+### Context (Default)
 ```
-New-CosmosDbStoredProcedure -Connection <Connection> [-KeyType <String>] [-Key <SecureString>]
- [-Database <String>] -CollectionId <String> -Id <String> -StoredProcedureBody <String> [<CommonParameters>]
+New-CosmosDbStoredProcedure -Context <Context> [-KeyType <String>] [-Key <SecureString>] [-Database <String>]
+ -CollectionId <String> -Id <String> -StoredProcedureBody <String> [<CommonParameters>]
 ```
 
 ### Account
@@ -30,7 +30,7 @@ This cmdlet will create a stored procedure for a collection in a CosmosDB.
 ## EXAMPLES
 
 ### Example 1
-```
+```powershell
 PS C:\> {{ Add example code here }}
 ```
 
@@ -38,16 +38,16 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
-### -Connection
-This is an object containing the connection information of
+### -Context
+This is an object containing the context information of
 the CosmosDB database that will be deleted.
 It should be created
-by \`New-CosmosDbConnection\`.
+by \`New-CosmosDbContext\`.
 
 ```yaml
-Type: Connection
-Parameter Sets: Connection
-Aliases:
+Type: Context
+Parameter Sets: Context
+Aliases: Connection
 
 Required: True
 Position: Named
@@ -162,7 +162,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/New-CosmosDbTrigger.md
+++ b/docs/New-CosmosDbTrigger.md
@@ -12,9 +12,9 @@ Create a new trigger for a collection in a CosmosDB database.
 
 ## SYNTAX
 
-### Connection (Default)
+### Context (Default)
 ```
-New-CosmosDbTrigger -Connection <Connection> [-KeyType <String>] [-Key <SecureString>] [-Database <String>]
+New-CosmosDbTrigger -Context <Context> [-KeyType <String>] [-Key <SecureString>] [-Database <String>]
  -CollectionId <String> -Id <String> -TriggerBody <String> -TriggerOperation <String> -TriggerType <String>
  [<CommonParameters>]
 ```
@@ -32,7 +32,7 @@ This cmdlet will create a trigger for a collection in a CosmosDB.
 ## EXAMPLES
 
 ### Example 1
-```
+```powershell
 PS C:\> {{ Add example code here }}
 ```
 
@@ -40,16 +40,16 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
-### -Connection
-This is an object containing the connection information of
+### -Context
+This is an object containing the context information of
 the CosmosDB database that will be deleted.
 It should be created
-by \`New-CosmosDbConnection\`.
+by \`New-CosmosDbContext\`.
 
 ```yaml
-Type: Connection
-Parameter Sets: Connection
-Aliases:
+Type: Context
+Parameter Sets: Context
+Aliases: Connection
 
 Required: True
 Position: Named
@@ -194,7 +194,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/New-CosmosDbUser.md
+++ b/docs/New-CosmosDbUser.md
@@ -12,10 +12,10 @@ Create a new user in a CosmosDB database.
 
 ## SYNTAX
 
-### Connection (Default)
+### Context (Default)
 ```
-New-CosmosDbUser -Connection <Connection> [-Database <String>] [-Key <SecureString>] [-KeyType <String>]
- -Id <String> [<CommonParameters>]
+New-CosmosDbUser -Context <Context> [-Database <String>] [-Key <SecureString>] [-KeyType <String>] -Id <String>
+ [<CommonParameters>]
 ```
 
 ### Account
@@ -30,7 +30,7 @@ This cmdlet will create a user in a CosmosDB.
 ## EXAMPLES
 
 ### Example 1
-```
+```powershell
 PS C:\> {{ Add example code here }}
 ```
 
@@ -38,16 +38,16 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
-### -Connection
-This is an object containing the connection information of
+### -Context
+This is an object containing the context information of
 the CosmosDB database that will be deleted.
 It should be created
-by \`New-CosmosDbConnection\`.
+by \`New-CosmosDbContext\`.
 
 ```yaml
-Type: Connection
-Parameter Sets: Connection
-Aliases:
+Type: Context
+Parameter Sets: Context
+Aliases: Connection
 
 Required: True
 Position: Named
@@ -132,7 +132,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/New-CosmosDbUserDefinedFunction.md
+++ b/docs/New-CosmosDbUserDefinedFunction.md
@@ -12,9 +12,9 @@ Create a new user defined function for a collection in a CosmosDB database.
 
 ## SYNTAX
 
-### Connection (Default)
+### Context (Default)
 ```
-New-CosmosDbUserDefinedFunction -Connection <Connection> [-KeyType <String>] [-Key <SecureString>]
+New-CosmosDbUserDefinedFunction -Context <Context> [-KeyType <String>] [-Key <SecureString>]
  [-Database <String>] -CollectionId <String> -Id <String> -UserDefinedFunctionBody <String>
  [<CommonParameters>]
 ```
@@ -32,7 +32,7 @@ This cmdlet will create a user defined function for a collection in a CosmosDB.
 ## EXAMPLES
 
 ### Example 1
-```
+```powershell
 PS C:\> {{ Add example code here }}
 ```
 
@@ -40,16 +40,16 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
-### -Connection
-This is an object containing the connection information of
+### -Context
+This is an object containing the context information of
 the CosmosDB database that will be deleted.
 It should be created
-by \`New-CosmosDbConnection\`.
+by \`New-CosmosDbContext\`.
 
 ```yaml
-Type: Connection
-Parameter Sets: Connection
-Aliases:
+Type: Context
+Parameter Sets: Context
+Aliases: Connection
 
 Required: True
 Position: Named
@@ -164,7 +164,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/New-InvalidArgumentException.md
+++ b/docs/New-InvalidArgumentException.md
@@ -22,7 +22,7 @@ New-InvalidArgumentException [-Message] <String> [-ArgumentName] <String> [<Comm
 ## EXAMPLES
 
 ### Example 1
-```
+```powershell
 PS C:\> {{ Add example code here }}
 ```
 
@@ -61,7 +61,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/New-InvalidOperationException.md
+++ b/docs/New-InvalidOperationException.md
@@ -22,7 +22,7 @@ New-InvalidOperationException [[-Message] <String>] [[-ErrorRecord] <ErrorRecord
 ## EXAMPLES
 
 ### Example 1
-```
+```powershell
 PS C:\> {{ Add example code here }}
 ```
 
@@ -61,7 +61,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/Remove-CosmosDbAttachment.md
+++ b/docs/Remove-CosmosDbAttachment.md
@@ -5,30 +5,27 @@ online version:
 schema: 2.0.0
 ---
 
-# Set-CosmosDbDocument
+# Remove-CosmosDbAttachment
 
 ## SYNOPSIS
-Update a document from a CosmosDB collection.
+Delete an attachment from a CosmosDB document.
 
 ## SYNTAX
 
 ### Context (Default)
 ```
-Set-CosmosDbDocument -Context <Context> [-Database <String>] [-Key <SecureString>] -CollectionId <String>
- -Id <String> -DocumentBody <String> [-IndexingDirective <String>] [-PartitionKey <String>]
- [<CommonParameters>]
+Remove-CosmosDbAttachment -Context <Context> [-Database <String>] [-Key <SecureString>] [-KeyType <String>]
+ -CollectionId <String> -DocumentId <String> -Id <String> [<CommonParameters>]
 ```
 
 ### Account
 ```
-Set-CosmosDbDocument -Account <String> [-Database <String>] [-Key <SecureString>] [-KeyType <String>]
- -CollectionId <String> -Id <String> -DocumentBody <String> [-IndexingDirective <String>]
- [-PartitionKey <String>] [<CommonParameters>]
+Remove-CosmosDbAttachment -Account <String> [-Database <String>] [-Key <SecureString>] [-KeyType <String>]
+ -CollectionId <String> -DocumentId <String> -Id <String> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-This cmdlet will update an existing document in a CosmosDB
-collection.
+This cmdlet will delete an attachment in a CosmosDB from a document.
 
 ## EXAMPLES
 
@@ -109,7 +106,7 @@ The type of key that will be used to access ths CosmosDB.
 
 ```yaml
 Type: String
-Parameter Sets: Account
+Parameter Sets: (All)
 Aliases:
 
 Required: False
@@ -120,7 +117,22 @@ Accept wildcard characters: False
 ```
 
 ### -CollectionId
-This is the Id of the collection to update the document for.
+This is the Id of the collection to delete the attachment from.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DocumentId
+This is the Id of the document to delete the attachment from.
 
 ```yaml
 Type: String
@@ -135,7 +147,7 @@ Accept wildcard characters: False
 ```
 
 ### -Id
-This is the Id of the document to update.
+This is the Id of the attachment to delete.
 
 ```yaml
 Type: String
@@ -143,57 +155,6 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -DocumentBody
-This is the body of the document to update.
-It must be
-formatted as a JSON string and contain the Id value of the
-document to create.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -IndexingDirective
-Include includes the document in the indexing path while
-Exclude omits the document from indexing.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -PartitionKey
-The partition key value for the document to be deleted.
-Required if and must be specified only if the collection is
-created with a partitionKey definition.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -207,8 +168,6 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## INPUTS
 
 ## OUTPUTS
-
-### System.Object
 
 ## NOTES
 

--- a/docs/Remove-CosmosDbCollection.md
+++ b/docs/Remove-CosmosDbCollection.md
@@ -12,10 +12,10 @@ Delete a collection from a CosmosDB database.
 
 ## SYNTAX
 
-### Connection (Default)
+### Context (Default)
 ```
-Remove-CosmosDbCollection -Connection <Connection> [-Key <SecureString>] [-KeyType <String>]
- [-Database <String>] -Id <String> [<CommonParameters>]
+Remove-CosmosDbCollection -Context <Context> [-Key <SecureString>] [-KeyType <String>] [-Database <String>]
+ -Id <String> [<CommonParameters>]
 ```
 
 ### Account
@@ -30,7 +30,7 @@ This cmdlet will delete a collection in a CosmosDB.
 ## EXAMPLES
 
 ### Example 1
-```
+```powershell
 PS C:\> {{ Add example code here }}
 ```
 
@@ -38,16 +38,16 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
-### -Connection
-This is an object containing the connection information of
+### -Context
+This is an object containing the context information of
 the CosmosDB database that will be deleted.
 It should be created
-by \`New-CosmosDbConnection\`.
+by \`New-CosmosDbContext\`.
 
 ```yaml
-Type: Connection
-Parameter Sets: Connection
-Aliases:
+Type: Context
+Parameter Sets: Context
+Aliases: Connection
 
 Required: True
 Position: Named
@@ -132,7 +132,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/Remove-CosmosDbDatabase.md
+++ b/docs/Remove-CosmosDbDatabase.md
@@ -12,9 +12,9 @@ Delete a datanase from a CosmosDB account.
 
 ## SYNTAX
 
-### Connection (Default)
+### Context (Default)
 ```
-Remove-CosmosDbDatabase -Connection <Connection> [-Key <SecureString>] [-KeyType <String>] -Id <String>
+Remove-CosmosDbDatabase -Context <Context> [-Key <SecureString>] [-KeyType <String>] -Id <String>
  [<CommonParameters>]
 ```
 
@@ -30,7 +30,7 @@ This cmdlet will delete a database in CosmosDB.
 ## EXAMPLES
 
 ### Example 1
-```
+```powershell
 PS C:\> {{ Add example code here }}
 ```
 
@@ -38,16 +38,16 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
-### -Connection
-This is an object containing the connection information of
+### -Context
+This is an object containing the context information of
 the CosmosDB database that will be deleted.
 It should be created
-by \`New-CosmosDbConnection\`.
+by \`New-CosmosDbContext\`.
 
 ```yaml
-Type: Connection
-Parameter Sets: Connection
-Aliases:
+Type: Context
+Parameter Sets: Context
+Aliases: Connection
 
 Required: True
 Position: Named
@@ -117,7 +117,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/Remove-CosmosDbDocument.md
+++ b/docs/Remove-CosmosDbDocument.md
@@ -12,9 +12,9 @@ Delete a document from a CosmosDB collection.
 
 ## SYNTAX
 
-### Connection (Default)
+### Context (Default)
 ```
-Remove-CosmosDbDocument -Connection <Connection> [-Database <String>] [-Key <SecureString>] [-KeyType <String>]
+Remove-CosmosDbDocument -Context <Context> [-Database <String>] [-Key <SecureString>] [-KeyType <String>]
  -CollectionId <String> [-Id <String>] [-PartitionKey <String>] [<CommonParameters>]
 ```
 
@@ -30,7 +30,7 @@ This cmdlet will delete a document in a CosmosDB from a collection.
 ## EXAMPLES
 
 ### Example 1
-```
+```powershell
 PS C:\> {{ Add example code here }}
 ```
 
@@ -38,16 +38,16 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
-### -Connection
-This is an object containing the connection information of
+### -Context
+This is an object containing the context information of
 the CosmosDB database that will be deleted.
 It should be created
-by \`New-CosmosDbConnection\`.
+by \`New-CosmosDbContext\`.
 
 ```yaml
-Type: Connection
-Parameter Sets: Connection
-Aliases:
+Type: Context
+Parameter Sets: Context
+Aliases: Connection
 
 Required: True
 Position: Named
@@ -164,7 +164,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/Remove-CosmosDbPermission.md
+++ b/docs/Remove-CosmosDbPermission.md
@@ -12,10 +12,10 @@ Delete a permission from a CosmosDB user.
 
 ## SYNTAX
 
-### Connection (Default)
+### Context (Default)
 ```
-Remove-CosmosDbPermission -Connection <Connection> [-Database <String>] [-Key <SecureString>]
- [-KeyType <String>] -UserId <String> [-Id <String>] [<CommonParameters>]
+Remove-CosmosDbPermission -Context <Context> [-Database <String>] [-Key <SecureString>] [-KeyType <String>]
+ -UserId <String> [-Id <String>] [<CommonParameters>]
 ```
 
 ### Account
@@ -30,7 +30,7 @@ This cmdlet will delete a permission in a CosmosDB from a user.
 ## EXAMPLES
 
 ### Example 1
-```
+```powershell
 PS C:\> {{ Add example code here }}
 ```
 
@@ -38,16 +38,16 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
-### -Connection
-This is an object containing the connection information of
+### -Context
+This is an object containing the context information of
 the CosmosDB database that will be deleted.
 It should be created
-by \`New-CosmosDbConnection\`.
+by \`New-CosmosDbContext\`.
 
 ```yaml
-Type: Connection
-Parameter Sets: Connection
-Aliases:
+Type: Context
+Parameter Sets: Context
+Aliases: Connection
 
 Required: True
 Position: Named
@@ -147,7 +147,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/Remove-CosmosDbStoredProcedure.md
+++ b/docs/Remove-CosmosDbStoredProcedure.md
@@ -12,9 +12,9 @@ Delete a stored procedure from a CosmosDB collection.
 
 ## SYNTAX
 
-### Connection (Default)
+### Context (Default)
 ```
-Remove-CosmosDbStoredProcedure -Connection <Connection> [-Database <String>] [-Key <SecureString>]
+Remove-CosmosDbStoredProcedure -Context <Context> [-Database <String>] [-Key <SecureString>]
  [-KeyType <String>] -CollectionId <String> [-Id <String>] [<CommonParameters>]
 ```
 
@@ -30,7 +30,7 @@ This cmdlet will delete a stored procedure in a CosmosDB from a collection.
 ## EXAMPLES
 
 ### Example 1
-```
+```powershell
 PS C:\> {{ Add example code here }}
 ```
 
@@ -38,16 +38,16 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
-### -Connection
-This is an object containing the connection information of
+### -Context
+This is an object containing the context information of
 the CosmosDB database that will be deleted.
 It should be created
-by \`New-CosmosDbConnection\`.
+by \`New-CosmosDbContext\`.
 
 ```yaml
-Type: Connection
-Parameter Sets: Connection
-Aliases:
+Type: Context
+Parameter Sets: Context
+Aliases: Connection
 
 Required: True
 Position: Named
@@ -147,7 +147,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/Remove-CosmosDbTrigger.md
+++ b/docs/Remove-CosmosDbTrigger.md
@@ -12,9 +12,9 @@ Delete a trigger from a CosmosDB collection.
 
 ## SYNTAX
 
-### Connection (Default)
+### Context (Default)
 ```
-Remove-CosmosDbTrigger -Connection <Connection> [-Database <String>] [-Key <SecureString>] [-KeyType <String>]
+Remove-CosmosDbTrigger -Context <Context> [-Database <String>] [-Key <SecureString>] [-KeyType <String>]
  -CollectionId <String> [-Id <String>] [<CommonParameters>]
 ```
 
@@ -30,7 +30,7 @@ This cmdlet will delete a trigger in a CosmosDB from a collection.
 ## EXAMPLES
 
 ### Example 1
-```
+```powershell
 PS C:\> {{ Add example code here }}
 ```
 
@@ -38,16 +38,16 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
-### -Connection
-This is an object containing the connection information of
+### -Context
+This is an object containing the context information of
 the CosmosDB database that will be deleted.
 It should be created
-by \`New-CosmosDbConnection\`.
+by \`New-CosmosDbContext\`.
 
 ```yaml
-Type: Connection
-Parameter Sets: Connection
-Aliases:
+Type: Context
+Parameter Sets: Context
+Aliases: Connection
 
 Required: True
 Position: Named
@@ -147,7 +147,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/Remove-CosmosDbUser.md
+++ b/docs/Remove-CosmosDbUser.md
@@ -12,9 +12,9 @@ Delete a user from a CosmosDB database.
 
 ## SYNTAX
 
-### Connection (Default)
+### Context (Default)
 ```
-Remove-CosmosDbUser -Connection <Connection> [-Database <String>] [-Key <SecureString>] -Id <String>
+Remove-CosmosDbUser -Context <Context> [-Database <String>] [-Key <SecureString>] -Id <String>
  [<CommonParameters>]
 ```
 
@@ -30,7 +30,7 @@ This cmdlet will delete a user in a CosmosDB.
 ## EXAMPLES
 
 ### Example 1
-```
+```powershell
 PS C:\> {{ Add example code here }}
 ```
 
@@ -38,16 +38,16 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
-### -Connection
-This is an object containing the connection information of
+### -Context
+This is an object containing the context information of
 the CosmosDB database that will be deleted.
 It should be created
-by \`New-CosmosDbConnection\`.
+by \`New-CosmosDbContext\`.
 
 ```yaml
-Type: Connection
-Parameter Sets: Connection
-Aliases:
+Type: Context
+Parameter Sets: Context
+Aliases: Connection
 
 Required: True
 Position: Named
@@ -132,7 +132,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/Remove-CosmosDbUserDefinedFunction.md
+++ b/docs/Remove-CosmosDbUserDefinedFunction.md
@@ -12,9 +12,9 @@ Delete a user defined function from a CosmosDB collection.
 
 ## SYNTAX
 
-### Connection (Default)
+### Context (Default)
 ```
-Remove-CosmosDbUserDefinedFunction -Connection <Connection> [-Database <String>] [-Key <SecureString>]
+Remove-CosmosDbUserDefinedFunction -Context <Context> [-Database <String>] [-Key <SecureString>]
  [-KeyType <String>] -CollectionId <String> [-Id <String>] [<CommonParameters>]
 ```
 
@@ -30,7 +30,7 @@ This cmdlet will delete a user defined function in a CosmosDB from a collection.
 ## EXAMPLES
 
 ### Example 1
-```
+```powershell
 PS C:\> {{ Add example code here }}
 ```
 
@@ -38,16 +38,16 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
-### -Connection
-This is an object containing the connection information of
+### -Context
+This is an object containing the context information of
 the CosmosDB database that will be deleted.
 It should be created
-by \`New-CosmosDbConnection\`.
+by \`New-CosmosDbContext\`.
 
 ```yaml
-Type: Connection
-Parameter Sets: Connection
-Aliases:
+Type: Context
+Parameter Sets: Context
+Aliases: Connection
 
 Required: True
 Position: Named
@@ -147,7 +147,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/Set-CosmosDbAttachment.md
+++ b/docs/Set-CosmosDbAttachment.md
@@ -5,30 +5,30 @@ online version:
 schema: 2.0.0
 ---
 
-# Set-CosmosDbDocument
+# Set-CosmosDbAttachment
 
 ## SYNOPSIS
-Update a document from a CosmosDB collection.
+Update am attachment for a CosmosDB document.
 
 ## SYNTAX
 
 ### Context (Default)
 ```
-Set-CosmosDbDocument -Context <Context> [-Database <String>] [-Key <SecureString>] -CollectionId <String>
- -Id <String> -DocumentBody <String> [-IndexingDirective <String>] [-PartitionKey <String>]
+Set-CosmosDbAttachment -Context <Context> [-Database <String>] [-Key <SecureString>] -CollectionId <String>
+ -DocumentId <String> -Id <String> [-NewId <String>] [-ContentType <String>] [-Media <String>] [-Slug <String>]
  [<CommonParameters>]
 ```
 
 ### Account
 ```
-Set-CosmosDbDocument -Account <String> [-Database <String>] [-Key <SecureString>] [-KeyType <String>]
- -CollectionId <String> -Id <String> -DocumentBody <String> [-IndexingDirective <String>]
- [-PartitionKey <String>] [<CommonParameters>]
+Set-CosmosDbAttachment -Account <String> [-Database <String>] [-Key <SecureString>] [-KeyType <String>]
+ -CollectionId <String> -DocumentId <String> -Id <String> [-NewId <String>] [-ContentType <String>]
+ [-Media <String>] [-Slug <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-This cmdlet will update an existing document in a CosmosDB
-collection.
+This cmdlet will update an existing attachment in a CosmosDB
+document.
 
 ## EXAMPLES
 
@@ -120,7 +120,22 @@ Accept wildcard characters: False
 ```
 
 ### -CollectionId
-This is the Id of the collection to update the document for.
+This is the Id of the collection to update the attachment for.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DocumentId
+This is the Id of the collection to update the attachment for.
 
 ```yaml
 Type: String
@@ -135,7 +150,7 @@ Accept wildcard characters: False
 ```
 
 ### -Id
-This is the Id of the document to update.
+This is the Id of the attachment to update.
 
 ```yaml
 Type: String
@@ -149,27 +164,8 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -DocumentBody
-This is the body of the document to update.
-It must be
-formatted as a JSON string and contain the Id value of the
-document to create.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -IndexingDirective
-Include includes the document in the indexing path while
-Exclude omits the document from indexing.
+### -NewId
+This is the new Id of the attachment if renaming the attachment.
 
 ```yaml
 Type: String
@@ -183,10 +179,45 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -PartitionKey
-The partition key value for the document to be deleted.
-Required if and must be specified only if the collection is
-created with a partitionKey definition.
+### -ContentType
+Not Required to be set when attaching raw media.
+This is a user
+settable property.
+It notes the content type of the attachment.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Media
+Not Required to be set when attaching raw media.
+This is the
+URL link or file path where the attachment resides.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Slug
+The name of the attachment.
+This is only required when raw media
+is submitted to the Azure Cosmos DB attachment storage.
 
 ```yaml
 Type: String

--- a/docs/Set-CosmosDbAttachmentType.md
+++ b/docs/Set-CosmosDbAttachmentType.md
@@ -5,20 +5,21 @@ online version:
 schema: 2.0.0
 ---
 
-# Get-CosmosDbPermissionResourcePath
+# Set-CosmosDbAttachmentType
 
 ## SYNOPSIS
-Return the resource path for a permission object.
+Set the custom Cosmos DB Attachment types to the attachment
+returned by an API call.
 
 ## SYNTAX
 
 ```
-Get-CosmosDbPermissionResourcePath [-Database] <String> [-UserId] <String> [-Id] <String> [<CommonParameters>]
+Set-CosmosDbAttachmentType [-Attachment] <Object> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-This cmdlet returns the resource identifier for a
-permission object.
+This function applies the custom types to the attachment
+returned by an API call.
 
 ## EXAMPLES
 
@@ -31,46 +32,16 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
-### -Database
-This is the database containing the permission.
+### -Attachment
+{{Fill Attachment Description}}
 
 ```yaml
-Type: String
+Type: Object
 Parameter Sets: (All)
 Aliases:
 
 Required: True
 Position: 1
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -UserId
-This is the Id of the user containing the permission.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: 2
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Id
-This is the Id of the permission.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: 3
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -83,8 +54,6 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## INPUTS
 
 ## OUTPUTS
-
-### System.String
 
 ## NOTES
 

--- a/docs/Set-CosmosDbCollectionType.md
+++ b/docs/Set-CosmosDbCollectionType.md
@@ -5,20 +5,21 @@ online version:
 schema: 2.0.0
 ---
 
-# Get-CosmosDbPermissionResourcePath
+# Set-CosmosDbCollectionType
 
 ## SYNOPSIS
-Return the resource path for a permission object.
+Set the custom Cosmos DB Collection types to the collection
+returned by an API call.
 
 ## SYNTAX
 
 ```
-Get-CosmosDbPermissionResourcePath [-Database] <String> [-UserId] <String> [-Id] <String> [<CommonParameters>]
+Set-CosmosDbCollectionType [-Collection] <Object> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-This cmdlet returns the resource identifier for a
-permission object.
+This function applies the custom types to the collection returned
+by an API call.
 
 ## EXAMPLES
 
@@ -31,46 +32,16 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
-### -Database
-This is the database containing the permission.
+### -Collection
+This is the collection that is returned by a collection API call.
 
 ```yaml
-Type: String
+Type: Object
 Parameter Sets: (All)
 Aliases:
 
 Required: True
 Position: 1
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -UserId
-This is the Id of the user containing the permission.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: 2
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Id
-This is the Id of the permission.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: 3
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -83,8 +54,6 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## INPUTS
 
 ## OUTPUTS
-
-### System.String
 
 ## NOTES
 

--- a/docs/Set-CosmosDbDatabaseType.md
+++ b/docs/Set-CosmosDbDatabaseType.md
@@ -5,20 +5,21 @@ online version:
 schema: 2.0.0
 ---
 
-# Get-CosmosDbPermissionResourcePath
+# Set-CosmosDbDatabaseType
 
 ## SYNOPSIS
-Return the resource path for a permission object.
+Set the custom Cosmos DB Database types to the database
+returned by an API call.
 
 ## SYNTAX
 
 ```
-Get-CosmosDbPermissionResourcePath [-Database] <String> [-UserId] <String> [-Id] <String> [<CommonParameters>]
+Set-CosmosDbDatabaseType [-Database] <Object> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-This cmdlet returns the resource identifier for a
-permission object.
+This function applies the custom types to the database returned
+by an API call.
 
 ## EXAMPLES
 
@@ -32,45 +33,15 @@ PS C:\> {{ Add example code here }}
 ## PARAMETERS
 
 ### -Database
-This is the database containing the permission.
+This is the database that is returned by a user API call.
 
 ```yaml
-Type: String
+Type: Object
 Parameter Sets: (All)
 Aliases:
 
 Required: True
 Position: 1
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -UserId
-This is the Id of the user containing the permission.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: 2
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Id
-This is the Id of the permission.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: 3
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -83,8 +54,6 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## INPUTS
 
 ## OUTPUTS
-
-### System.String
 
 ## NOTES
 

--- a/docs/Set-CosmosDbDocumentType.md
+++ b/docs/Set-CosmosDbDocumentType.md
@@ -5,20 +5,21 @@ online version:
 schema: 2.0.0
 ---
 
-# Get-CosmosDbPermissionResourcePath
+# Set-CosmosDbDocumentType
 
 ## SYNOPSIS
-Return the resource path for a permission object.
+Set the custom Cosmos DB document types to the document returned
+by an API call.
 
 ## SYNTAX
 
 ```
-Get-CosmosDbPermissionResourcePath [-Database] <String> [-UserId] <String> [-Id] <String> [<CommonParameters>]
+Set-CosmosDbDocumentType [-Document] <Object> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-This cmdlet returns the resource identifier for a
-permission object.
+This function applies the custom types to the document returned
+by an API call.
 
 ## EXAMPLES
 
@@ -31,46 +32,16 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
-### -Database
-This is the database containing the permission.
+### -Document
+This is the document that is returned by a document API call.
 
 ```yaml
-Type: String
+Type: Object
 Parameter Sets: (All)
 Aliases:
 
 Required: True
 Position: 1
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -UserId
-This is the Id of the user containing the permission.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: 2
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Id
-This is the Id of the permission.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: 3
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -83,8 +54,6 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## INPUTS
 
 ## OUTPUTS
-
-### System.String
 
 ## NOTES
 

--- a/docs/Set-CosmosDbPermissionType.md
+++ b/docs/Set-CosmosDbPermissionType.md
@@ -5,20 +5,21 @@ online version:
 schema: 2.0.0
 ---
 
-# Get-CosmosDbPermissionResourcePath
+# Set-CosmosDbPermissionType
 
 ## SYNOPSIS
-Return the resource path for a permission object.
+Set the custom Cosmos DB User types to the permission
+returned by an API call.
 
 ## SYNTAX
 
 ```
-Get-CosmosDbPermissionResourcePath [-Database] <String> [-UserId] <String> [-Id] <String> [<CommonParameters>]
+Set-CosmosDbPermissionType [-Permission] <Object> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-This cmdlet returns the resource identifier for a
-permission object.
+This function applies the custom types to the permission returned
+by an API call.
 
 ## EXAMPLES
 
@@ -31,46 +32,16 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
-### -Database
-This is the database containing the permission.
+### -Permission
+This is the permission that is returned by a user API call.
 
 ```yaml
-Type: String
+Type: Object
 Parameter Sets: (All)
 Aliases:
 
 Required: True
 Position: 1
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -UserId
-This is the Id of the user containing the permission.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: 2
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Id
-This is the Id of the permission.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: 3
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -83,8 +54,6 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## INPUTS
 
 ## OUTPUTS
-
-### System.String
 
 ## NOTES
 

--- a/docs/Set-CosmosDbStoredProcedure.md
+++ b/docs/Set-CosmosDbStoredProcedure.md
@@ -12,9 +12,9 @@ Update a stored procedure from a CosmosDB collection.
 
 ## SYNTAX
 
-### Connection (Default)
+### Context (Default)
 ```
-Set-CosmosDbStoredProcedure -Connection <Connection> [-Database <String>] [-Key <SecureString>]
+Set-CosmosDbStoredProcedure -Context <Context> [-Database <String>] [-Key <SecureString>]
  -CollectionId <String> -Id <String> -StoredProcedureBody <String> [<CommonParameters>]
 ```
 
@@ -31,7 +31,7 @@ collection.
 ## EXAMPLES
 
 ### Example 1
-```
+```powershell
 PS C:\> {{ Add example code here }}
 ```
 
@@ -39,16 +39,16 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
-### -Connection
-This is an object containing the connection information of
+### -Context
+This is an object containing the context information of
 the CosmosDB database that will be deleted.
 It should be created
-by \`New-CosmosDbConnection\`.
+by \`New-CosmosDbContext\`.
 
 ```yaml
-Type: Connection
-Parameter Sets: Connection
-Aliases:
+Type: Context
+Parameter Sets: Context
+Aliases: Connection
 
 Required: True
 Position: Named
@@ -163,7 +163,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/Set-CosmosDbStoredProcedureType.md
+++ b/docs/Set-CosmosDbStoredProcedureType.md
@@ -5,20 +5,21 @@ online version:
 schema: 2.0.0
 ---
 
-# Get-CosmosDbPermissionResourcePath
+# Set-CosmosDbStoredProcedureType
 
 ## SYNOPSIS
-Return the resource path for a permission object.
+Set the custom Cosmos DB stored procedure types to the
+stored procedure returned by an API call.
 
 ## SYNTAX
 
 ```
-Get-CosmosDbPermissionResourcePath [-Database] <String> [-UserId] <String> [-Id] <String> [<CommonParameters>]
+Set-CosmosDbStoredProcedureType [-StoredProcedure] <Object> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-This cmdlet returns the resource identifier for a
-permission object.
+This function applies the custom types to the stored
+procedure returned by an API call.
 
 ## EXAMPLES
 
@@ -31,46 +32,17 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
-### -Database
-This is the database containing the permission.
+### -StoredProcedure
+This is the stored procedure that is returned by a
+stored procedure API call.
 
 ```yaml
-Type: String
+Type: Object
 Parameter Sets: (All)
 Aliases:
 
 Required: True
 Position: 1
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -UserId
-This is the Id of the user containing the permission.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: 2
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Id
-This is the Id of the permission.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: 3
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -83,8 +55,6 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## INPUTS
 
 ## OUTPUTS
-
-### System.String
 
 ## NOTES
 

--- a/docs/Set-CosmosDbTrigger.md
+++ b/docs/Set-CosmosDbTrigger.md
@@ -12,9 +12,9 @@ Update a trigger from a CosmosDB collection.
 
 ## SYNTAX
 
-### Connection (Default)
+### Context (Default)
 ```
-Set-CosmosDbTrigger -Connection <Connection> [-Database <String>] [-Key <SecureString>] -CollectionId <String>
+Set-CosmosDbTrigger -Context <Context> [-Database <String>] [-Key <SecureString>] -CollectionId <String>
  -Id <String> -TriggerBody <String> -TriggerOperation <String> -TriggerType <String> [<CommonParameters>]
 ```
 
@@ -32,7 +32,7 @@ collection.
 ## EXAMPLES
 
 ### Example 1
-```
+```powershell
 PS C:\> {{ Add example code here }}
 ```
 
@@ -40,16 +40,16 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
-### -Connection
-This is an object containing the connection information of
+### -Context
+This is an object containing the context information of
 the CosmosDB database that will be deleted.
 It should be created
-by \`New-CosmosDbConnection\`.
+by \`New-CosmosDbContext\`.
 
 ```yaml
-Type: Connection
-Parameter Sets: Connection
-Aliases:
+Type: Context
+Parameter Sets: Context
+Aliases: Connection
 
 Required: True
 Position: Named
@@ -194,7 +194,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/Set-CosmosDbTriggerType.md
+++ b/docs/Set-CosmosDbTriggerType.md
@@ -5,20 +5,21 @@ online version:
 schema: 2.0.0
 ---
 
-# Get-CosmosDbPermissionResourcePath
+# Set-CosmosDbTriggerType
 
 ## SYNOPSIS
-Return the resource path for a permission object.
+Set the custom Cosmos DB trigger types to the trigger returned
+by an API call.
 
 ## SYNTAX
 
 ```
-Get-CosmosDbPermissionResourcePath [-Database] <String> [-UserId] <String> [-Id] <String> [<CommonParameters>]
+Set-CosmosDbTriggerType [-Trigger] <Object> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-This cmdlet returns the resource identifier for a
-permission object.
+This function applies the custom types to the trigger returned
+by an API call.
 
 ## EXAMPLES
 
@@ -31,46 +32,16 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
-### -Database
-This is the database containing the permission.
+### -Trigger
+This is the trigger that is returned by a trigger API call.
 
 ```yaml
-Type: String
+Type: Object
 Parameter Sets: (All)
 Aliases:
 
 Required: True
 Position: 1
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -UserId
-This is the Id of the user containing the permission.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: 2
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Id
-This is the Id of the permission.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: 3
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -83,8 +54,6 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## INPUTS
 
 ## OUTPUTS
-
-### System.String
 
 ## NOTES
 

--- a/docs/Set-CosmosDbUser.md
+++ b/docs/Set-CosmosDbUser.md
@@ -12,10 +12,10 @@ Set the user Id of an existing user in a CosmosDB database.
 
 ## SYNTAX
 
-### Connection (Default)
+### Context (Default)
 ```
-Set-CosmosDbUser -Connection <Connection> [-Database <String>] [-Key <SecureString>] -Id <String>
- -NewId <String> [<CommonParameters>]
+Set-CosmosDbUser -Context <Context> [-Database <String>] [-Key <SecureString>] -Id <String> -NewId <String>
+ [<CommonParameters>]
 ```
 
 ### Account
@@ -31,7 +31,7 @@ a CosmosDB.
 ## EXAMPLES
 
 ### Example 1
-```
+```powershell
 PS C:\> {{ Add example code here }}
 ```
 
@@ -39,16 +39,16 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
-### -Connection
-This is an object containing the connection information of
+### -Context
+This is an object containing the context information of
 the CosmosDB database that will be deleted.
 It should be created
-by \`New-CosmosDbConnection\`.
+by \`New-CosmosDbContext\`.
 
 ```yaml
-Type: Connection
-Parameter Sets: Connection
-Aliases:
+Type: Context
+Parameter Sets: Context
+Aliases: Connection
 
 Required: True
 Position: Named
@@ -148,7 +148,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/Set-CosmosDbUserDefinedFunction.md
+++ b/docs/Set-CosmosDbUserDefinedFunction.md
@@ -12,9 +12,9 @@ Update a user defined function from a CosmosDB collection.
 
 ## SYNTAX
 
-### Connection (Default)
+### Context (Default)
 ```
-Set-CosmosDbUserDefinedFunction -Connection <Connection> [-Database <String>] [-Key <SecureString>]
+Set-CosmosDbUserDefinedFunction -Context <Context> [-Database <String>] [-Key <SecureString>]
  -CollectionId <String> -Id <String> -UserDefinedFunctionBody <String> [<CommonParameters>]
 ```
 
@@ -31,7 +31,7 @@ collection.
 ## EXAMPLES
 
 ### Example 1
-```
+```powershell
 PS C:\> {{ Add example code here }}
 ```
 
@@ -39,16 +39,16 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
-### -Connection
-This is an object containing the connection information of
+### -Context
+This is an object containing the context information of
 the CosmosDB database that will be deleted.
 It should be created
-by \`New-CosmosDbConnection\`.
+by \`New-CosmosDbContext\`.
 
 ```yaml
-Type: Connection
-Parameter Sets: Connection
-Aliases:
+Type: Context
+Parameter Sets: Context
+Aliases: Connection
 
 Required: True
 Position: Named
@@ -163,7 +163,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/Set-CosmosDbUserDefinedFunctionType.md
+++ b/docs/Set-CosmosDbUserDefinedFunctionType.md
@@ -5,20 +5,21 @@ online version:
 schema: 2.0.0
 ---
 
-# Get-CosmosDbPermissionResourcePath
+# Set-CosmosDbUserDefinedFunctionType
 
 ## SYNOPSIS
-Return the resource path for a permission object.
+Set the custom Cosmos DB User Defined Function types to the user
+defined function returned by an API call.
 
 ## SYNTAX
 
 ```
-Get-CosmosDbPermissionResourcePath [-Database] <String> [-UserId] <String> [-Id] <String> [<CommonParameters>]
+Set-CosmosDbUserDefinedFunctionType [-UserDefinedFunction] <Object> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-This cmdlet returns the resource identifier for a
-permission object.
+This function applies the custom types to the user defined function
+returned by an API call.
 
 ## EXAMPLES
 
@@ -31,46 +32,17 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
-### -Database
-This is the database containing the permission.
+### -UserDefinedFunction
+This is the user defined function that is returned by a user
+defined function API call.
 
 ```yaml
-Type: String
+Type: Object
 Parameter Sets: (All)
 Aliases:
 
 Required: True
 Position: 1
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -UserId
-This is the Id of the user containing the permission.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: 2
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Id
-This is the Id of the permission.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: 3
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -83,8 +55,6 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## INPUTS
 
 ## OUTPUTS
-
-### System.String
 
 ## NOTES
 

--- a/docs/Set-CosmosDbUserType.md
+++ b/docs/Set-CosmosDbUserType.md
@@ -5,20 +5,21 @@ online version:
 schema: 2.0.0
 ---
 
-# Get-CosmosDbPermissionResourcePath
+# Set-CosmosDbUserType
 
 ## SYNOPSIS
-Return the resource path for a permission object.
+Set the custom Cosmos DB User types to the user
+returned by an API call.
 
 ## SYNTAX
 
 ```
-Get-CosmosDbPermissionResourcePath [-Database] <String> [-UserId] <String> [-Id] <String> [<CommonParameters>]
+Set-CosmosDbUserType [-User] <Object> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-This cmdlet returns the resource identifier for a
-permission object.
+This function applies the custom types to the user returned
+by an API call.
 
 ## EXAMPLES
 
@@ -31,46 +32,16 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
-### -Database
-This is the database containing the permission.
+### -User
+This is the user that is returned by a user API call.
 
 ```yaml
-Type: String
+Type: Object
 Parameter Sets: (All)
 Aliases:
 
 Required: True
 Position: 1
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -UserId
-This is the Id of the user containing the permission.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: 2
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Id
-This is the Id of the permission.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: 3
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -83,8 +54,6 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## INPUTS
 
 ## OUTPUTS
-
-### System.String
 
 ## NOTES
 

--- a/src/CosmosDB.psd1
+++ b/src/CosmosDB.psd1
@@ -3,7 +3,7 @@
     RootModule        = 'CosmosDB.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '2.0.1.173'
+    ModuleVersion     = '2.0.2.173'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()
@@ -18,7 +18,7 @@
     CompanyName       = ''
 
     # Copyright statement for this module
-    Copyright         = '(c) 2017 Daniel Scott-Raynsford. All rights reserved.'
+    Copyright         = '(c) 2018 Daniel Scott-Raynsford. All rights reserved.'
 
     # Description of the functionality provided by this module
     Description       = 'This module provides cmdlets for working with Azure Cosmos DB databases, collections, users and permissions.'
@@ -107,7 +107,7 @@
         'New-CosmosDbCollection'
         'New-CosmosDbDatabase'
         'New-CosmosDbDocument'
-        'New-CosmosDbConnection'
+        'New-CosmosDbContext'
         'New-CosmosDbPermission'
         'New-CosmosDbStoredProcedure'
         'New-CosmosDbTrigger'
@@ -131,7 +131,9 @@
     )
 
     # Variables to export from this module
-    VariablesToExport = '*'
+    VariablesToExport = @(
+        'New-CosmosDbConnection'
+    )
 
     # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
     AliasesToExport   = '*'
@@ -162,6 +164,14 @@
 
             # ReleaseNotes of this module
             ReleaseNotes = '
+## What is New in CosmosDB Unreleased
+
+February 24, 2018
+
+- Converted all `connection` function names and parameter names
+  over to `context`. Aliases were implemented for old `connection`
+  function and parameter names to reduce possibility of breakage.
+
 ## What is New in CosmosDB 2.0.1
 
 January 27, 2018

--- a/src/CosmosDB.psm1
+++ b/src/CosmosDB.psm1
@@ -5,11 +5,11 @@ $moduleRoot = Split-Path `
     -Parent
 
 #region Types
-if (-not ([System.Management.Automation.PSTypeName]'CosmosDB.Connection').Type)
+if (-not ([System.Management.Automation.PSTypeName]'CosmosDB.Context').Type)
 {
     $typeDefinition = @'
 namespace CosmosDB {
-    public class Connection
+    public class Context
     {
         public System.String Account;
         public System.String Database;
@@ -50,3 +50,6 @@ Foreach ($lib in $libs)
     . $lib.Fullname
 }
 #endregion
+
+# Add Aliases
+New-Alias -Name 'New-CosmosDbConnection' -Value 'New-CosmosDbContext' -Force

--- a/src/lib/attachments.ps1
+++ b/src/lib/attachments.ps1
@@ -86,10 +86,10 @@ function Get-CosmosDbAttachmentResourcePath
     in a CosmosDB database. If an Id is specified then only the
     specified permission will be returned.
 
-.PARAMETER Connection
-    This is an object containing the connection information of
+.PARAMETER Context
+    This is an object containing the context information of
     the CosmosDB database that will be accessed. It should be created
-    by `New-CosmosDbConnection`.
+    by `New-CosmosDbContext`.
 
 .PARAMETER Account
     The account name of the CosmosDB to access.
@@ -114,14 +114,15 @@ function Get-CosmosDbAttachmentResourcePath
 #>
 function Get-CosmosDbAttachment
 {
-    [CmdletBinding(DefaultParameterSetName = 'Connection')]
+    [CmdletBinding(DefaultParameterSetName = 'Context')]
     [OutputType([Object])]
     param
     (
-        [Parameter(Mandatory = $true, ParameterSetName = 'Connection')]
+        [Alias("Connection")]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
-        [CosmosDb.Connection]
-        $Connection,
+        [CosmosDb.Context]
+        $Context,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Account')]
         [ValidateNotNullOrEmpty()]
@@ -195,10 +196,10 @@ function Get-CosmosDbAttachment
 .DESCRIPTION
     This cmdlet will create a attachment for a document in a CosmosDB.
 
-.PARAMETER Connection
-    This is an object containing the connection information of
+.PARAMETER Context
+    This is an object containing the context information of
     the CosmosDB database that will be deleted. It should be created
-    by `New-CosmosDbConnection`.
+    by `New-CosmosDbContext`.
 
 .PARAMETER Account
     The account name of the CosmosDB to access.
@@ -238,14 +239,15 @@ function Get-CosmosDbAttachment
 #>
 function New-CosmosDbAttachment
 {
-    [CmdletBinding(DefaultParameterSetName = 'Connection')]
+    [CmdletBinding(DefaultParameterSetName = 'Context')]
     [OutputType([Object])]
     param
     (
-        [Parameter(Mandatory = $true, ParameterSetName = 'Connection')]
+        [Alias("Connection")]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
-        [CosmosDb.Connection]
-        $Connection,
+        [CosmosDb.Context]
+        $Context,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Account')]
         [ValidateNotNullOrEmpty()]
@@ -354,10 +356,10 @@ function New-CosmosDbAttachment
 .DESCRIPTION
     This cmdlet will delete an attachment in a CosmosDB from a document.
 
-.PARAMETER Connection
-    This is an object containing the connection information of
+.PARAMETER Context
+    This is an object containing the context information of
     the CosmosDB database that will be deleted. It should be created
-    by `New-CosmosDbConnection`.
+    by `New-CosmosDbContext`.
 
 .PARAMETER Account
     The account name of the CosmosDB to access.
@@ -382,13 +384,14 @@ function New-CosmosDbAttachment
 #>
 function Remove-CosmosDbAttachment
 {
-    [CmdletBinding(DefaultParameterSetName = 'Connection')]
+    [CmdletBinding(DefaultParameterSetName = 'Context')]
     param
     (
-        [Parameter(Mandatory = $true, ParameterSetName = 'Connection')]
+        [Alias("Connection")]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
-        [CosmosDb.Connection]
-        $Connection,
+        [CosmosDb.Context]
+        $Context,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Account')]
         [ValidateNotNullOrEmpty()]
@@ -446,10 +449,10 @@ function Remove-CosmosDbAttachment
     This cmdlet will update an existing attachment in a CosmosDB
     document.
 
-.PARAMETER Connection
-    This is an object containing the connection information of
+.PARAMETER Context
+    This is an object containing the context information of
     the CosmosDB database that will be deleted. It should be created
-    by `New-CosmosDbConnection`.
+    by `New-CosmosDbContext`.
 
 .PARAMETER Account
     The account name of the CosmosDB to access.
@@ -489,14 +492,15 @@ function Remove-CosmosDbAttachment
 #>
 function Set-CosmosDbAttachment
 {
-    [CmdletBinding(DefaultParameterSetName = 'Connection')]
+    [CmdletBinding(DefaultParameterSetName = 'Context')]
     [OutputType([Object])]
     param
     (
-        [Parameter(Mandatory = $true, ParameterSetName = 'Connection')]
+        [Alias("Connection")]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
-        [CosmosDb.Connection]
-        $Connection,
+        [CosmosDb.Context]
+        $Context,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Account')]
         [ValidateNotNullOrEmpty()]

--- a/src/lib/collections.ps1
+++ b/src/lib/collections.ps1
@@ -87,10 +87,10 @@ function Get-CosmosDbCollectionResourcePath
     If the Id is specified then only the collection matching this
     Id will be returned, otherwise all collections will be returned.
 
-.PARAMETER Connection
-    This is an object containing the connection information of
+.PARAMETER Context
+    This is an object containing the context information of
     the CosmosDB database that will be accessed. It should be created
-    by `New-CosmosDbConnection`.
+    by `New-CosmosDbContext`.
 
 .PARAMETER Account
     The account name of the CosmosDB to access.
@@ -110,14 +110,15 @@ function Get-CosmosDbCollectionResourcePath
 #>
 function Get-CosmosDbCollection
 {
-    [CmdletBinding(DefaultParameterSetName = 'Connection')]
+    [CmdletBinding(DefaultParameterSetName = 'Context')]
     [OutputType([Object])]
     param
     (
-        [Parameter(Mandatory = $true, ParameterSetName = 'Connection')]
+        [Alias("Connection")]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
-        [CosmosDb.Connection]
-        $Connection,
+        [CosmosDb.Context]
+        $Context,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Account')]
         [ValidateNotNullOrEmpty()]
@@ -176,10 +177,10 @@ function Get-CosmosDbCollection
 .DESCRIPTION
     This cmdlet will create a collection in a CosmosDB.
 
-.PARAMETER Connection
-    This is an object containing the connection information of
+.PARAMETER Context
+    This is an object containing the context information of
     the CosmosDB database that will be deleted. It should be created
-    by `New-CosmosDbConnection`.
+    by `New-CosmosDbContext`.
 
 .PARAMETER Account
     The account name of the CosmosDB to access.
@@ -213,14 +214,15 @@ function Get-CosmosDbCollection
 #>
 function New-CosmosDbCollection
 {
-    [CmdletBinding(DefaultParameterSetName = 'Connection')]
+    [CmdletBinding(DefaultParameterSetName = 'Context')]
     [OutputType([Object])]
     param
     (
-        [Parameter(Mandatory = $true, ParameterSetName = 'Connection')]
+        [Alias("Connection")]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
-        [CosmosDb.Connection]
-        $Connection,
+        [CosmosDb.Context]
+        $Context,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Account')]
         [ValidateNotNullOrEmpty()]
@@ -315,10 +317,10 @@ function New-CosmosDbCollection
 .DESCRIPTION
     This cmdlet will delete a collection in a CosmosDB.
 
-.PARAMETER Connection
-    This is an object containing the connection information of
+.PARAMETER Context
+    This is an object containing the context information of
     the CosmosDB database that will be deleted. It should be created
-    by `New-CosmosDbConnection`.
+    by `New-CosmosDbContext`.
 
 .PARAMETER Account
     The account name of the CosmosDB to access.
@@ -337,13 +339,14 @@ function New-CosmosDbCollection
 #>
 function Remove-CosmosDbCollection
 {
-    [CmdletBinding(DefaultParameterSetName = 'Connection')]
+    [CmdletBinding(DefaultParameterSetName = 'Context')]
     param
     (
-        [Parameter(Mandatory = $true, ParameterSetName = 'Connection')]
+        [Alias("Connection")]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
-        [CosmosDb.Connection]
-        $Connection,
+        [CosmosDb.Context]
+        $Context,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Account')]
         [ValidateNotNullOrEmpty()]

--- a/src/lib/databases.ps1
+++ b/src/lib/databases.ps1
@@ -62,12 +62,12 @@ function Get-CosmosDbDatabaseResourcePath
     If the Id is specified then only the database matching this
     Id will be returned, otherwise all databases will be returned.
 
-.PARAMETER Connection
-    This is an object containing the connection information of
+.PARAMETER Context
+    This is an object containing the context information of
     the CosmosDB database that will be accessed. It should be created
-    by `New-CosmosDbConnection`.
+    by `New-CosmosDbContext`.
 
-    If the connection contains a database it will be ignored.
+    If the context contains a database it will be ignored.
 
 .PARAMETER Account
     The account name of the CosmosDB to access.
@@ -83,14 +83,15 @@ function Get-CosmosDbDatabaseResourcePath
 #>
 function Get-CosmosDbDatabase
 {
-    [CmdletBinding(DefaultParameterSetName = 'Connection')]
+    [CmdletBinding(DefaultParameterSetName = 'Context')]
     [OutputType([Object])]
     param
     (
-        [Parameter(Mandatory = $true, ParameterSetName = 'Connection')]
+        [Alias("Connection")]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
-        [CosmosDb.Connection]
-        $Connection,
+        [CosmosDb.Context]
+        $Context,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Account')]
         [ValidateNotNullOrEmpty()]
@@ -144,10 +145,10 @@ function Get-CosmosDbDatabase
 .DESCRIPTION
     This cmdlet will create a database in CosmosDB.
 
-.PARAMETER Connection
-    This is an object containing the connection information of
+.PARAMETER Context
+    This is an object containing the context information of
     the CosmosDB database that will be deleted. It should be created
-    by `New-CosmosDbConnection`.
+    by `New-CosmosDbContext`.
 
 .PARAMETER Account
     The account name of the CosmosDB to access.
@@ -163,14 +164,15 @@ function Get-CosmosDbDatabase
 #>
 function New-CosmosDbDatabase
 {
-    [CmdletBinding(DefaultParameterSetName = 'Connection')]
+    [CmdletBinding(DefaultParameterSetName = 'Context')]
     [OutputType([Object])]
     param
     (
-        [Parameter(Mandatory = $true, ParameterSetName = 'Connection')]
+        [Alias("Connection")]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
-        [CosmosDb.Connection]
-        $Connection,
+        [CosmosDb.Context]
+        $Context,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Account')]
         [ValidateNotNullOrEmpty()]
@@ -213,10 +215,10 @@ function New-CosmosDbDatabase
 .DESCRIPTION
     This cmdlet will delete a database in CosmosDB.
 
-.PARAMETER Connection
-    This is an object containing the connection information of
+.PARAMETER Context
+    This is an object containing the context information of
     the CosmosDB database that will be deleted. It should be created
-    by `New-CosmosDbConnection`.
+    by `New-CosmosDbContext`.
 
 .PARAMETER Account
     The account name of the CosmosDB to access.
@@ -232,13 +234,14 @@ function New-CosmosDbDatabase
 #>
 function Remove-CosmosDbDatabase
 {
-    [CmdletBinding(DefaultParameterSetName = 'Connection')]
+    [CmdletBinding(DefaultParameterSetName = 'Context')]
     param
     (
-        [Parameter(Mandatory = $true, ParameterSetName = 'Connection')]
+        [Alias("Connection")]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
-        [CosmosDb.Connection]
-        $Connection,
+        [CosmosDb.Context]
+        $Context,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Account')]
         [ValidateNotNullOrEmpty()]

--- a/src/lib/documents.ps1
+++ b/src/lib/documents.ps1
@@ -79,10 +79,10 @@ function Get-CosmosDbDocumentResourcePath
     collection in a CosmosDB database. If an Id is specified then only
     the specified documents will be returned.
 
-.PARAMETER Connection
-    This is an object containing the connection information of
+.PARAMETER Context
+    This is an object containing the context information of
     the CosmosDB database that will be accessed. It should be created
-    by `New-CosmosDbConnection`.
+    by `New-CosmosDbContext`.
 
 .PARAMETER Account
     The account name of the CosmosDB to access.
@@ -146,14 +146,15 @@ function Get-CosmosDbDocumentResourcePath
 #>
 function Get-CosmosDbDocument
 {
-    [CmdletBinding(DefaultParameterSetName = 'Connection')]
+    [CmdletBinding(DefaultParameterSetName = 'Context')]
     [OutputType([Object])]
     param
     (
-        [Parameter(Mandatory = $true, ParameterSetName = 'Connection')]
+        [Alias("Connection")]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
-        [CosmosDb.Connection]
-        $Connection,
+        [CosmosDb.Context]
+        $Context,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Account')]
         [ValidateNotNullOrEmpty()]
@@ -360,10 +361,10 @@ function Get-CosmosDbDocument
 .DESCRIPTION
     This cmdlet will create a document for a collection in a CosmosDB.
 
-.PARAMETER Connection
-    This is an object containing the connection information of
+.PARAMETER Context
+    This is an object containing the context information of
     the CosmosDB database that will be deleted. It should be created
-    by `New-CosmosDbConnection`.
+    by `New-CosmosDbContext`.
 
 .PARAMETER Account
     The account name of the CosmosDB to access.
@@ -395,14 +396,15 @@ function Get-CosmosDbDocument
 #>
 function New-CosmosDbDocument
 {
-    [CmdletBinding(DefaultParameterSetName = 'Connection')]
+    [CmdletBinding(DefaultParameterSetName = 'Context')]
     [OutputType([Object])]
     param
     (
-        [Parameter(Mandatory = $true, ParameterSetName = 'Connection')]
+        [Alias("Connection")]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
-        [CosmosDb.Connection]
-        $Connection,
+        [CosmosDb.Context]
+        $Context,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Account')]
         [ValidateNotNullOrEmpty()]
@@ -476,10 +478,10 @@ function New-CosmosDbDocument
 .DESCRIPTION
     This cmdlet will delete a document in a CosmosDB from a collection.
 
-.PARAMETER Connection
-    This is an object containing the connection information of
+.PARAMETER Context
+    This is an object containing the context information of
     the CosmosDB database that will be deleted. It should be created
-    by `New-CosmosDbConnection`.
+    by `New-CosmosDbContext`.
 
 .PARAMETER Account
     The account name of the CosmosDB to access.
@@ -506,13 +508,14 @@ function New-CosmosDbDocument
 #>
 function Remove-CosmosDbDocument
 {
-    [CmdletBinding(DefaultParameterSetName = 'Connection')]
+    [CmdletBinding(DefaultParameterSetName = 'Context')]
     param
     (
-        [Parameter(Mandatory = $true, ParameterSetName = 'Connection')]
+        [Alias("Connection")]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
-        [CosmosDb.Connection]
-        $Connection,
+        [CosmosDb.Context]
+        $Context,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Account')]
         [ValidateNotNullOrEmpty()]
@@ -580,10 +583,10 @@ function Remove-CosmosDbDocument
     This cmdlet will update an existing document in a CosmosDB
     collection.
 
-.PARAMETER Connection
-    This is an object containing the connection information of
+.PARAMETER Context
+    This is an object containing the context information of
     the CosmosDB database that will be deleted. It should be created
-    by `New-CosmosDbConnection`.
+    by `New-CosmosDbContext`.
 
 .PARAMETER Account
     The account name of the CosmosDB to access.
@@ -619,14 +622,15 @@ function Remove-CosmosDbDocument
 #>
 function Set-CosmosDbDocument
 {
-    [CmdletBinding(DefaultParameterSetName = 'Connection')]
+    [CmdletBinding(DefaultParameterSetName = 'Context')]
     [OutputType([Object])]
     param
     (
-        [Parameter(Mandatory = $true, ParameterSetName = 'Connection')]
+        [Alias("Connection")]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
-        [CosmosDb.Connection]
-        $Connection,
+        [CosmosDb.Context]
+        $Context,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Account')]
         [ValidateNotNullOrEmpty()]

--- a/src/lib/permissions.ps1
+++ b/src/lib/permissions.ps1
@@ -78,10 +78,10 @@ function Get-CosmosDbPermissionResourcePath
     in a CosmosDB database. If an Id is specified then only the
     specified permission will be returned.
 
-.PARAMETER Connection
-    This is an object containing the connection information of
+.PARAMETER Context
+    This is an object containing the context information of
     the CosmosDB database that will be accessed. It should be created
-    by `New-CosmosDbConnection`.
+    by `New-CosmosDbContext`.
 
 .PARAMETER Account
     The account name of the CosmosDB to access.
@@ -111,14 +111,15 @@ function Get-CosmosDbPermissionResourcePath
 #>
 function Get-CosmosDbPermission
 {
-    [CmdletBinding(DefaultParameterSetName = 'Connection')]
+    [CmdletBinding(DefaultParameterSetName = 'Context')]
     [OutputType([Object])]
     param
     (
-        [Parameter(Mandatory = $true, ParameterSetName = 'Connection')]
+        [Alias("Connection")]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
-        [CosmosDb.Connection]
-        $Connection,
+        [CosmosDb.Context]
+        $Context,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Account')]
         [ValidateNotNullOrEmpty()]
@@ -205,10 +206,10 @@ function Get-CosmosDbPermission
 .DESCRIPTION
     This cmdlet will create a permission for a user in a CosmosDB.
 
-.PARAMETER Connection
-    This is an object containing the connection information of
+.PARAMETER Context
+    This is an object containing the context information of
     the CosmosDB database that will be deleted. It should be created
-    by `New-CosmosDbConnection`.
+    by `New-CosmosDbContext`.
 
 .PARAMETER Account
     The account name of the CosmosDB to access.
@@ -237,14 +238,15 @@ function Get-CosmosDbPermission
 #>
 function New-CosmosDbPermission
 {
-    [CmdletBinding(DefaultParameterSetName = 'Connection')]
+    [CmdletBinding(DefaultParameterSetName = 'Context')]
     [OutputType([Object])]
     param
     (
-        [Parameter(Mandatory = $true, ParameterSetName = 'Connection')]
+        [Alias("Connection")]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
-        [CosmosDb.Connection]
-        $Connection,
+        [CosmosDb.Context]
+        $Context,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Account')]
         [ValidateNotNullOrEmpty()]
@@ -313,10 +315,10 @@ function New-CosmosDbPermission
 .DESCRIPTION
     This cmdlet will delete a permission in a CosmosDB from a user.
 
-.PARAMETER Connection
-    This is an object containing the connection information of
+.PARAMETER Context
+    This is an object containing the context information of
     the CosmosDB database that will be deleted. It should be created
-    by `New-CosmosDbConnection`.
+    by `New-CosmosDbContext`.
 
 .PARAMETER Account
     The account name of the CosmosDB to access.
@@ -338,13 +340,14 @@ function New-CosmosDbPermission
 #>
 function Remove-CosmosDbPermission
 {
-    [CmdletBinding(DefaultParameterSetName = 'Connection')]
+    [CmdletBinding(DefaultParameterSetName = 'Context')]
     param
     (
-        [Parameter(Mandatory = $true, ParameterSetName = 'Connection')]
+        [Alias("Connection")]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
-        [CosmosDb.Connection]
-        $Connection,
+        [CosmosDb.Context]
+        $Context,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Account')]
         [ValidateNotNullOrEmpty()]

--- a/src/lib/storedprocedures.ps1
+++ b/src/lib/storedprocedures.ps1
@@ -79,10 +79,10 @@ function Get-CosmosDbStoredProcedureResourcePath
     collection in a CosmosDB database. If an Id is specified then only
     the specified stored procedures will be returned.
 
-.PARAMETER Connection
-    This is an object containing the connection information of
+.PARAMETER Context
+    This is an object containing the context information of
     the CosmosDB database that will be accessed. It should be created
-    by `New-CosmosDbConnection`.
+    by `New-CosmosDbContext`.
 
 .PARAMETER Account
     The account name of the CosmosDB to access.
@@ -104,14 +104,15 @@ function Get-CosmosDbStoredProcedureResourcePath
 #>
 function Get-CosmosDbStoredProcedure
 {
-    [CmdletBinding(DefaultParameterSetName = 'Connection')]
+    [CmdletBinding(DefaultParameterSetName = 'Context')]
     [OutputType([Object])]
     param
     (
-        [Parameter(Mandatory = $true, ParameterSetName = 'Connection')]
+        [Alias("Connection")]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
-        [CosmosDb.Connection]
-        $Connection,
+        [CosmosDb.Context]
+        $Context,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Account')]
         [ValidateNotNullOrEmpty()]
@@ -181,10 +182,10 @@ function Get-CosmosDbStoredProcedure
     This cmdlet will execute a stored procedure contained in a collection
     in a CosmosDB.
 
-.PARAMETER Connection
-    This is an object containing the connection information of
+.PARAMETER Context
+    This is an object containing the context information of
     the CosmosDB database that will be deleted. It should be created
-    by `New-CosmosDbConnection`.
+    by `New-CosmosDbContext`.
 
 .PARAMETER Account
     The account name of the CosmosDB to access.
@@ -211,14 +212,15 @@ function Get-CosmosDbStoredProcedure
 #>
 function Invoke-CosmosDbStoredProcedure
 {
-    [CmdletBinding(DefaultParameterSetName = 'Connection')]
+    [CmdletBinding(DefaultParameterSetName = 'Context')]
     [OutputType([Object])]
     param
     (
-        [Parameter(Mandatory = $true, ParameterSetName = 'Connection')]
+        [Alias("Connection")]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
-        [CosmosDb.Connection]
-        $Connection,
+        [CosmosDb.Context]
+        $Context,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Account')]
         [ValidateNotNullOrEmpty()]
@@ -286,10 +288,10 @@ function Invoke-CosmosDbStoredProcedure
 .DESCRIPTION
     This cmdlet will create a stored procedure for a collection in a CosmosDB.
 
-.PARAMETER Connection
-    This is an object containing the connection information of
+.PARAMETER Context
+    This is an object containing the context information of
     the CosmosDB database that will be deleted. It should be created
-    by `New-CosmosDbConnection`.
+    by `New-CosmosDbContext`.
 
 .PARAMETER Account
     The account name of the CosmosDB to access.
@@ -314,14 +316,15 @@ function Invoke-CosmosDbStoredProcedure
 #>
 function New-CosmosDbStoredProcedure
 {
-    [CmdletBinding(DefaultParameterSetName = 'Connection')]
+    [CmdletBinding(DefaultParameterSetName = 'Context')]
     [OutputType([Object])]
     param
     (
-        [Parameter(Mandatory = $true, ParameterSetName = 'Connection')]
+        [Alias("Connection")]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
-        [CosmosDb.Connection]
-        $Connection,
+        [CosmosDb.Context]
+        $Context,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Account')]
         [ValidateNotNullOrEmpty()]
@@ -386,10 +389,10 @@ function New-CosmosDbStoredProcedure
 .DESCRIPTION
     This cmdlet will delete a stored procedure in a CosmosDB from a collection.
 
-.PARAMETER Connection
-    This is an object containing the connection information of
+.PARAMETER Context
+    This is an object containing the context information of
     the CosmosDB database that will be deleted. It should be created
-    by `New-CosmosDbConnection`.
+    by `New-CosmosDbContext`.
 
 .PARAMETER Account
     The account name of the CosmosDB to access.
@@ -411,13 +414,14 @@ function New-CosmosDbStoredProcedure
 #>
 function Remove-CosmosDbStoredProcedure
 {
-    [CmdletBinding(DefaultParameterSetName = 'Connection')]
+    [CmdletBinding(DefaultParameterSetName = 'Context')]
     param
     (
-        [Parameter(Mandatory = $true, ParameterSetName = 'Connection')]
+        [Alias("Connection")]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
-        [CosmosDb.Connection]
-        $Connection,
+        [CosmosDb.Context]
+        $Context,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Account')]
         [ValidateNotNullOrEmpty()]
@@ -469,10 +473,10 @@ function Remove-CosmosDbStoredProcedure
     This cmdlet will update an existing stored procedure in a CosmosDB
     collection.
 
-.PARAMETER Connection
-    This is an object containing the connection information of
+.PARAMETER Context
+    This is an object containing the context information of
     the CosmosDB database that will be deleted. It should be created
-    by `New-CosmosDbConnection`.
+    by `New-CosmosDbContext`.
 
 .PARAMETER Account
     The account name of the CosmosDB to access.
@@ -497,14 +501,15 @@ function Remove-CosmosDbStoredProcedure
 #>
 function Set-CosmosDbStoredProcedure
 {
-    [CmdletBinding(DefaultParameterSetName = 'Connection')]
+    [CmdletBinding(DefaultParameterSetName = 'Context')]
     [OutputType([Object])]
     param
     (
-        [Parameter(Mandatory = $true, ParameterSetName = 'Connection')]
+        [Alias("Connection")]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
-        [CosmosDb.Connection]
-        $Connection,
+        [CosmosDb.Context]
+        $Context,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Account')]
         [ValidateNotNullOrEmpty()]

--- a/src/lib/triggers.ps1
+++ b/src/lib/triggers.ps1
@@ -78,10 +78,10 @@ function Get-CosmosDbTriggerResourcePath
     in a CosmosDB database. If an Id is specified then only the
     specified trigger will be returned.
 
-.PARAMETER Connection
-    This is an object containing the connection information of
+.PARAMETER Context
+    This is an object containing the context information of
     the CosmosDB database that will be accessed. It should be created
-    by `New-CosmosDbConnection`.
+    by `New-CosmosDbContext`.
 
 .PARAMETER Account
     The account name of the CosmosDB to access.
@@ -103,14 +103,15 @@ function Get-CosmosDbTriggerResourcePath
 #>
 function Get-CosmosDbTrigger
 {
-    [CmdletBinding(DefaultParameterSetName = 'Connection')]
+    [CmdletBinding(DefaultParameterSetName = 'Context')]
     [OutputType([Object])]
     param
     (
-        [Parameter(Mandatory = $true, ParameterSetName = 'Connection')]
+        [Alias("Connection")]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
-        [CosmosDb.Connection]
-        $Connection,
+        [CosmosDb.Context]
+        $Context,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Account')]
         [ValidateNotNullOrEmpty()]
@@ -179,10 +180,10 @@ function Get-CosmosDbTrigger
 .DESCRIPTION
     This cmdlet will create a trigger for a collection in a CosmosDB.
 
-.PARAMETER Connection
-    This is an object containing the connection information of
+.PARAMETER Context
+    This is an object containing the context information of
     the CosmosDB database that will be deleted. It should be created
-    by `New-CosmosDbConnection`.
+    by `New-CosmosDbContext`.
 
 .PARAMETER Account
     The account name of the CosmosDB to access.
@@ -213,14 +214,15 @@ function Get-CosmosDbTrigger
 #>
 function New-CosmosDbTrigger
 {
-    [CmdletBinding(DefaultParameterSetName = 'Connection')]
+    [CmdletBinding(DefaultParameterSetName = 'Context')]
     [OutputType([Object])]
     param
     (
-        [Parameter(Mandatory = $true, ParameterSetName = 'Connection')]
+        [Alias("Connection")]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
-        [CosmosDb.Connection]
-        $Connection,
+        [CosmosDb.Context]
+        $Context,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Account')]
         [ValidateNotNullOrEmpty()]
@@ -297,10 +299,10 @@ function New-CosmosDbTrigger
 .DESCRIPTION
     This cmdlet will delete a trigger in a CosmosDB from a collection.
 
-.PARAMETER Connection
-    This is an object containing the connection information of
+.PARAMETER Context
+    This is an object containing the context information of
     the CosmosDB database that will be deleted. It should be created
-    by `New-CosmosDbConnection`.
+    by `New-CosmosDbContext`.
 
 .PARAMETER Account
     The account name of the CosmosDB to access.
@@ -322,13 +324,14 @@ function New-CosmosDbTrigger
 #>
 function Remove-CosmosDbTrigger
 {
-    [CmdletBinding(DefaultParameterSetName = 'Connection')]
+    [CmdletBinding(DefaultParameterSetName = 'Context')]
     param
     (
-        [Parameter(Mandatory = $true, ParameterSetName = 'Connection')]
+        [Alias("Connection")]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
-        [CosmosDb.Connection]
-        $Connection,
+        [CosmosDb.Context]
+        $Context,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Account')]
         [ValidateNotNullOrEmpty()]
@@ -380,10 +383,10 @@ function Remove-CosmosDbTrigger
     This cmdlet will update an existing trigger in a CosmosDB
     collection.
 
-.PARAMETER Connection
-    This is an object containing the connection information of
+.PARAMETER Context
+    This is an object containing the context information of
     the CosmosDB database that will be deleted. It should be created
-    by `New-CosmosDbConnection`.
+    by `New-CosmosDbContext`.
 
 .PARAMETER Account
     The account name of the CosmosDB to access.
@@ -414,14 +417,15 @@ function Remove-CosmosDbTrigger
 #>
 function Set-CosmosDbTrigger
 {
-    [CmdletBinding(DefaultParameterSetName = 'Connection')]
+    [CmdletBinding(DefaultParameterSetName = 'Context')]
     [OutputType([Object])]
     param
     (
-        [Parameter(Mandatory = $true, ParameterSetName = 'Connection')]
+        [Alias("Connection")]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
-        [CosmosDb.Connection]
-        $Connection,
+        [CosmosDb.Context]
+        $Context,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Account')]
         [ValidateNotNullOrEmpty()]

--- a/src/lib/userdefinedfunctions.ps1
+++ b/src/lib/userdefinedfunctions.ps1
@@ -79,10 +79,10 @@ function Get-CosmosDbUserDefinedFunctionResourcePath
     collection in a CosmosDB database. If an Id is specified then only
     the specified user defined functions will be returned.
 
-.PARAMETER Connection
-    This is an object containing the connection information of
+.PARAMETER Context
+    This is an object containing the context information of
     the CosmosDB database that will be accessed. It should be created
-    by `New-CosmosDbConnection`.
+    by `New-CosmosDbContext`.
 
 .PARAMETER Account
     The account name of the CosmosDB to access.
@@ -104,14 +104,15 @@ function Get-CosmosDbUserDefinedFunctionResourcePath
 #>
 function Get-CosmosDbUserDefinedFunction
 {
-    [CmdletBinding(DefaultParameterSetName = 'Connection')]
+    [CmdletBinding(DefaultParameterSetName = 'Context')]
     [OutputType([Object])]
     param
     (
-        [Parameter(Mandatory = $true, ParameterSetName = 'Connection')]
+        [Alias("Connection")]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
-        [CosmosDb.Connection]
-        $Connection,
+        [CosmosDb.Context]
+        $Context,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Account')]
         [ValidateNotNullOrEmpty()]
@@ -180,10 +181,10 @@ function Get-CosmosDbUserDefinedFunction
 .DESCRIPTION
     This cmdlet will create a user defined function for a collection in a CosmosDB.
 
-.PARAMETER Connection
-    This is an object containing the connection information of
+.PARAMETER Context
+    This is an object containing the context information of
     the CosmosDB database that will be deleted. It should be created
-    by `New-CosmosDbConnection`.
+    by `New-CosmosDbContext`.
 
 .PARAMETER Account
     The account name of the CosmosDB to access.
@@ -208,14 +209,15 @@ function Get-CosmosDbUserDefinedFunction
 #>
 function New-CosmosDbUserDefinedFunction
 {
-    [CmdletBinding(DefaultParameterSetName = 'Connection')]
+    [CmdletBinding(DefaultParameterSetName = 'Context')]
     [OutputType([Object])]
     param
     (
-        [Parameter(Mandatory = $true, ParameterSetName = 'Connection')]
+        [Alias("Connection")]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
-        [CosmosDb.Connection]
-        $Connection,
+        [CosmosDb.Context]
+        $Context,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Account')]
         [ValidateNotNullOrEmpty()]
@@ -280,10 +282,10 @@ function New-CosmosDbUserDefinedFunction
 .DESCRIPTION
     This cmdlet will delete a user defined function in a CosmosDB from a collection.
 
-.PARAMETER Connection
-    This is an object containing the connection information of
+.PARAMETER Context
+    This is an object containing the context information of
     the CosmosDB database that will be deleted. It should be created
-    by `New-CosmosDbConnection`.
+    by `New-CosmosDbContext`.
 
 .PARAMETER Account
     The account name of the CosmosDB to access.
@@ -305,13 +307,14 @@ function New-CosmosDbUserDefinedFunction
 #>
 function Remove-CosmosDbUserDefinedFunction
 {
-    [CmdletBinding(DefaultParameterSetName = 'Connection')]
+    [CmdletBinding(DefaultParameterSetName = 'Context')]
     param
     (
-        [Parameter(Mandatory = $true, ParameterSetName = 'Connection')]
+        [Alias("Connection")]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
-        [CosmosDb.Connection]
-        $Connection,
+        [CosmosDb.Context]
+        $Context,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Account')]
         [ValidateNotNullOrEmpty()]
@@ -363,10 +366,10 @@ function Remove-CosmosDbUserDefinedFunction
     This cmdlet will update an existing user defined function in a CosmosDB
     collection.
 
-.PARAMETER Connection
-    This is an object containing the connection information of
+.PARAMETER Context
+    This is an object containing the context information of
     the CosmosDB database that will be deleted. It should be created
-    by `New-CosmosDbConnection`.
+    by `New-CosmosDbContext`.
 
 .PARAMETER Account
     The account name of the CosmosDB to access.
@@ -391,14 +394,15 @@ function Remove-CosmosDbUserDefinedFunction
 #>
 function Set-CosmosDbUserDefinedFunction
 {
-    [CmdletBinding(DefaultParameterSetName = 'Connection')]
+    [CmdletBinding(DefaultParameterSetName = 'Context')]
     [OutputType([Object])]
     param
     (
-        [Parameter(Mandatory = $true, ParameterSetName = 'Connection')]
+        [Alias("Connection")]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
-        [CosmosDb.Connection]
-        $Connection,
+        [CosmosDb.Context]
+        $Context,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Account')]
         [ValidateNotNullOrEmpty()]

--- a/src/lib/users.ps1
+++ b/src/lib/users.ps1
@@ -68,10 +68,10 @@ function Get-CosmosDbUserResourcePath
     If the Id is specified then only the user matching this
     Id will be returned, otherwise all users will be returned.
 
-.PARAMETER Connection
-    This is an object containing the connection information of
+.PARAMETER Context
+    This is an object containing the context information of
     the CosmosDB database that will be accessed. It should be created
-    by `New-CosmosDbConnection`.
+    by `New-CosmosDbContext`.
 
 .PARAMETER Account
     The account name of the CosmosDB to access.
@@ -91,14 +91,15 @@ function Get-CosmosDbUserResourcePath
 #>
 function Get-CosmosDbUser
 {
-    [CmdletBinding(DefaultParameterSetName = 'Connection')]
+    [CmdletBinding(DefaultParameterSetName = 'Context')]
     [OutputType([Object])]
     param
     (
-        [Parameter(Mandatory = $true, ParameterSetName = 'Connection')]
+        [Alias("Connection")]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
-        [CosmosDb.Connection]
-        $Connection,
+        [CosmosDb.Context]
+        $Context,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Account')]
         [ValidateNotNullOrEmpty()]
@@ -157,10 +158,10 @@ function Get-CosmosDbUser
 .DESCRIPTION
     This cmdlet will create a user in a CosmosDB.
 
-.PARAMETER Connection
-    This is an object containing the connection information of
+.PARAMETER Context
+    This is an object containing the context information of
     the CosmosDB database that will be deleted. It should be created
-    by `New-CosmosDbConnection`.
+    by `New-CosmosDbContext`.
 
 .PARAMETER Account
     The account name of the CosmosDB to access.
@@ -179,14 +180,15 @@ function Get-CosmosDbUser
 #>
 function New-CosmosDbUser
 {
-    [CmdletBinding(DefaultParameterSetName = 'Connection')]
+    [CmdletBinding(DefaultParameterSetName = 'Context')]
     [OutputType([Object])]
     param
     (
-        [Parameter(Mandatory = $true, ParameterSetName = 'Connection')]
+        [Alias("Connection")]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
-        [CosmosDb.Connection]
-        $Connection,
+        [CosmosDb.Context]
+        $Context,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Account')]
         [ValidateNotNullOrEmpty()]
@@ -234,10 +236,10 @@ function New-CosmosDbUser
 .DESCRIPTION
     This cmdlet will delete a user in a CosmosDB.
 
-.PARAMETER Connection
-    This is an object containing the connection information of
+.PARAMETER Context
+    This is an object containing the context information of
     the CosmosDB database that will be deleted. It should be created
-    by `New-CosmosDbConnection`.
+    by `New-CosmosDbContext`.
 
 .PARAMETER Account
     The account name of the CosmosDB to access.
@@ -256,13 +258,14 @@ function New-CosmosDbUser
 #>
 function Remove-CosmosDbUser
 {
-    [CmdletBinding(DefaultParameterSetName = 'Connection')]
+    [CmdletBinding(DefaultParameterSetName = 'Context')]
     param
     (
-        [Parameter(Mandatory = $true, ParameterSetName = 'Connection')]
+        [Alias("Connection")]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
-        [CosmosDb.Connection]
-        $Connection,
+        [CosmosDb.Context]
+        $Context,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Account')]
         [ValidateNotNullOrEmpty()]
@@ -306,10 +309,10 @@ function Remove-CosmosDbUser
     This cmdlet will set the user Id of an existing  user in
     a CosmosDB.
 
-.PARAMETER Connection
-    This is an object containing the connection information of
+.PARAMETER Context
+    This is an object containing the context information of
     the CosmosDB database that will be deleted. It should be created
-    by `New-CosmosDbConnection`.
+    by `New-CosmosDbContext`.
 
 .PARAMETER Account
     The account name of the CosmosDB to access.
@@ -331,14 +334,15 @@ function Remove-CosmosDbUser
 #>
 function Set-CosmosDbUser
 {
-    [CmdletBinding(DefaultParameterSetName = 'Connection')]
+    [CmdletBinding(DefaultParameterSetName = 'Context')]
     [OutputType([Object])]
     param
     (
-        [Parameter(Mandatory = $true, ParameterSetName = 'Connection')]
+        [Alias("Connection")]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
-        [CosmosDb.Connection]
-        $Connection,
+        [CosmosDb.Context]
+        $Context,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Account')]
         [ValidateNotNullOrEmpty()]

--- a/test/CosmosDB.attachments.Tests.ps1
+++ b/test/CosmosDB.attachments.Tests.ps1
@@ -14,7 +14,7 @@ InModuleScope CosmosDB {
     $script:testDatabase = 'testDatabase'
     $script:testKey = 'GFJqJeri2Rq910E0G7PsWoZkzowzbj23Sm9DUWFC0l0P8o16mYyuaZKN00Nbtj9F1QQnumzZKSGZwknXGERrlA=='
     $script:testKeySecureString = ConvertTo-SecureString -String $script:testKey -AsPlainText -Force
-    $script:testConnection = [CosmosDb.Connection] @{
+    $script:testContext = [CosmosDb.Context] @{
         Account  = $script:testAccount
         Database = $script:testDatabase
         Key      = $script:testKeySecureString
@@ -96,7 +96,7 @@ InModuleScope CosmosDB {
             { Get-Command -Name Get-CosmosDbAttachment -ErrorAction Stop } | Should -Not -Throw
         }
 
-        Context 'Called with connection parameter and no id' {
+        Context 'Called with context parameter and no id' {
             $script:result = $null
 
             Mock `
@@ -106,7 +106,7 @@ InModuleScope CosmosDB {
 
             It 'Should not throw exception' {
                 $getCosmosDbAttachmentParameters = @{
-                    Connection   = $script:testConnection
+                    Context      = $script:testContext
                     CollectionId = $script:testCollection
                     DocumentId   = $script:testDocument
                 }
@@ -128,7 +128,7 @@ InModuleScope CosmosDB {
             }
         }
 
-        Context 'Called with connection parameter and an id' {
+        Context 'Called with context parameter and an id' {
             $script:result = $null
 
             Mock `
@@ -138,7 +138,7 @@ InModuleScope CosmosDB {
 
             It 'Should not throw exception' {
                 $getCosmosDbAttachmentParameters = @{
-                    Connection   = $script:testConnection
+                    Context      = $script:testContext
                     CollectionId = $script:testCollection
                     DocumentId   = $script:testDocument
                     Id           = $script:testAttachment1
@@ -165,7 +165,7 @@ InModuleScope CosmosDB {
             { Get-Command -Name New-CosmosDbAttachment -ErrorAction Stop } | Should -Not -Throw
         }
 
-        Context 'Called with connection parameter and an id' {
+        Context 'Called with context parameter and an id' {
             $script:result = $null
 
             Mock `
@@ -175,7 +175,7 @@ InModuleScope CosmosDB {
 
             It 'Should not throw exception' {
                 $newCosmosDbAttachmentParameters = @{
-                    Connection   = $script:testConnection
+                    Context      = $script:testContext
                     CollectionId = $script:testCollection
                     DocumentId   = $script:testDocument
                     Id           = $script:testAttachment1
@@ -204,7 +204,7 @@ InModuleScope CosmosDB {
             { Get-Command -Name Remove-CosmosDbAttachment -ErrorAction Stop } | Should -Not -Throw
         }
 
-        Context 'Called with connection parameter and an id' {
+        Context 'Called with context parameter and an id' {
             $script:result = $null
 
             Mock `
@@ -213,7 +213,7 @@ InModuleScope CosmosDB {
 
             It 'Should not throw exception' {
                 $removeCosmosDbAttachmentParameters = @{
-                    Connection   = $script:testConnection
+                    Context      = $script:testContext
                     CollectionId = $script:testCollection
                     DocumentId   = $script:testDocument
                     Id           = $script:testAttachment1
@@ -236,7 +236,7 @@ InModuleScope CosmosDB {
             { Get-Command -Name Set-CosmosDbAttachment -ErrorAction Stop } | Should -Not -Throw
         }
 
-        Context 'Called with connection parameter and an Id' {
+        Context 'Called with context parameter and an Id' {
             $script:result = $null
 
             Mock `
@@ -246,7 +246,7 @@ InModuleScope CosmosDB {
 
             It 'Should not throw exception' {
                 $setCosmosDbAttachmentParameters = @{
-                    Connection   = $script:testConnection
+                    Context      = $script:testContext
                     CollectionId = $script:testCollection
                     DocumentId   = $script:testDocument
                     Id           = $script:testAttachment1

--- a/test/CosmosDB.collections.Tests.ps1
+++ b/test/CosmosDB.collections.Tests.ps1
@@ -14,7 +14,7 @@ InModuleScope CosmosDB {
     $script:testDatabase = 'testDatabase'
     $script:testKey = 'GFJqJeri2Rq910E0G7PsWoZkzowzbj23Sm9DUWFC0l0P8o16mYyuaZKN00Nbtj9F1QQnumzZKSGZwknXGERrlA=='
     $script:testKeySecureString = ConvertTo-SecureString -String $script:testKey -AsPlainText -Force
-    $script:testConnection = [CosmosDb.Connection] @{
+    $script:testContext = [CosmosDb.Context] @{
         Account  = $script:testAccount
         Database = $script:testDatabase
         Key      = $script:testKeySecureString
@@ -75,7 +75,7 @@ InModuleScope CosmosDB {
             Mock -CommandName Set-CosmosDbCollectionType -MockWith { $Collection }
         }
 
-        Context 'Called with connection parameter and no Id' {
+        Context 'Called with context parameter and no Id' {
             $script:result = $null
 
             Mock `
@@ -85,7 +85,7 @@ InModuleScope CosmosDB {
 
             It 'Should not throw exception' {
                 $getCosmosDbCollectionParameters = @{
-                    Connection = $script:testConnection
+                    Context = $script:testContext
                 }
 
                 { $script:result = Get-CosmosDbCollection @getCosmosDbCollectionParameters } | Should -Not -Throw
@@ -105,7 +105,7 @@ InModuleScope CosmosDB {
             }
         }
 
-        Context 'Called with connection parameter and an Id' {
+        Context 'Called with context parameter and an Id' {
             $script:result = $null
 
             Mock `
@@ -115,7 +115,7 @@ InModuleScope CosmosDB {
 
             It 'Should not throw exception' {
                 $getCosmosDbCollectionParameters = @{
-                    Connection = $script:testConnection
+                    Context = $script:testContext
                     Id         = $script:testCollection1
                 }
 
@@ -144,7 +144,7 @@ InModuleScope CosmosDB {
             Mock -CommandName Set-CosmosDbCollectionType -MockWith { $Collection }
         }
 
-        Context 'Called with connection parameter and an Id' {
+        Context 'Called with context parameter and an Id' {
             $script:result = $null
 
             Mock `
@@ -154,7 +154,7 @@ InModuleScope CosmosDB {
 
             It 'Should not throw exception' {
                 $newCosmosDbCollectionParameters = @{
-                    Connection = $script:testConnection
+                    Context = $script:testContext
                     Id         = $script:testCollection1
                 }
 
@@ -173,7 +173,7 @@ InModuleScope CosmosDB {
             }
         }
 
-        Context 'Called with connection parameter and an Id and OfferThroughput parameter' {
+        Context 'Called with context parameter and an Id and OfferThroughput parameter' {
             $script:result = $null
 
             Mock `
@@ -183,7 +183,7 @@ InModuleScope CosmosDB {
 
             It 'Should not throw exception' {
                 $newCosmosDbCollectionParameters = @{
-                    Connection      = $script:testConnection
+                    Context      = $script:testContext
                     Id              = $script:testCollection1
                     OfferThroughput = 400
                 }
@@ -202,7 +202,7 @@ InModuleScope CosmosDB {
             }
         }
 
-        Context 'Called with connection parameter and an Id and OfferType parameter' {
+        Context 'Called with context parameter and an Id and OfferType parameter' {
             $script:result = $null
 
             Mock `
@@ -212,7 +212,7 @@ InModuleScope CosmosDB {
 
             It 'Should not throw exception' {
                 $newCosmosDbCollectionParameters = @{
-                    Connection = $script:testConnection
+                    Context = $script:testContext
                     Id         = $script:testCollection1
                     OfferType  = 'S2'
                 }
@@ -232,7 +232,7 @@ InModuleScope CosmosDB {
             }
         }
 
-        Context 'Called with connection parameter and an Id and PartitionKey parameter' {
+        Context 'Called with context parameter and an Id and PartitionKey parameter' {
             $script:result = $null
 
             Mock `
@@ -242,7 +242,7 @@ InModuleScope CosmosDB {
 
             It 'Should not throw exception' {
                 $newCosmosDbCollectionParameters = @{
-                    Connection   = $script:testConnection
+                    Context   = $script:testContext
                     Id           = $script:testCollection1
                     PartitionKey = 'partitionkey'
                 }
@@ -262,7 +262,7 @@ InModuleScope CosmosDB {
             }
         }
 
-        Context 'Called with connection parameter and an Id and OfferType and OfferThrougput' {
+        Context 'Called with context parameter and an Id and OfferType and OfferThrougput' {
             $script:result = $null
 
             Mock `
@@ -271,7 +271,7 @@ InModuleScope CosmosDB {
 
             It 'Should not throw exception' {
                 $newCosmosDbCollectionParameters = @{
-                    Connection      = $script:testConnection
+                    Context      = $script:testContext
                     Id              = $script:testCollection1
                     OfferThroughput = 400
                     OfferType       = 'S1'
@@ -294,7 +294,7 @@ InModuleScope CosmosDB {
             { Get-Command -Name Remove-CosmosDbCollection -ErrorAction Stop } | Should -Not -Throw
         }
 
-        Context 'Called with connection parameter and an Id' {
+        Context 'Called with context parameter and an Id' {
             $script:result = $null
 
             Mock `
@@ -303,7 +303,7 @@ InModuleScope CosmosDB {
 
             It 'Should not throw exception' {
                 $removeCosmosDbCollectionParameters = @{
-                    Connection = $script:testConnection
+                    Context = $script:testContext
                     Id         = $script:testCollection1
                 }
 

--- a/test/CosmosDB.databases.Tests.ps1
+++ b/test/CosmosDB.databases.Tests.ps1
@@ -14,7 +14,7 @@ InModuleScope CosmosDB {
     $script:testDatabase = 'testDatabase'
     $script:testKey = 'GFJqJeri2Rq910E0G7PsWoZkzowzbj23Sm9DUWFC0l0P8o16mYyuaZKN00Nbtj9F1QQnumzZKSGZwknXGERrlA=='
     $script:testKeySecureString = ConvertTo-SecureString -String $script:testKey -AsPlainText -Force
-    $script:testConnection = [CosmosDb.Connection] @{
+    $script:testContext = [CosmosDb.Context] @{
         Account  = $script:testAccount
         Database = $script:testDatabase
         Key      = $script:testKeySecureString
@@ -49,7 +49,7 @@ InModuleScope CosmosDB {
     "_count": 2
 }
 '@
-$script:testJsonSingle = @'
+    $script:testJsonSingle = @'
 {
     "id": "testdatabase1",
     "_rid": "vdoeAA==",
@@ -88,7 +88,7 @@ $script:testJsonSingle = @'
             { Get-Command -Name Get-CosmosDbDatabase -ErrorAction Stop } | Should -Not -Throw
         }
 
-        Context 'Called with connection parameter and no Id' {
+        Context 'Called with context parameter and no Id' {
             $script:result = $null
 
             Mock `
@@ -98,7 +98,7 @@ $script:testJsonSingle = @'
 
             It 'Should not throw exception' {
                 $getCosmosDbDatabaseParameters = @{
-                    Connection = $script:testConnection
+                    Context = $script:testContext
                 }
 
                 { $script:result = Get-CosmosDbDatabase @getCosmosDbDatabaseParameters } | Should -Not -Throw
@@ -118,7 +118,7 @@ $script:testJsonSingle = @'
             }
         }
 
-        Context 'Called with connection parameter and an Id' {
+        Context 'Called with context parameter and an Id' {
             $script:result = $null
 
             Mock `
@@ -128,8 +128,8 @@ $script:testJsonSingle = @'
 
             It 'Should not throw exception' {
                 $getCosmosDbDatabaseParameters = @{
-                    Connection = $script:testConnection
-                    Id         = $script:testDatabase
+                    Context = $script:testContext
+                    Id      = $script:testDatabase
                 }
 
                 { $script:result = Get-CosmosDbDatabase @getCosmosDbDatabaseParameters } | Should -Not -Throw
@@ -152,7 +152,7 @@ $script:testJsonSingle = @'
             { Get-Command -Name New-CosmosDbDatabase -ErrorAction Stop } | Should -Not -Throw
         }
 
-        Context 'Called with connection parameter and an Id' {
+        Context 'Called with context parameter and an Id' {
             $script:result = $null
 
             Mock `
@@ -162,8 +162,8 @@ $script:testJsonSingle = @'
 
             It 'Should not throw exception' {
                 $newCosmosDbDatabaseParameters = @{
-                    Connection = $script:testConnection
-                    Id         = $script:testDatabase
+                    Context = $script:testContext
+                    Id      = $script:testDatabase
                 }
 
                 { $script:result = New-CosmosDbDatabase @newCosmosDbDatabaseParameters } | Should -Not -Throw
@@ -187,7 +187,7 @@ $script:testJsonSingle = @'
             { Get-Command -Name Remove-CosmosDbDatabase -ErrorAction Stop } | Should -Not -Throw
         }
 
-        Context 'Called with connection parameter and an Id' {
+        Context 'Called with context parameter and an Id' {
             $script:result = $null
 
             Mock `
@@ -196,8 +196,8 @@ $script:testJsonSingle = @'
 
             It 'Should not throw exception' {
                 $removeCosmosDbDatabaseParameters = @{
-                    Connection = $script:testConnection
-                    Id         = $script:testDatabase
+                    Context = $script:testContext
+                    Id      = $script:testDatabase
                 }
 
                 { $script:result = Remove-CosmosDbDatabase @removeCosmosDbDatabaseParameters } | Should -Not -Throw

--- a/test/CosmosDB.documents.Tests.ps1
+++ b/test/CosmosDB.documents.Tests.ps1
@@ -14,7 +14,7 @@ InModuleScope CosmosDB {
     $script:testDatabase = 'testDatabase'
     $script:testKey = 'GFJqJeri2Rq910E0G7PsWoZkzowzbj23Sm9DUWFC0l0P8o16mYyuaZKN00Nbtj9F1QQnumzZKSGZwknXGERrlA=='
     $script:testKeySecureString = ConvertTo-SecureString -String $script:testKey -AsPlainText -Force
-    $script:testConnection = [CosmosDb.Connection] @{
+    $script:testContext = [CosmosDb.Context] @{
         Account  = $script:testAccount
         Database = $script:testDatabase
         Key      = $script:testKeySecureString
@@ -95,7 +95,7 @@ InModuleScope CosmosDB {
             { Get-Command -Name Get-CosmosDbDocument -ErrorAction Stop } | Should -Not -Throw
         }
 
-        Context 'Called with connection parameter and no Id but with header parameters' {
+        Context 'Called with context parameter and no Id but with header parameters' {
             $script:result = $null
 
             Mock `
@@ -109,7 +109,7 @@ InModuleScope CosmosDB {
 
             It 'Should not throw exception' {
                 $getCosmosDbDocumentParameters = @{
-                    Connection          = $script:testConnection
+                    Context          = $script:testContext
                     CollectionId        = $script:testCollection
                     MaxItemCount        = 5
                     ContinuationToken   = 'token'
@@ -135,7 +135,7 @@ InModuleScope CosmosDB {
             }
         }
 
-        Context 'Called with connection parameter and no Id with headers returned' {
+        Context 'Called with context parameter and no Id with headers returned' {
             $script:result = $null
 
             Mock `
@@ -151,7 +151,7 @@ InModuleScope CosmosDB {
             It 'Should not throw exception' {
                 [ref] $script:resultHeaders = @{}
                 $getCosmosDbDocumentParameters = @{
-                    Connection    = $script:testConnection
+                    Context    = $script:testContext
                     CollectionId  = $script:testCollection
                     ResultHeaders = $script:resultHeaders
                 }
@@ -174,7 +174,7 @@ InModuleScope CosmosDB {
             }
         }
 
-        Context 'Called with connection parameter and an Id' {
+        Context 'Called with context parameter and an Id' {
             $script:result = $null
 
             Mock `
@@ -184,7 +184,7 @@ InModuleScope CosmosDB {
 
             It 'Should not throw exception' {
                 $getCosmosDbDocumentParameters = @{
-                    Connection   = $script:testConnection
+                    Context   = $script:testContext
                     CollectionId = $script:testCollection
                     Id           = $script:testDocument1
                 }
@@ -210,7 +210,7 @@ InModuleScope CosmosDB {
             { Get-Command -Name New-CosmosDbDocument -ErrorAction Stop } | Should -Not -Throw
         }
 
-        Context 'Called with connection parameter and an Id' {
+        Context 'Called with context parameter and an Id' {
             $script:result = $null
 
             Mock `
@@ -220,7 +220,7 @@ InModuleScope CosmosDB {
 
             It 'Should not throw exception' {
                 $newCosmosDbDocumentParameters = @{
-                    Connection   = $script:testConnection
+                    Context   = $script:testContext
                     CollectionId = $script:testCollection
                     DocumentBody = $script:testDocumentBody
                 }
@@ -246,7 +246,7 @@ InModuleScope CosmosDB {
             { Get-Command -Name Remove-CosmosDbDocument -ErrorAction Stop } | Should -Not -Throw
         }
 
-        Context 'Called with connection parameter and an Id' {
+        Context 'Called with context parameter and an Id' {
             $script:result = $null
 
             Mock `
@@ -255,7 +255,7 @@ InModuleScope CosmosDB {
 
             It 'Should not throw exception' {
                 $removeCosmosDbDocumentParameters = @{
-                    Connection   = $script:testConnection
+                    Context   = $script:testContext
                     CollectionId = $script:testCollection
                     Id           = $script:testDocument1
                 }
@@ -277,7 +277,7 @@ InModuleScope CosmosDB {
             { Get-Command -Name Set-CosmosDbDocument -ErrorAction Stop } | Should -Not -Throw
         }
 
-        Context 'Called with connection parameter and an Id' {
+        Context 'Called with context parameter and an Id' {
             $script:result = $null
 
             Mock `
@@ -287,7 +287,7 @@ InModuleScope CosmosDB {
 
             It 'Should not throw exception' {
                 $setCosmosDbDocumentParameters = @{
-                    Connection   = $script:testConnection
+                    Context   = $script:testContext
                     CollectionId = $script:testCollection
                     Id           = $script:testDocument1
                     DocumentBody = $script:testDocumentBody

--- a/test/CosmosDB.permissions.Tests.ps1
+++ b/test/CosmosDB.permissions.Tests.ps1
@@ -14,7 +14,7 @@ InModuleScope CosmosDB {
     $script:testDatabase = 'testDatabase'
     $script:testKey = 'GFJqJeri2Rq910E0G7PsWoZkzowzbj23Sm9DUWFC0l0P8o16mYyuaZKN00Nbtj9F1QQnumzZKSGZwknXGERrlA=='
     $script:testKeySecureString = ConvertTo-SecureString -String $script:testKey -AsPlainText -Force
-    $script:testConnection = [CosmosDb.Connection] @{
+    $script:testContext = [CosmosDb.Context] @{
         Account  = $script:testAccount
         Database = $script:testDatabase
         Key      = $script:testKeySecureString
@@ -95,7 +95,7 @@ InModuleScope CosmosDB {
             { Get-Command -Name Get-CosmosDbPermission -ErrorAction Stop } | Should -Not -Throw
         }
 
-        Context 'Called with connection parameter and no id' {
+        Context 'Called with context parameter and no id' {
             $script:result = $null
 
             Mock `
@@ -105,8 +105,8 @@ InModuleScope CosmosDB {
 
             It 'Should not throw exception' {
                 $getCosmosDbPermissionParameters = @{
-                    Connection = $script:testConnection
-                    UserId     = $script:testUser
+                    Context = $script:testContext
+                    UserId  = $script:testUser
                 }
 
                 { $script:result = Get-CosmosDbPermission @getCosmosDbPermissionParameters } | Should -Not -Throw
@@ -126,7 +126,7 @@ InModuleScope CosmosDB {
             }
         }
 
-        Context 'Called with connection parameter and an id' {
+        Context 'Called with context parameter and an id' {
             $script:result = $null
 
             Mock `
@@ -136,9 +136,9 @@ InModuleScope CosmosDB {
 
             It 'Should not throw exception' {
                 $getCosmosDbPermissionParameters = @{
-                    Connection = $script:testConnection
-                    UserId     = $script:testUser
-                    Id         = $script:testPermission1
+                    Context = $script:testContext
+                    UserId  = $script:testUser
+                    Id      = $script:testPermission1
                 }
 
                 { $script:result = Get-CosmosDbPermission @getCosmosDbPermissionParameters } | Should -Not -Throw
@@ -156,7 +156,7 @@ InModuleScope CosmosDB {
             }
         }
 
-        Context 'Called with connection parameter and an id and token expiry' {
+        Context 'Called with context parameter and an id and token expiry' {
             $script:result = $null
 
             Mock `
@@ -166,7 +166,7 @@ InModuleScope CosmosDB {
 
             It 'Should not throw exception' {
                 $getCosmosDbPermissionParameters = @{
-                    Connection  = $script:testConnection
+                    Context     = $script:testContext
                     UserId      = $script:testUser
                     Id          = $script:testPermission1
                     TokenExpiry = 18000
@@ -193,7 +193,7 @@ InModuleScope CosmosDB {
             { Get-Command -Name New-CosmosDbPermission -ErrorAction Stop } | Should -Not -Throw
         }
 
-        Context 'Called with connection parameter and an id' {
+        Context 'Called with context parameter and an id' {
             $script:result = $null
 
             Mock `
@@ -203,10 +203,10 @@ InModuleScope CosmosDB {
 
             It 'Should not throw exception' {
                 $newCosmosDbPermissionParameters = @{
-                    Connection = $script:testConnection
-                    UserId     = $script:testUser
-                    Id         = $script:testPermission1
-                    Resource   = $script:testResource
+                    Context  = $script:testContext
+                    UserId   = $script:testUser
+                    Id       = $script:testPermission1
+                    Resource = $script:testResource
                 }
 
                 { $script:result = New-CosmosDbPermission @newCosmosDbPermissionParameters } | Should -Not -Throw
@@ -230,7 +230,7 @@ InModuleScope CosmosDB {
             { Get-Command -Name Remove-CosmosDbPermission -ErrorAction Stop } | Should -Not -Throw
         }
 
-        Context 'Called with connection parameter and an id' {
+        Context 'Called with context parameter and an id' {
             $script:result = $null
 
             Mock `
@@ -239,9 +239,9 @@ InModuleScope CosmosDB {
 
             It 'Should not throw exception' {
                 $removeCosmosDbPermissionParameters = @{
-                    Connection = $script:testConnection
-                    UserId     = $script:testUser
-                    Id         = $script:testPermission1
+                    Context = $script:testContext
+                    UserId  = $script:testUser
+                    Id      = $script:testPermission1
                 }
 
                 { $script:result = Remove-CosmosDbPermission @removeCosmosDbPermissionParameters } | Should -Not -Throw

--- a/test/CosmosDB.storedprocedures.Tests.ps1
+++ b/test/CosmosDB.storedprocedures.Tests.ps1
@@ -14,7 +14,7 @@ InModuleScope CosmosDB {
     $script:testDatabase = 'testDatabase'
     $script:testKey = 'GFJqJeri2Rq910E0G7PsWoZkzowzbj23Sm9DUWFC0l0P8o16mYyuaZKN00Nbtj9F1QQnumzZKSGZwknXGERrlA=='
     $script:testKeySecureString = ConvertTo-SecureString -String $script:testKey -AsPlainText -Force
-    $script:testConnection = [CosmosDb.Connection] @{
+    $script:testContext = [CosmosDb.Context] @{
         Account  = $script:testAccount
         Database = $script:testDatabase
         Key      = $script:testKeySecureString
@@ -50,7 +50,7 @@ InModuleScope CosmosDB {
     }
 '@
 
-$script:testJsonSingle = @'
+    $script:testJsonSingle = @'
 {
     "body": "testStoredProcedureBody",
     "id": "testStoredProcedure1",
@@ -90,7 +90,7 @@ $script:testJsonSingle = @'
             { Get-Command -Name Get-CosmosDbStoredProcedure -ErrorAction Stop } | Should -Not -Throw
         }
 
-        Context 'Called with connection parameter and no id' {
+        Context 'Called with context parameter and no id' {
             $script:result = $null
 
             Mock `
@@ -100,7 +100,7 @@ $script:testJsonSingle = @'
 
             It 'Should not throw exception' {
                 $getCosmosDbStoredProcedureParameters = @{
-                    Connection   = $script:testConnection
+                    Context      = $script:testContext
                     CollectionId = $script:testCollection
                 }
 
@@ -121,7 +121,7 @@ $script:testJsonSingle = @'
             }
         }
 
-        Context 'Called with connection parameter and an id' {
+        Context 'Called with context parameter and an id' {
             $script:result = $null
 
             Mock `
@@ -131,7 +131,7 @@ $script:testJsonSingle = @'
 
             It 'Should not throw exception' {
                 $getCosmosDbStoredProcedureParameters = @{
-                    Connection   = $script:testConnection
+                    Context      = $script:testContext
                     CollectionId = $script:testCollection
                     Id           = $script:testStoredProcedure1
                 }
@@ -157,7 +157,7 @@ $script:testJsonSingle = @'
             { Get-Command -Name Invoke-CosmosDbStoredProcedure -ErrorAction Stop } | Should -Not -Throw
         }
 
-        Context 'Called with connection parameter and an id' {
+        Context 'Called with context parameter and an id' {
             $script:result = $null
 
             Mock `
@@ -167,7 +167,7 @@ $script:testJsonSingle = @'
 
             It 'Should not throw exception' {
                 $invokeCosmosDbStoredProcedureParameters = @{
-                    Connection               = $script:testConnection
+                    Context                  = $script:testContext
                     CollectionId             = $script:testCollection
                     Id                       = $script:testStoredProcedure1
                     StoredProcedureParameter = @('testParameter1', 'testParameter2')
@@ -194,7 +194,7 @@ $script:testJsonSingle = @'
             { Get-Command -Name New-CosmosDbStoredProcedure -ErrorAction Stop } | Should -Not -Throw
         }
 
-        Context 'Called with connection parameter and an id' {
+        Context 'Called with context parameter and an id' {
             $script:result = $null
 
             Mock `
@@ -204,7 +204,7 @@ $script:testJsonSingle = @'
 
             It 'Should not throw exception' {
                 $newCosmosDbStoredProcedureParameters = @{
-                    Connection          = $script:testConnection
+                    Context             = $script:testContext
                     CollectionId        = $script:testCollection
                     Id                  = $script:testStoredProcedure1
                     StoredProcedureBody = $script:testStoredProcedureBody
@@ -231,7 +231,7 @@ $script:testJsonSingle = @'
             { Get-Command -Name Remove-CosmosDbStoredProcedure -ErrorAction Stop } | Should -Not -Throw
         }
 
-        Context 'Called with connection parameter and an id' {
+        Context 'Called with context parameter and an id' {
             $script:result = $null
 
             Mock `
@@ -240,7 +240,7 @@ $script:testJsonSingle = @'
 
             It 'Should not throw exception' {
                 $removeCosmosDbStoredProcedureParameters = @{
-                    Connection   = $script:testConnection
+                    Context      = $script:testContext
                     CollectionId = $script:testCollection
                     Id           = $script:testStoredProcedure1
                 }
@@ -262,7 +262,7 @@ $script:testJsonSingle = @'
             { Get-Command -Name Set-CosmosDbStoredProcedure -ErrorAction Stop } | Should -Not -Throw
         }
 
-        Context 'Called with connection parameter and an id' {
+        Context 'Called with context parameter and an id' {
             $script:result = $null
 
             Mock `
@@ -272,7 +272,7 @@ $script:testJsonSingle = @'
 
             It 'Should not throw exception' {
                 $setCosmosDbStoredProcedureParameters = @{
-                    Connection          = $script:testConnection
+                    Context             = $script:testContext
                     CollectionId        = $script:testCollection
                     Id                  = $script:testStoredProcedure1
                     StoredProcedureBody = $script:testStoredProcedureBody

--- a/test/CosmosDB.triggers.Tests.ps1
+++ b/test/CosmosDB.triggers.Tests.ps1
@@ -14,7 +14,7 @@ InModuleScope CosmosDB {
     $script:testDatabase = 'testDatabase'
     $script:testKey = 'GFJqJeri2Rq910E0G7PsWoZkzowzbj23Sm9DUWFC0l0P8o16mYyuaZKN00Nbtj9F1QQnumzZKSGZwknXGERrlA=='
     $script:testKeySecureString = ConvertTo-SecureString -String $script:testKey -AsPlainText -Force
-    $script:testConnection = [CosmosDb.Connection] @{
+    $script:testContext = [CosmosDb.Context] @{
         Account  = $script:testAccount
         Database = $script:testDatabase
         Key      = $script:testKeySecureString
@@ -96,7 +96,7 @@ InModuleScope CosmosDB {
             { Get-Command -Name Get-CosmosDbTrigger -ErrorAction Stop } | Should -Not -Throw
         }
 
-        Context 'Called with connection parameter and no id' {
+        Context 'Called with context parameter and no id' {
             $script:result = $null
 
             Mock `
@@ -106,7 +106,7 @@ InModuleScope CosmosDB {
 
             It 'Should not throw exception' {
                 $getCosmosDbTriggerParameters = @{
-                    Connection   = $script:testConnection
+                    Context      = $script:testContext
                     CollectionId = $script:testCollection
                 }
 
@@ -127,7 +127,7 @@ InModuleScope CosmosDB {
             }
         }
 
-        Context 'Called with connection parameter and an id' {
+        Context 'Called with context parameter and an id' {
             $script:result = $null
 
             Mock `
@@ -137,7 +137,7 @@ InModuleScope CosmosDB {
 
             It 'Should not throw exception' {
                 $getCosmosDbTriggerParameters = @{
-                    Connection   = $script:testConnection
+                    Context      = $script:testContext
                     CollectionId = $script:testCollection
                     Id           = $script:testTrigger1
                 }
@@ -163,7 +163,7 @@ InModuleScope CosmosDB {
             { Get-Command -Name New-CosmosDbTrigger -ErrorAction Stop } | Should -Not -Throw
         }
 
-        Context 'Called with connection parameter and an id' {
+        Context 'Called with context parameter and an id' {
             $script:result = $null
 
             Mock `
@@ -173,7 +173,7 @@ InModuleScope CosmosDB {
 
             It 'Should not throw exception' {
                 $newCosmosDbTriggerParameters = @{
-                    Connection       = $script:testConnection
+                    Context          = $script:testContext
                     CollectionId     = $script:testCollection
                     Id               = $script:testTrigger1
                     TriggerBody      = $script:testTriggerBody
@@ -202,7 +202,7 @@ InModuleScope CosmosDB {
             { Get-Command -Name Remove-CosmosDbTrigger -ErrorAction Stop } | Should -Not -Throw
         }
 
-        Context 'Called with connection parameter and an id' {
+        Context 'Called with context parameter and an id' {
             $script:result = $null
 
             Mock `
@@ -211,7 +211,7 @@ InModuleScope CosmosDB {
 
             It 'Should not throw exception' {
                 $removeCosmosDbTriggerParameters = @{
-                    Connection   = $script:testConnection
+                    Context      = $script:testContext
                     CollectionId = $script:testCollection
                     Id           = $script:testTrigger1
                 }
@@ -233,7 +233,7 @@ InModuleScope CosmosDB {
             { Get-Command -Name Set-CosmosDbTrigger -ErrorAction Stop } | Should -Not -Throw
         }
 
-        Context 'Called with connection parameter and an id' {
+        Context 'Called with context parameter and an id' {
             $script:result = $null
 
             Mock `
@@ -243,7 +243,7 @@ InModuleScope CosmosDB {
 
             It 'Should not throw exception' {
                 $setCosmosDbTriggerParameters = @{
-                    Connection       = $script:testConnection
+                    Context          = $script:testContext
                     CollectionId     = $script:testCollection
                     Id               = $script:testTrigger1
                     TriggerBody      = $script:testTriggerBody

--- a/test/CosmosDB.userdefinedfunctions.Tests.ps1
+++ b/test/CosmosDB.userdefinedfunctions.Tests.ps1
@@ -14,7 +14,7 @@ InModuleScope CosmosDB {
     $script:testDatabase = 'testDatabase'
     $script:testKey = 'GFJqJeri2Rq910E0G7PsWoZkzowzbj23Sm9DUWFC0l0P8o16mYyuaZKN00Nbtj9F1QQnumzZKSGZwknXGERrlA=='
     $script:testKeySecureString = ConvertTo-SecureString -String $script:testKey -AsPlainText -Force
-    $script:testConnection = [CosmosDb.Connection] @{
+    $script:testContext = [CosmosDb.Context] @{
         Account  = $script:testAccount
         Database = $script:testDatabase
         Key      = $script:testKeySecureString
@@ -49,7 +49,7 @@ InModuleScope CosmosDB {
         "_count": 2
     }
 '@
-$script:testJsonSingle = @'
+    $script:testJsonSingle = @'
 {
     "body": "testUserDefinedFunctionBody",
     "id": "testUserDefinedFunction1",
@@ -89,7 +89,7 @@ $script:testJsonSingle = @'
             { Get-Command -Name Get-CosmosDbUserDefinedFunction -ErrorAction Stop } | Should -Not -Throw
         }
 
-        Context 'Called with connection parameter and no id' {
+        Context 'Called with context parameter and no id' {
             $script:result = $null
 
             Mock `
@@ -99,7 +99,7 @@ $script:testJsonSingle = @'
 
             It 'Should not throw exception' {
                 $getCosmosDbUserDefinedFunctionParameters = @{
-                    Connection   = $script:testConnection
+                    Context      = $script:testContext
                     CollectionId = $script:testCollection
                 }
 
@@ -120,7 +120,7 @@ $script:testJsonSingle = @'
             }
         }
 
-        Context 'Called with connection parameter and an id' {
+        Context 'Called with context parameter and an id' {
             $script:result = $null
 
             Mock `
@@ -130,7 +130,7 @@ $script:testJsonSingle = @'
 
             It 'Should not throw exception' {
                 $getCosmosDbUserDefinedFunctionParameters = @{
-                    Connection   = $script:testConnection
+                    Context      = $script:testContext
                     CollectionId = $script:testCollection
                     Id           = $script:testUserDefinedFunction1
                 }
@@ -156,7 +156,7 @@ $script:testJsonSingle = @'
             { Get-Command -Name New-CosmosDbUserDefinedFunction -ErrorAction Stop } | Should -Not -Throw
         }
 
-        Context 'Called with connection parameter and an id' {
+        Context 'Called with context parameter and an id' {
             $script:result = $null
 
             Mock `
@@ -166,7 +166,7 @@ $script:testJsonSingle = @'
 
             It 'Should not throw exception' {
                 $newCosmosDbUserDefinedFunctionParameters = @{
-                    Connection              = $script:testConnection
+                    Context                 = $script:testContext
                     CollectionId            = $script:testCollection
                     Id                      = $script:testUserDefinedFunction1
                     UserDefinedFunctionBody = $script:testUserDefinedFunction1Body
@@ -193,7 +193,7 @@ $script:testJsonSingle = @'
             { Get-Command -Name Remove-CosmosDbUserDefinedFunction -ErrorAction Stop } | Should -Not -Throw
         }
 
-        Context 'Called with connection parameter and an id' {
+        Context 'Called with context parameter and an id' {
             $script:result = $null
 
             Mock `
@@ -202,7 +202,7 @@ $script:testJsonSingle = @'
 
             It 'Should not throw exception' {
                 $removeCosmosDbUserDefinedFunctionParameters = @{
-                    Connection   = $script:testConnection
+                    Context      = $script:testContext
                     CollectionId = $script:testCollection
                     Id           = $script:testUserDefinedFunction1
                 }
@@ -224,7 +224,7 @@ $script:testJsonSingle = @'
             { Get-Command -Name Set-CosmosDbUserDefinedFunction -ErrorAction Stop } | Should -Not -Throw
         }
 
-        Context 'Called with connection parameter and an id' {
+        Context 'Called with context parameter and an id' {
             $script:result = $null
 
             Mock `
@@ -234,7 +234,7 @@ $script:testJsonSingle = @'
 
             It 'Should not throw exception' {
                 $setCosmosDbUserDefinedFunctionParameters = @{
-                    Connection              = $script:testConnection
+                    Context                 = $script:testContext
                     CollectionId            = $script:testCollection
                     Id                      = $script:testUserDefinedFunction1
                     UserDefinedFunctionBody = $script:testUserDefinedFunction1Body

--- a/test/CosmosDB.users.Tests.ps1
+++ b/test/CosmosDB.users.Tests.ps1
@@ -14,7 +14,7 @@ InModuleScope CosmosDB {
     $script:testDatabase = 'testDatabase'
     $script:testKey = 'GFJqJeri2Rq910E0G7PsWoZkzowzbj23Sm9DUWFC0l0P8o16mYyuaZKN00Nbtj9F1QQnumzZKSGZwknXGERrlA=='
     $script:testKeySecureString = ConvertTo-SecureString -String $script:testKey -AsPlainText -Force
-    $script:testConnection = [CosmosDb.Connection] @{
+    $script:testContext = [CosmosDb.Context] @{
         Account  = $script:testAccount
         Database = $script:testDatabase
         Key      = $script:testKeySecureString
@@ -71,7 +71,7 @@ InModuleScope CosmosDB {
             { Get-Command -Name Get-CosmosDbUser -ErrorAction Stop } | Should -Not -Throw
         }
 
-        Context 'Called with connection parameter and no id' {
+        Context 'Called with context parameter and no id' {
             $script:result = $null
 
             Mock `
@@ -81,7 +81,7 @@ InModuleScope CosmosDB {
 
             It 'Should not throw exception' {
                 $getCosmosDbUserParameters = @{
-                    Connection = $script:testConnection
+                    Context = $script:testContext
                 }
 
                 { $script:result = Get-CosmosDbUser @getCosmosDbUserParameters } | Should -Not -Throw
@@ -101,7 +101,7 @@ InModuleScope CosmosDB {
             }
         }
 
-        Context 'Called with connection parameter and an id' {
+        Context 'Called with context parameter and an id' {
             $script:result = $null
 
             Mock `
@@ -111,8 +111,8 @@ InModuleScope CosmosDB {
 
             It 'Should not throw exception' {
                 $getCosmosDbUserParameters = @{
-                    Connection = $script:testConnection
-                    Id         = $script:testUser1
+                    Context = $script:testContext
+                    Id      = $script:testUser1
                 }
 
                 { $script:result = Get-CosmosDbUser @getCosmosDbUserParameters } | Should -Not -Throw
@@ -136,7 +136,7 @@ InModuleScope CosmosDB {
             { Get-Command -Name New-CosmosDbUser -ErrorAction Stop } | Should -Not -Throw
         }
 
-        Context 'Called with connection parameter and an id' {
+        Context 'Called with context parameter and an id' {
             $script:result = $null
 
             Mock `
@@ -146,8 +146,8 @@ InModuleScope CosmosDB {
 
             It 'Should not throw exception' {
                 $newCosmosDbUserParameters = @{
-                    Connection = $script:testConnection
-                    Id         = $script:testUser1
+                    Context = $script:testContext
+                    Id      = $script:testUser1
                 }
 
                 { $script:result = New-CosmosDbUser @newCosmosDbUserParameters } | Should -Not -Throw
@@ -171,7 +171,7 @@ InModuleScope CosmosDB {
             { Get-Command -Name Remove-CosmosDbUser -ErrorAction Stop } | Should -Not -Throw
         }
 
-        Context 'Called with connection parameter and an id' {
+        Context 'Called with context parameter and an id' {
             $script:result = $null
 
             Mock `
@@ -180,8 +180,8 @@ InModuleScope CosmosDB {
 
             It 'Should not throw exception' {
                 $removeCosmosDbUserParameters = @{
-                    Connection = $script:testConnection
-                    Id         = $script:testUser1
+                    Context = $script:testContext
+                    Id      = $script:testUser1
                 }
 
                 { $script:result = Remove-CosmosDbUser @removeCosmosDbUserParameters } | Should -Not -Throw
@@ -201,7 +201,7 @@ InModuleScope CosmosDB {
             { Get-Command -Name Set-CosmosDbUser -ErrorAction Stop } | Should -Not -Throw
         }
 
-        Context 'Called with connection parameter and Id and NewId' {
+        Context 'Called with context parameter and Id and NewId' {
             $script:result = $null
 
             Mock `
@@ -211,9 +211,9 @@ InModuleScope CosmosDB {
 
             It 'Should not throw exception' {
                 $setCosmosDbUserParameters = @{
-                    Connection = $script:testConnection
-                    Id         = $script:testUser1
-                    NewId      = 'NewId'
+                    Context = $script:testContext
+                    Id      = $script:testUser1
+                    NewId   = 'NewId'
                 }
 
                 { $script:result = Set-CosmosDbUser @setCosmosDbUserParameters } | Should -Not -Throw

--- a/test/CosmosDB.utils.Tests.ps1
+++ b/test/CosmosDB.utils.Tests.ps1
@@ -18,7 +18,7 @@ InModuleScope CosmosDB {
     $script:testBaseUri = 'documents.contoso.com'
     $script:testDate = (Get-Date -Year 2017 -Month 11 -Day 29 -Hour 10 -Minute 45 -Second 10)
     $script:testUniversalDate = 'Tue, 28 Nov 2017 21:45:10 GMT'
-    $script:testConnection = [CosmosDb.Connection] @{
+    $script:testContext = [CosmosDb.Context] @{
         Account  = $script:testAccount
         Database = $script:testDatabase
         Key      = $script:testKeySecureString
@@ -38,23 +38,23 @@ InModuleScope CosmosDB {
 '@
     $script:testResourceGroup = 'testResourceGroup'
 
-    Describe 'New-CosmosDbConnection' -Tag 'Unit' {
+    Describe 'New-CosmosDbContext' -Tag 'Unit' {
         It 'Should exist' {
-            { Get-Command -Name New-CosmosDbConnection -ErrorAction Stop } | Should -Not -Throw
+            { Get-Command -Name New-CosmosDbContext -ErrorAction Stop } | Should -Not -Throw
         }
 
-        Context 'Called with Connection parameters' {
+        Context 'Called with Context parameters' {
             $script:result = $null
 
             It 'Should not throw exception' {
-                $newCosmosDbConnectionParameters = @{
+                $newCosmosDbContextParameters = @{
                     Account  = $script:testAccount
                     Database = $script:testDatabase
                     Key      = $script:testKeySecureString
                     KeyType  = 'master'
                 }
 
-                { $script:result = New-CosmosDbConnection @newCosmosDbConnectionParameters } | Should -Not -Throw
+                { $script:result = New-CosmosDbContext @newCosmosDbContextParameters } | Should -Not -Throw
             }
 
             It 'Should return expected result' {
@@ -81,13 +81,13 @@ InModuleScope CosmosDB {
                 } }
 
             It 'Should not throw exception' {
-                $newCosmosDbConnectionParameters = @{
+                $newCosmosDbContextParameters = @{
                     Account       = $script:testAccount
                     Database      = $script:testDatabase
                     ResourceGroup = $script:testResourceGroup
                 }
 
-                { $script:result = New-CosmosDbConnection @newCosmosDbConnectionParameters } | Should -Not -Throw
+                { $script:result = New-CosmosDbContext @newCosmosDbContextParameters } | Should -Not -Throw
             }
 
             It 'Should return expected result' {
@@ -120,13 +120,13 @@ InModuleScope CosmosDB {
             Mock -CommandName Add-AzureRmAccount
 
             It 'Should not throw exception' {
-                $newCosmosDbConnectionParameters = @{
+                $newCosmosDbContextParameters = @{
                     Account       = $script:testAccount
                     Database      = $script:testDatabase
                     ResourceGroup = $script:testResourceGroup
                 }
 
-                { $script:result = New-CosmosDbConnection @newCosmosDbConnectionParameters } | Should -Not -Throw
+                { $script:result = New-CosmosDbContext @newCosmosDbContextParameters } | Should -Not -Throw
             }
 
             It 'Should return expected result' {
@@ -147,12 +147,12 @@ InModuleScope CosmosDB {
             $script:result = $null
 
             It 'Should not throw exception' {
-                $newCosmosDbConnectionParameters = @{
+                $newCosmosDbContextParameters = @{
                     Database = $script:testDatabase
                     Emulator = $true
                 }
 
-                { $script:result = New-CosmosDbConnection @newCosmosDbConnectionParameters } | Should -Not -Throw
+                { $script:result = New-CosmosDbContext @newCosmosDbContextParameters } | Should -Not -Throw
             }
 
             It 'Should return expected result' {
@@ -266,12 +266,12 @@ InModuleScope CosmosDB {
             Mock -CommandName Get-Date -MockWith { $script:testDate }
         }
 
-        Context 'Called with connection parameter and Get method' {
+        Context 'Called with context parameter and Get method' {
             $script:result = $null
 
             It 'Should not throw exception' {
                 $invokeCosmosDbRequestparameters = @{
-                    Connection   = $script:testConnection
+                    Context      = $script:testContext
                     Method       = 'Get'
                     ResourceType = 'users'
                 }
@@ -289,12 +289,12 @@ InModuleScope CosmosDB {
             }
         }
 
-        Context 'Called with connection parameter and Post method' {
+        Context 'Called with context parameter and Post method' {
             $script:result = $null
 
             It 'Should not throw exception' {
                 $invokeCosmosDbRequestparameters = @{
-                    Connection   = $script:testConnection
+                    Context      = $script:testContext
                     Method       = 'Post'
                     ResourceType = 'users'
                     Body         = '{ "id": "daniel" }'


### PR DESCRIPTION
Converted all `connection` function names and parameter names over to `context`. Aliases were implemented for old `connection` function and parameter names to reduce possibility of breakage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plagueho/cosmosdb/44)
<!-- Reviewable:end -->
