### PR TITLE
Enhance Invoke-CosmosDbStoredProcedure - Issue #116

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Change Log
 
-## Unreleased
+### Unreleased
 
 - Fix creation of spatial index by `New-CosmosDbCollectionIncludedPathIndex`
   so that precision is not used when passing to `New-CosmosDbCollection`.
+- Added support for `-PartitionKey` in `Invoke-CosmosDbStoredProcedure` - See [Issue #116](https://github.com/PlagueHO/CosmosDB/issues/116)
+- Changed -StoredProcedureParameter from string[] to object[] in `Invoke-CosmosDbStoredProcedure` - See [Issue #116](https://github.com/PlagueHO/CosmosDB/issues/116)
+- Updated `Invoke-CosmosDbStoredProcedure` to set `x-ms-documentdb-script-enable-logging: true` header and write stored procedure logs to the Verbose Stream when `-Debug` is set - See [Issue #116](https://github.com/PlagueHO/CosmosDB/issues/116)
 
 ## 2.0.14.439
 

--- a/src/lib/storedprocedures.ps1
+++ b/src/lib/storedprocedures.ps1
@@ -200,7 +200,7 @@ function Invoke-CosmosDbStoredProcedure
     # Because the headers of this request will contain important information
     # then we need to use a plain web request.
     $result = Invoke-CosmosDbRequest @PSBoundParameters `
-        -Method $method `
+        -Method 'Post' `
         -ResourceType 'sprocs' `
         -ResourcePath $resourcePath `
         -Headers $headers `

--- a/src/lib/storedprocedures.ps1
+++ b/src/lib/storedprocedures.ps1
@@ -211,7 +211,12 @@ function Invoke-CosmosDbStoredProcedure
         Write-Verbose "Script Log Results: $($result.Headers.'x-ms-documentdb-script-log-results')"
     }
 
-    return (ConvertFrom-JSON -InputObject $result.Content)
+    if($result.Content) {
+        return (ConvertFrom-JSON -InputObject $result.Content)
+    }
+    else {
+        return $null
+    }
 }
 
 function New-CosmosDbStoredProcedure

--- a/src/lib/storedprocedures.ps1
+++ b/src/lib/storedprocedures.ps1
@@ -212,13 +212,6 @@ function Invoke-CosmosDbStoredProcedure
     }
 
     return (ConvertFrom-JSON -InputObject $result.Content)
-
-    # return Invoke-CosmosDbRequest @PSBoundParameters `
-    #     -Method 'Post' `
-    #     -Headers $headers `
-    #     -ResourceType 'sprocs' `
-    #     -ResourcePath $resourcePath `
-    #     -Body $body `
 }
 
 function New-CosmosDbStoredProcedure

--- a/src/lib/storedprocedures.ps1
+++ b/src/lib/storedprocedures.ps1
@@ -207,14 +207,17 @@ function Invoke-CosmosDbStoredProcedure
         -Body $body `
         -UseWebRequest
 
-    if($result.Headers.'x-ms-documentdb-script-log-results') {
-        Write-Verbose "Script Log Results: $($result.Headers.'x-ms-documentdb-script-log-results')"
+    if ($result.Headers.'x-ms-documentdb-script-log-results')
+    {
+        Write-Verbose -Message "Script Log Results: $($result.Headers.'x-ms-documentdb-script-log-results')"
     }
 
-    if($result.Content) {
+    if ($result.Content)
+    {
         return (ConvertFrom-JSON -InputObject $result.Content)
     }
-    else {
+    else
+    {
         return $null
     }
 }

--- a/test/CosmosDB.storedprocedures.Tests.ps1
+++ b/test/CosmosDB.storedprocedures.Tests.ps1
@@ -163,7 +163,9 @@ InModuleScope CosmosDB {
             Mock `
                 -CommandName Invoke-CosmosDbRequest `
                 -ParameterFilter { $Method -eq 'Post' -and $ResourceType -eq 'sprocs' -and $body -eq '["testParameter1","testParameter2"]'} `
-                -MockWith { ConvertFrom-Json -InputObject $script:testJsonSingle }
+                -MockWith {
+                    @{ Content = $script:testJsonSingle }
+                }
 
             It 'Should not throw exception' {
                 $invokeCosmosDbStoredProcedureParameters = @{


### PR DESCRIPTION
# Improvements / Enhancements

- Added support for `-PartitionKey` in `Invoke-CosmosDbStoredProcedure` - See [Issue #116](https://github.com/PlagueHO/CosmosDB/issues/116)
- Changed -StoredProcedureParameter from string[] to object[] - See [Issue #116](https://github.com/PlagueHO/CosmosDB/issues/116)
- Updated `Invoke-CosmosDbStoredProcedure` to set `x-ms-documentdb-script-enable-logging: true` header and write stored procedure logs to the Verbose Stream when `-Debug` is set - See [Issue #116](https://github.com/PlagueHO/CosmosDB/issues/116)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plagueho/cosmosdb/117)
<!-- Reviewable:end -->
