### PR TITLE
Make resource ID case sensitive

### DIFF
--- a/src/lib/utils.ps1
+++ b/src/lib/utils.ps1
@@ -191,7 +191,7 @@ function New-CosmosDbAuthorizationToken
     $payLoad = @(
         $Method.ToLowerInvariant() + "`n" + `
             $ResourceType.ToLowerInvariant() + "`n" + `
-            $ResourceId.ToLowerInvariant() + "`n" + `
+            $ResourceId + "`n" + `
             $dateString.ToLowerInvariant() + "`n" + `
             "" + "`n"
     )


### PR DESCRIPTION
This PR addresses issue #76 

The ResourceLink (ResourceID variable) should not be converted to lowercase when creating the authorization token

@PlagueHO 
