### PR TITLE
Fix creation of spatial index - Fixes #115

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+- Fix creation of spatial index by `New-CosmosDbCollectionIncludedPathIndex`
+  so that precision is not used when passing to `New-CosmosDbCollection`.
+
 ## 2.0.14.439
 
 - Fixed Code Coverage upload to CodeCov.io.

--- a/README.md
+++ b/README.md
@@ -237,13 +237,15 @@ an Indexing Policy object using the functions:
 - New-CosmosDbCollectionExcludedPath
 - New-CosmosDbCollectionIndexingPolicy
 
-For example, to create a string range and number range index on the '/*'
-path using consistent indexing mode with no excluded paths:
+For example, to create a string range, a number range index and a point
+spatial index on the '/*' path using consistent indexing mode with no
+excluded paths:
 
 ```powershell
 $indexStringRange = New-CosmosDbCollectionIncludedPathIndex -Kind Range -DataType String -Precision -1
 $indexNumberRange = New-CosmosDbCollectionIncludedPathIndex -Kind Range -DataType Number -Precision -1
-$indexIncludedPath = New-CosmosDbCollectionIncludedPath -Path '/*' -Index $indexStringRange, $indexNumberRange
+$indexNumberSpatial = New-CosmosDbCollectionIncludedPathIndex -Kind Spatial -DataType Point
+$indexIncludedPath = New-CosmosDbCollectionIncludedPath -Path '/*' -Index $indexStringRange, $indexNumberRange, $indexNumberSpatial
 $indexingPolicy = New-CosmosDbCollectionIndexingPolicy -Automatic $true -IndexingMode Consistent -IncludedPath $indexIncludedPath
 New-CosmosDbCollection -Context $cosmosDbContext -Id 'MyNewCollection' -PartitionKey 'account' -IndexingPolicy $indexingPolicy
 ```

--- a/src/CosmosDB.psm1
+++ b/src/CosmosDB.psm1
@@ -35,7 +35,17 @@ namespace CosmosDB {
             public class Index {
                 public System.String dataType;
                 public System.String kind;
+            }
+
+            public class IndexRange : CosmosDB.IndexingPolicy.Path.Index {
                 public System.Int32 precision;
+            }
+
+            public class IndexHash : CosmosDB.IndexingPolicy.Path.Index {
+                public System.Int32 precision;
+            }
+
+            public class IndexSpatial : CosmosDB.IndexingPolicy.Path.Index {
             }
 
             public class IncludedPath

--- a/src/lib/collections.ps1
+++ b/src/lib/collections.ps1
@@ -84,8 +84,6 @@ function New-CosmosDbCollectionIncludedPathIndex
                     -Message $($LocalizedData.ErrorNewCollectionIncludedPathIndexInvalidDataType -f $Kind, $DataType, 'String, Number') `
                     -ArgumentName 'DataType'
             }
-
-            $typeName = 'CosmosDB.IndexingPolicy.Path.IndexHash'
         }
 
         'Range'
@@ -96,8 +94,6 @@ function New-CosmosDbCollectionIncludedPathIndex
                     -Message $($LocalizedData.ErrorNewCollectionIncludedPathIndexInvalidDataType -f $Kind, $DataType, 'String, Number') `
                     -ArgumentName 'DataType'
             }
-
-            $typeName = 'CosmosDB.IndexingPolicy.Path.IndexRange'
         }
 
         'Spatial'
@@ -108,12 +104,10 @@ function New-CosmosDbCollectionIncludedPathIndex
                     -Message $($LocalizedData.ErrorNewCollectionIncludedPathIndexInvalidDataType -f $Kind, $DataType, 'Point, Polygon, LineString') `
                     -ArgumentName 'DataType'
             }
-
-            $typeName = 'CosmosDB.IndexingPolicy.Path.IndexSpatial'
         }
     }
 
-    $index = New-Object -TypeName $typeName
+    $index = New-Object -TypeName ('CosmosDB.IndexingPolicy.Path.Index' + $Kind)
     $index.Kind = $Kind
     $index.DataType = $DataType
     if ($PSBoundParameters.ContainsKey('Precision'))

--- a/src/lib/collections.ps1
+++ b/src/lib/collections.ps1
@@ -84,6 +84,8 @@ function New-CosmosDbCollectionIncludedPathIndex
                     -Message $($LocalizedData.ErrorNewCollectionIncludedPathIndexInvalidDataType -f $Kind, $DataType, 'String, Number') `
                     -ArgumentName 'DataType'
             }
+
+            $typeName = 'CosmosDB.IndexingPolicy.Path.IndexHash'
         }
 
         'Range'
@@ -95,6 +97,7 @@ function New-CosmosDbCollectionIncludedPathIndex
                     -ArgumentName 'DataType'
             }
 
+            $typeName = 'CosmosDB.IndexingPolicy.Path.IndexRange'
         }
 
         'Spatial'
@@ -105,9 +108,12 @@ function New-CosmosDbCollectionIncludedPathIndex
                     -Message $($LocalizedData.ErrorNewCollectionIncludedPathIndexInvalidDataType -f $Kind, $DataType, 'Point, Polygon, LineString') `
                     -ArgumentName 'DataType'
             }
+
+            $typeName = 'CosmosDB.IndexingPolicy.Path.IndexSpatial'
         }
     }
-    $index = [CosmosDB.IndexingPolicy.Path.Index]::new()
+
+    $index = New-Object -TypeName $typeName
     $index.Kind = $Kind
     $index.DataType = $DataType
     if ($PSBoundParameters.ContainsKey('Precision'))

--- a/test/CosmosDB.collections.Tests.ps1
+++ b/test/CosmosDB.collections.Tests.ps1
@@ -169,7 +169,6 @@ InModuleScope CosmosDB {
                 $newCosmosDbCollectionIncludedPathIndexParameters = @{
                     Kind      = 'Spatial'
                     DataType  = 'Point'
-                    Precision = -1
                 }
 
                 { $script:result = New-CosmosDbCollectionIncludedPathIndex @newCosmosDbCollectionIncludedPathIndexParameters } | Should -Not -Throw
@@ -179,7 +178,7 @@ InModuleScope CosmosDB {
                 $script:result | Should -BeOfType 'CosmosDB.IndexingPolicy.Path.Index'
                 $script:result.Kind | Should -Be 'Spatial'
                 $script:result.DataType | Should -Be 'Point'
-                $script:result.Precision | Should -Be -1
+                $script:result.Precision | Should -BeNull
             }
         }
 

--- a/test/CosmosDB.integration.Tests.ps1
+++ b/test/CosmosDB.integration.Tests.ps1
@@ -141,7 +141,8 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
             {
                 $script:indexNumberRange = New-CosmosDbCollectionIncludedPathIndex -Kind Range -DataType Number -Precision -1
                 $script:indexStringRange = New-CosmosDbCollectionIncludedPathIndex -Kind Hash -DataType String -Precision 3
-                $script:indexIncludedPath = New-CosmosDbCollectionIncludedPath -Path '/*' -Index $script:indexNumberRange, $script:indexStringRange
+                $script:indexSpatialPoint = New-CosmosDbCollectionIncludedPathIndex -Kind Spatial -DataType Point
+                $script:indexIncludedPath = New-CosmosDbCollectionIncludedPath -Path '/*' -Index $script:indexNumberRange, $script:indexStringRange, $script:indexSpatialPoint
                 $script:indexingPolicy = New-CosmosDbCollectionIndexingPolicy -Automatic $true -IndexingMode Consistent -IncludedPath $script:indexIncludedPath
             } | Should -Not -Throw
         }
@@ -178,6 +179,8 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
             $script:result.indexingPolicy.includedPaths.Indexes[1].DataType | Should -Be 'String'
             $script:result.indexingPolicy.includedPaths.Indexes[1].Kind | Should -Be 'Hash'
             $script:result.indexingPolicy.includedPaths.Indexes[1].Precision | Should -Be 3
+            $script:result.indexingPolicy.includedPaths.Indexes[2].DataType | Should -Be 'Point'
+            $script:result.indexingPolicy.includedPaths.Indexes[2].Kind | Should -Be 'Spatial'
         }
     }
 
@@ -210,6 +213,8 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
             $script:result.indexingPolicy.includedPaths.Indexes[1].DataType | Should -Be 'String'
             $script:result.indexingPolicy.includedPaths.Indexes[1].Kind | Should -Be 'Hash'
             $script:result.indexingPolicy.includedPaths.Indexes[1].Precision | Should -Be 3
+            $script:result.indexingPolicy.includedPaths.Indexes[2].DataType | Should -Be 'Point'
+            $script:result.indexingPolicy.includedPaths.Indexes[2].Kind | Should -Be 'Spatial'
         }
     }
 
@@ -243,6 +248,8 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
             $script:result.indexingPolicy.includedPaths.Indexes[1].DataType | Should -Be 'String'
             $script:result.indexingPolicy.includedPaths.Indexes[1].Kind | Should -Be 'Hash'
             $script:result.indexingPolicy.includedPaths.Indexes[1].Precision | Should -Be 3
+            $script:result.indexingPolicy.includedPaths.Indexes[2].DataType | Should -Be 'Point'
+            $script:result.indexingPolicy.includedPaths.Indexes[2].Kind | Should -Be 'Spatial'
         }
     }
 
@@ -348,6 +355,8 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
             $script:result.indexingPolicy.includedPaths.Indexes[1].DataType | Should -Be 'String'
             $script:result.indexingPolicy.includedPaths.Indexes[1].Kind | Should -Be 'Hash'
             $script:result.indexingPolicy.includedPaths.Indexes[1].Precision | Should -Be 3
+            $script:result.indexingPolicy.includedPaths.Indexes[2].DataType | Should -Be 'Point'
+            $script:result.indexingPolicy.includedPaths.Indexes[2].Kind | Should -Be 'Spatial'
         }
     }
 
@@ -559,14 +568,6 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
             $script:result.Triggers | Should -BeOfType [System.String]
             $script:result.UserDefinedFunctions | Should -BeOfType [System.String]
             $script:result.Id | Should -Be $script:testCollection
-            $script:result.indexingPolicy.indexingMode | Should -Be 'consistent'
-            $script:result.indexingPolicy.automatic | Should -Be $true
-            $script:result.indexingPolicy.includedPaths.Indexes[0].DataType | Should -Be 'Number'
-            $script:result.indexingPolicy.includedPaths.Indexes[0].Kind | Should -Be 'Range'
-            $script:result.indexingPolicy.includedPaths.Indexes[0].Precision | Should -Be -1
-            $script:result.indexingPolicy.includedPaths.Indexes[1].DataType | Should -Be 'String'
-            $script:result.indexingPolicy.includedPaths.Indexes[1].Kind | Should -Be 'Hash'
-            $script:result.indexingPolicy.includedPaths.Indexes[1].Precision | Should -Be 3
             $script:result.partitionKey.kind | Should -Be 'Hash'
             $script:result.partitionKey.paths[0] | Should -Be ('/{0}' -f $script:testPartitionKey)
         }


### PR DESCRIPTION
Fix creation of spatial index by `New-CosmosDbCollectionIncludedPathIndex` so that precision is not used when passing to `New-CosmosDbCollection`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plagueho/cosmosdb/118)
<!-- Reviewable:end -->
