### PR TITLE
Add Support for Back-off Policy to handle 429 - Fixes #87

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Added integration tests for user defined functions.
 - Added `New-CosmosDbBackOffPolicy` function for controlling the behaviour
   of a function when a "Too Many Request" (error code 429) is recieved.
+- Added support for handling a back-off policy to the `Invoke-CosmosDbRequest`
+  function.
 
 ## 2.0.16.465
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
 - Added integration tests for triggers.
 - Added integration tests for user defined functions.
 - Added `New-CosmosDbBackOffPolicy` function for controlling the behaviour
-  of a function when a "Too Many Request" (error code 429) is recieved.
+  of a function when a "Too Many Request" (error code 429) is recieved -
+  See [Issue #87](https://github.com/PlagueHO/CosmosDB/issues/87)
 - Added support for handling a back-off policy to the `Invoke-CosmosDbRequest`
   function.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Added integration tests for stored procedures.
 - Added integration tests for triggers.
 - Added integration tests for user defined functions.
+- Added `New-CosmosDbBackOffPolicy` function for controlling the behaviour
+  of a function when a "Too Many Request" (error code 429) is recieved.
 
 ## 2.0.16.465
 

--- a/README.md
+++ b/README.md
@@ -712,16 +712,54 @@ throw an exception. The number of milliseconds to delay before retrying will be
 determined automatically by using the `x-ms-retry-after-ms` header returned by
 Cosmos DB.
 
-Additional Back-off Policy options can be set to override and extend the value
-returned in the `x-ms-retry-after-ms` header. For example, an exponential
-Back-off Policy can be created by using:
+Additional Back-off Policy options can be set to override or extend the value
+returned in the `x-ms-retry-after-ms` header.
+
+**Note: if the delay calculated by the policy is less than the value returned in
+the `x-ms-retry-after-ms` header, then the `x-ms-retry-after-ms` value will always
+be used.**
+
+The following show examples of alternative policy back-off types that can
+implemented:
+
+#### Default
+
+```powershell
+$backoffPolicy = New-CosmosDbBackoffPolicy -MaxRetries 10 -Method Default -Delay 100
+```
+
+The delay of 100ms will always be used unless it is less than `x-ms-retry-after-ms`.
+The delay can be set to 0 and will cause the  `x-ms-retry-after-ms` to always be used.
+It is the default Back-off Policy behavior.
+
+#### Additive
+
+```powershell
+$backoffPolicy = New-CosmosDbBackoffPolicy -MaxRetries 10 -Method Additive -Delay 1000
+```
+
+This will create a policy that will retry 10 times with a delay equaling the value of
+the returned `x-ms-retry-after-ms` header plus 1000ms.
+
+#### Linear
+
+```powershell
+$backoffPolicy = New-CosmosDbBackoffPolicy -MaxRetries 3 -Method Linear -Delay 500
+```
+
+This will create a policy that will wait for 500ms on the first retry, 1000ms on the
+second retry, 1500ms on final retry.
+
+#### Exponential
 
 ```powershell
 $backoffPolicy = New-CosmosDbBackoffPolicy -MaxRetries 4 -Method Exponential -Delay 1000
 ```
 
 This will create a policy that will wait for 1000ms on the first retry, 4000ms on the
-second retry, 9000ms on the 3rd retry and 16000ms on the 4th and final retry.
+second retry, 9000ms on the 3rd retry and 16000ms on the final retry.
+
+#### Random
 
 ```powershell
 $backoffPolicy = New-CosmosDbBackoffPolicy -MaxRetries 3 -Method Random -Delay 1000
@@ -729,11 +767,7 @@ $backoffPolicy = New-CosmosDbBackoffPolicy -MaxRetries 3 -Method Random -Delay 1
 
 A policy that adds or subtracts up to 50% of the delay period to the base delay
 each time can also be applied. For example, the first delay might be 850ms, with
-the second delay being 1424ms and the 3rd and final delay being 983ms.
-
-**Note: if the delay calculated by the policy is less than the value returned in
-the `x-ms-retry-after-ms` header, then the `x-ms-retry-after-ms` value will always
-be used.**
+the second delay being 1424ms and final delay being 983ms.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -719,6 +719,14 @@ returned in the `x-ms-retry-after-ms` header.
 the `x-ms-retry-after-ms` header, then the `x-ms-retry-after-ms` value will always
 be used.**
 
+The available Back-off Methods are:
+
+- Default
+- Additive
+- Linear
+- Exponential
+- Random
+
 The following show examples of alternative policy back-off types that can
 implemented:
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -14,7 +14,8 @@ June 23, 2018
 - Added integration tests for triggers.
 - Added integration tests for user defined functions.
 - Added `New-CosmosDbBackOffPolicy` function for controlling the behaviour
-  of a function when a "Too Many Request" (error code 429) is recieved.
+  of a function when a "Too Many Request" (error code 429) is recieved -
+  See [Issue #87](https://github.com/PlagueHO/CosmosDB/issues/87)
 - Added support for handling a back-off policy to the `Invoke-CosmosDbRequest`
   function.
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -13,6 +13,10 @@ June 23, 2018
 - Added integration tests for stored procedures.
 - Added integration tests for triggers.
 - Added integration tests for user defined functions.
+- Added `New-CosmosDbBackOffPolicy` function for controlling the behaviour
+  of a function when a "Too Many Request" (error code 429) is recieved.
+- Added support for handling a back-off policy to the `Invoke-CosmosDbRequest`
+  function.
 
 ## What is New in CosmosDB 2.0.16.465
 

--- a/docs/New-CosmosDbBackoffPolicy.md
+++ b/docs/New-CosmosDbBackoffPolicy.md
@@ -33,9 +33,43 @@ be used to control whether or not to retry the request.
 If no Back-off Policy is defined then the 429 error is simply returned to
 the caller.
 
+The default back-off method will use the largest of the two values,
+delay and `x-ms-retry-after-ms` each time.
+
+An additive back-off method will add the delay to the value of the
+`x-ms-retry-after-ms` header each time.
+
+A linear back-off method will use a delay equal to the delay times
+the number of retries.
+
+An exponential back-off method will exponentially increase the delay
+with value each retry.
+
+A random back-off method will wait +/- 50% of the delay value each
+retry.
+
+Note: If a calculated delay results in a value less than the
+`x-ms-retry-after-ms` header value then the `x-ms-retry-after-ms`
+value will be used.
+
 ## EXAMPLES
 
 ### Example 1
+
+```powershell
+PS C:\> $primaryKey = ConvertTo-SecureString -String 'your master key' -AsPlainText -Force
+PS C:\> $backoffPolicy = New-CosmosDBBackoffPolicy -MaxRetries 5
+PS C:\> $cosmosDbContext = New-CosmosDbContext -Account 'MyAzureCosmosDB' -Database 'MyDatabase' -Key $primaryKey -BackoffPolicy $backoffPolicy
+PS C:\> $query = "SELECT * FROM customers c WHERE (c.id = 'user@contoso.com')"
+PS C:\> $documents = Get-CosmosDBDocument -Context $cosmosDBContext -CollectionId 'MyNewCollection' -Query $query
+```
+
+Creates a CosmosDB context specifying the master key manually. A
+Back-off Policy will be applied to the context that allows 5 retries
+with a delay between them matching the `x-ms-retry-after-ms` header
+value returned from Cosmos DB.
+
+### Example 2
 
 ```powershell
 PS C:\> $primaryKey = ConvertTo-SecureString -String 'your master key' -AsPlainText -Force
@@ -48,6 +82,84 @@ PS C:\> $documents = Get-CosmosDBDocument -Context $cosmosDBContext -CollectionI
 Creates a CosmosDB context specifying the master key manually. A
 Back-off Policy will be applied to the context that allows 5 retries
 with a delay of 2 seconds between them.
+
+#### Example 3
+
+```powershell
+PS C:\> $primaryKey = ConvertTo-SecureString -String 'your master key' -AsPlainText -Force
+PS C:\> $backoffPolicy = New-CosmosDBBackoffPolicy -MaxRetries 10 -Method Default -Delay 100
+PS C:\> $cosmosDbContext = New-CosmosDbContext -Account 'MyAzureCosmosDB' -Database 'MyDatabase' -Key $primaryKey -BackoffPolicy $backoffPolicy
+PS C:\> $query = "SELECT * FROM customers c WHERE (c.id = 'user@contoso.com')"
+PS C:\> $documents = Get-CosmosDBDocument -Context $cosmosDBContext -CollectionId 'MyNewCollection' -Query $query
+```
+
+Creates a CosmosDB context specifying the master key manually. A
+Back-off Policy will be applied to the context that allows 10 retries.
+A delay of 100ms will always be used unless it is less than the
+`x-ms-retry-after-ms` header.
+
+#### Example 4
+
+```powershell
+PS C:\> $primaryKey = ConvertTo-SecureString -String 'your master key' -AsPlainText -Force
+PS C:\> $backoffPolicy = New-CosmosDbBackoffPolicy -MaxRetries 10 -Method Additive -Delay 1000
+PS C:\> $cosmosDbContext = New-CosmosDbContext -Account 'MyAzureCosmosDB' -Database 'MyDatabase' -Key $primaryKey -BackoffPolicy $backoffPolicy
+PS C:\> $query = "SELECT * FROM customers c WHERE (c.id = 'user@contoso.com')"
+PS C:\> $documents = Get-CosmosDBDocument -Context $cosmosDBContext -CollectionId 'MyNewCollection' -Query $query
+```
+
+Creates a CosmosDB context specifying the master key manually. A
+Back-off Policy will be applied to the context that allows 10 retries.
+The delay between each retry will be the returned `x-ms-retry-after-ms`
+header value plus 1000ms.
+
+#### Example 5
+
+```powershell
+PS C:\> $primaryKey = ConvertTo-SecureString -String 'your master key' -AsPlainText -Force
+PS C:\> $backoffPolicy = New-CosmosDbBackoffPolicy -MaxRetries 3 -Method Linear -Delay 500
+PS C:\> $cosmosDbContext = New-CosmosDbContext -Account 'MyAzureCosmosDB' -Database 'MyDatabase' -Key $primaryKey -BackoffPolicy $backoffPolicy
+PS C:\> $query = "SELECT * FROM customers c WHERE (c.id = 'user@contoso.com')"
+PS C:\> $documents = Get-CosmosDBDocument -Context $cosmosDBContext -CollectionId 'MyNewCollection' -Query $query
+```
+
+Creates a CosmosDB context specifying the master key manually. A
+Back-off Policy will be applied to the context that allows 3 retries.
+The delay between each retry will wait for 500ms on the first retry,
+1000ms on the second retry, 1500ms on final retry.
+
+#### Example 6
+
+```powershell
+PS C:\> $primaryKey = ConvertTo-SecureString -String 'your master key' -AsPlainText -Force
+PS C:\> $backoffPolicy = New-CosmosDbBackoffPolicy -MaxRetries 4 -Method Exponential -Delay 1000
+PS C:\> $cosmosDbContext = New-CosmosDbContext -Account 'MyAzureCosmosDB' -Database 'MyDatabase' -Key $primaryKey -BackoffPolicy $backoffPolicy
+PS C:\> $query = "SELECT * FROM customers c WHERE (c.id = 'user@contoso.com')"
+PS C:\> $documents = Get-CosmosDBDocument -Context $cosmosDBContext -CollectionId 'MyNewCollection' -Query $query
+```
+
+Creates a CosmosDB context specifying the master key manually. A
+Back-off Policy will be applied to the context that allows 3 retries.
+The delay between each retry will wait for 1000ms on the first retry,
+4000ms on the second retry, 9000ms on the 3rd retry and 16000ms on
+the final retry.
+
+#### Example 7
+
+```powershell
+PS C:\> $primaryKey = ConvertTo-SecureString -String 'your master key' -AsPlainText -Force
+PS C:\> $backoffPolicy = New-CosmosDbBackoffPolicy -MaxRetries 3 -Method Random -Delay 1000
+PS C:\> $cosmosDbContext = New-CosmosDbContext -Account 'MyAzureCosmosDB' -Database 'MyDatabase' -Key $primaryKey -BackoffPolicy $backoffPolicy
+PS C:\> $query = "SELECT * FROM customers c WHERE (c.id = 'user@contoso.com')"
+PS C:\> $documents = Get-CosmosDBDocument -Context $cosmosDBContext -CollectionId 'MyNewCollection' -Query $query
+```
+
+Creates a CosmosDB context specifying the master key manually. A
+Back-off Policy will be applied to the context that allows 3 retries.
+The delay adds or subtracts up to 50% of the delay period to the base
+delay each time can also be applied. For example, the first delay
+might be 850ms, with the second delay being 1424ms and final delay
+being 983ms.
 
 ## PARAMETERS
 
@@ -72,15 +184,6 @@ Accept wildcard characters: False
 
 This is the back-off method of the policy.
 
-A linear back-off method will always wait the same amount of time
-between retried.
-
-An exponential back-off method will double the delay value each
-retry.
-
-A random back-off method will wait +/- 50% of the delay value each
-retry.
-
 ```yaml
 Type: String
 Parameter Sets: (All)
@@ -88,7 +191,7 @@ Aliases:
 
 Required: True
 Position: 1
-Default value: Linear
+Default value: Default
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -96,21 +199,8 @@ Accept wildcard characters: False
 ### -Delay
 
 This is the number of milliseconds to wait before retrying the
-last request.
-
-If a linear back-off method is used then this is the exact
-number of milliseconds to wait between retries.
-
-If an exponential back-off method is used then this is the base
-delay to use for the first failure. Further failures will double
-this value.
-
-If a random back-off method is used then the delay will
-be this value +/- 50%.
-
-If the request returned a 'x-ms-retry-after-ms' header then the
-greater of the 'x-ms-retry-after-ms' value and the current value
-of the delay will be used.
+last request. The behavior of this value depends on the method.
+See the description of this function for more detail.
 
 ```yaml
 Type: Int32

--- a/docs/New-CosmosDbBackoffPolicy.md
+++ b/docs/New-CosmosDbBackoffPolicy.md
@@ -39,7 +39,7 @@ the caller.
 
 ```powershell
 PS C:\> $primaryKey = ConvertTo-SecureString -String 'your master key' -AsPlainText -Force
-PS C:\> $backoffPolicy = New-CosmosDBBackoffPolicy -MaxRetries 5 -Delay 2
+PS C:\> $backoffPolicy = New-CosmosDBBackoffPolicy -MaxRetries 5 -Delay 2000
 PS C:\> $cosmosDbContext = New-CosmosDbContext -Account 'MyAzureCosmosDB' -Database 'MyDatabase' -Key $primaryKey -BackoffPolicy $backoffPolicy
 PS C:\> $query = "SELECT * FROM customers c WHERE (c.id = 'user@contoso.com')"
 PS C:\> $documents = Get-CosmosDBDocument -Context $cosmosDBContext -CollectionId 'MyNewCollection' -Query $query
@@ -95,11 +95,11 @@ Accept wildcard characters: False
 
 ### -Delay
 
-This is the number of seconds to wait before retrying the
+This is the number of milliseconds to wait before retrying the
 last request.
 
 If a linear back-off method is used then this is the exact
-number of seconds to wait between retries.
+number of milliseconds to wait between retries.
 
 If an exponential back-off method is used then this is the base
 delay to use for the first failure. Further failures will double
@@ -119,7 +119,7 @@ Aliases:
 
 Required: True
 Position: 2
-Default value: 5
+Default value: 5000
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/New-CosmosDbBackoffPolicy.md
+++ b/docs/New-CosmosDbBackoffPolicy.md
@@ -1,0 +1,144 @@
+---
+external help file: CosmosDB-help.xml
+Module Name: CosmosDB
+online version:
+schema: 2.0.0
+---
+
+# New-CosmosDbBackoffPolicy
+
+## SYNOPSIS
+
+Create a new Backoff Policy that can be added to a Cosmos DB Context to
+control the behavior when "Too Many Request" (error code 429) responses
+are recieved.
+
+## SYNTAX
+
+```powershell
+New-CosmosDbBackoffPolicy [-MaxRetries] <Int32> [-Method] <String> [-Delay] <Int32>
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+This function creates a new Back-off Policy that can be used to control
+the behavior of most Cosmos DB functions when a "Too Many Request"
+(error code 429) response is recieved.
+
+If a Back-off Policy is applied to a context that is used with a Cosmos DB
+function and an error code 429 is recieved then a Back-off Policy can
+be used to control whether or not to retry the request.
+
+If no Back-off Policy is defined then the 429 error is simply returned to
+the caller.
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+PS C:\> $primaryKey = ConvertTo-SecureString -String 'your master key' -AsPlainText -Force
+PS C:\> $backoffPolicy = New-CosmosDBBackoffPolicy -MaxRetries 5 -Delay 2
+PS C:\> $cosmosDbContext = New-CosmosDbContext -Account 'MyAzureCosmosDB' -Database 'MyDatabase' -Key $primaryKey -BackoffPolicy $backoffPolicy
+PS C:\> $query = "SELECT * FROM customers c WHERE (c.id = 'user@contoso.com')"
+PS C:\> $documents = Get-CosmosDBDocument -Context $cosmosDBContext -CollectionId 'MyNewCollection' -Query $query
+```
+
+Creates a CosmosDB context specifying the master key manually. A
+Back-off Policy will be applied to the context that allows 5 retries
+with a delay of 2 seconds between them.
+
+## PARAMETERS
+
+### -MaxRetries
+
+This is the number of times to retry the request if a 429 error
+is recieved.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: 10
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Method
+
+This is the back-off method of the policy.
+
+A linear back-off method will always wait the same amount of time
+between retried.
+
+An exponential back-off method will double the delay value each
+retry.
+
+A random back-off method will wait +/- 50% of the delay value each
+retry.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: Linear
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Delay
+
+This is the number of seconds to wait before retrying the
+last request.
+
+If a linear back-off method is used then this is the exact
+number of seconds to wait between retries.
+
+If an exponential back-off method is used then this is the base
+delay to use for the first failure. Further failures will double
+this value.
+
+If a random back-off method is used then the delay will
+be this value +/- 50%.
+
+If the request returned a 'x-ms-retry-after-ms' header then the
+greater of the 'x-ms-retry-after-ms' value and the current value
+of the delay will be used.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 2
+Default value: 5
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+
+## OUTPUTS
+
+### System.Management.Automation.PSCustomObject
+
+
+## NOTES
+
+## RELATED LINKS

--- a/docs/New-CosmosDbBackoffPolicy.md
+++ b/docs/New-CosmosDbBackoffPolicy.md
@@ -83,7 +83,7 @@ Creates a CosmosDB context specifying the master key manually. A
 Back-off Policy will be applied to the context that allows 5 retries
 with a delay of 2 seconds between them.
 
-#### Example 3
+### Example 3
 
 ```powershell
 PS C:\> $primaryKey = ConvertTo-SecureString -String 'your master key' -AsPlainText -Force
@@ -98,7 +98,7 @@ Back-off Policy will be applied to the context that allows 10 retries.
 A delay of 100ms will always be used unless it is less than the
 `x-ms-retry-after-ms` header.
 
-#### Example 4
+### Example 4
 
 ```powershell
 PS C:\> $primaryKey = ConvertTo-SecureString -String 'your master key' -AsPlainText -Force
@@ -113,7 +113,7 @@ Back-off Policy will be applied to the context that allows 10 retries.
 The delay between each retry will be the returned `x-ms-retry-after-ms`
 header value plus 1000ms.
 
-#### Example 5
+### Example 5
 
 ```powershell
 PS C:\> $primaryKey = ConvertTo-SecureString -String 'your master key' -AsPlainText -Force
@@ -128,7 +128,7 @@ Back-off Policy will be applied to the context that allows 3 retries.
 The delay between each retry will wait for 500ms on the first retry,
 1000ms on the second retry, 1500ms on final retry.
 
-#### Example 6
+### Example 6
 
 ```powershell
 PS C:\> $primaryKey = ConvertTo-SecureString -String 'your master key' -AsPlainText -Force
@@ -144,7 +144,7 @@ The delay between each retry will wait for 1000ms on the first retry,
 4000ms on the second retry, 9000ms on the 3rd retry and 16000ms on
 the final retry.
 
-#### Example 7
+### Example 7
 
 ```powershell
 PS C:\> $primaryKey = ConvertTo-SecureString -String 'your master key' -AsPlainText -Force

--- a/docs/New-CosmosDbContext.md
+++ b/docs/New-CosmosDbContext.md
@@ -18,20 +18,21 @@ to connect to a CosmosDB.
 
 ```powershell
 New-CosmosDbContext -Account <String> [-Database <String>] -Key <SecureString> [-KeyType <String>]
- [<CommonParameters>]
+ [-RetryPolicy <CosmosDB.RetryPolicy>] [<CommonParameters>]
 ```
 
 ### Azure
 
 ```powershell
 New-CosmosDbContext -Account <String> [-Database <String>] -ResourceGroup <String> [-MasterKeyType <String>]
- [<CommonParameters>]
+ [-RetryPolicy <CosmosDB.RetryPolicy>] [<CommonParameters>]
 ```
 
 ### Emulator
 
 ```powershell
-New-CosmosDbContext [-Database <String>] [-Emulator] [-Port <Int16>] [<CommonParameters>]
+New-CosmosDbContext [-Database <String>] [-Emulator] [-Port <Int16>] [-RetryPolicy <CosmosDB.RetryPolicy>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -42,6 +43,10 @@ object that can be passed to the CosmosDB cmdlets.
 
 It can also retrieve the CosmosDB primary or secondary key
 from Azure Resource Manager.
+
+A retry policy can be applied to the context to control
+the behavior of "Too Many Request" (error code 429) responses
+from Cosmos DB.
 
 ## EXAMPLES
 
@@ -71,6 +76,18 @@ PS C:\> $cosmosDbContext = New-CosmosDbContext -Emulator
 ```
 
 Creates a CosmosDB context by using a local CosmosDB Emulator.
+
+### EXAMPLE 4
+
+```powershell
+PS C:\> $primaryKey = ConvertTo-SecureString -String 'your master key' -AsPlainText -Force
+PS C:\> $retryPolicy = New-CosmosDBRetryPolicy -MaxRetries 5 -Delay 2
+PS C:\> $cosmosDbContext = New-CosmosDbContext -Account 'MyAzureCosmosDB' -Database 'MyDatabase' -Key $primaryKey -RetryPolicy $retryPolicy
+```
+
+Creates a CosmosDB context specifying the master key manually. A
+retry policy will be applied to the context that allows 5 retries
+with a delay of 2 seconds between them.
 
 ## PARAMETERS
 
@@ -217,6 +234,23 @@ retrieving a CosmosDB user account that has had permissions assigned.
 ```yaml
 Type: CosmosDB.Token
 Parameter Sets: Emulator, Token
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -BackoffPolicy
+
+This a Back-off Policy object that controls the retry behaviour for
+requests using this context.
+
+```yaml
+Type: CosmosDB.BackoffPolicy
+Parameter Sets:  (All)
 Aliases:
 
 Required: False

--- a/docs/New-CosmosDbContext.md
+++ b/docs/New-CosmosDbContext.md
@@ -81,7 +81,7 @@ Creates a CosmosDB context by using a local CosmosDB Emulator.
 
 ```powershell
 PS C:\> $primaryKey = ConvertTo-SecureString -String 'your master key' -AsPlainText -Force
-PS C:\> $retryPolicy = New-CosmosDBRetryPolicy -MaxRetries 5 -Delay 2
+PS C:\> $retryPolicy = New-CosmosDBRetryPolicy -MaxRetries 5 -Delay 2000
 PS C:\> $cosmosDbContext = New-CosmosDbContext -Account 'MyAzureCosmosDB' -Database 'MyDatabase' -Key $primaryKey -RetryPolicy $retryPolicy
 ```
 

--- a/src/CosmosDB.psd1
+++ b/src/CosmosDB.psd1
@@ -191,7 +191,8 @@ June 23, 2018
 - Added integration tests for triggers.
 - Added integration tests for user defined functions.
 - Added `New-CosmosDbBackOffPolicy` function for controlling the behaviour
-  of a function when a "Too Many Request" (error code 429) is recieved.
+  of a function when a "Too Many Request" (error code 429) is recieved -
+  See [Issue #87](https://github.com/PlagueHO/CosmosDB/issues/87)
 - Added support for handling a back-off policy to the `Invoke-CosmosDbRequest`
   function.
 

--- a/src/CosmosDB.psd1
+++ b/src/CosmosDB.psd1
@@ -106,6 +106,7 @@
         'Get-CosmosDbUserDefinedFunctionResourcePath'
         'Invoke-CosmosDbStoredProcedure'
         'New-CosmosDbAttachment'
+        'New-CosmosDbBackoffPolicy'
         'New-CosmosDbCollection'
         'New-CosmosDbCollectionIncludedPathIndex'
         'New-CosmosDbCollectionIncludedPath'
@@ -189,6 +190,10 @@ June 23, 2018
 - Added integration tests for stored procedures.
 - Added integration tests for triggers.
 - Added integration tests for user defined functions.
+- Added `New-CosmosDbBackOffPolicy` function for controlling the behaviour
+  of a function when a "Too Many Request" (error code 429) is recieved.
+- Added support for handling a back-off policy to the `Invoke-CosmosDbRequest`
+  function.
 
 ## What is New in CosmosDB 2.0.16.465
 

--- a/src/CosmosDB.psm1
+++ b/src/CosmosDB.psm1
@@ -20,6 +20,13 @@ namespace CosmosDB {
         public System.Security.SecureString Token;
     }
 
+    public class BackoffPolicy
+    {
+        public System.Int32 MaxRetries;
+        public System.String Method;
+        public System.Int32 Delay;
+    }
+
     public class Context
     {
         public System.String Account;
@@ -28,6 +35,7 @@ namespace CosmosDB {
         public System.String KeyType;
         public System.String BaseUri;
         public CosmosDB.ContextToken[] Token;
+        public CosmosDB.BackoffPolicy BackoffPolicy;
     }
 
     namespace IndexingPolicy {

--- a/src/en-US/CosmosDB.strings.psd1
+++ b/src/en-US/CosmosDB.strings.psd1
@@ -8,6 +8,13 @@ ConvertFrom-StringData -StringData @'
     NoMatchingUnexpiredResourceTokenInContext = At least one matching context token with resource '{0}' was found, but all are expired.
     CreateAuthorizationToken = Creating authorization token: Method = '{0}', ResourceType = '{1}', ResourceId = '{2}', Date = '{3}'.
     StoredProcedureScriptLogResults = Stored Procedure '{0}' script log results:\n{1}
+    RequestChargeResults = Request charge for {0} to '{1}' was {2} RUs.
+    CollectionProvisionedThroughputExceededWithBackoffPolicy = The collection has exceeded the provisioned throughput limit but a back-off policy is specified.
+    CollectionProvisionedThroughputExceededNoBackoffPolicy = The collection has exceeded the provisioned throughput limit but there is no back-off policy.
+    CollectionProvisionedThroughputExceededMaxRetriesHit = The maximum back-off policy retries {0} has been exceeded.
+    BackOffPolicyAppliedPolicyDelay = The {0} back-off policy delay {1}ms will be used because it is longer than the requested delay {2}ms.
+    BackOffPolicyAppliedRequestedDelay = The requested delay {2}ms will be used because it is longer than the {0} back-off policy delay {1}ms.
+    WaitingBackoffPolicyDelay = The collection has exceeded the provisioned throughput limit but retry {0} will be attempted in {1}ms.
     ErrorAuthorizationKeyEmpty = The authorization key is empty. It must be passed in the context or a valid token context for the resource being accessed must be supplied.
     ErrorNewCollectionOfferParameterConflict = Both 'OfferType' and 'OfferThroughput' should not be specified when creating a new collection.
     ErrorNewCollectionParitionKeyRequired = A 'PartitionKey' is required when the 'OfferThroughput' is greater than 10000.

--- a/src/lib/utils.ps1
+++ b/src/lib/utils.ps1
@@ -9,9 +9,9 @@ function New-CosmosDbBackoffPolicy
         $MaxRetries = 10,
 
         [Parameter()]
-        [ValidateSet('Linear', 'Exponential', 'Random')]
+        [ValidateSet('Default', 'Additive', 'Linear', 'Exponential', 'Random')]
         [System.String]
-        $Method = 'Linear',
+        $Method = 'Default',
 
         [Parameter()]
         [ValidateRange(0, 3600000)]
@@ -630,9 +630,19 @@ function Get-CosmosDbBackoffDelay
         {
             switch ($BackoffPolicy.Method)
             {
-                'Linear'
+                'Default'
                 {
                     $backoffPolicyDelay = $backoffPolicy.Delay
+                }
+
+                'Additive'
+                {
+                    $backoffPolicyDelay = $RequestedDelay + $backoffPolicy.Delay
+                }
+
+                'Linear'
+                {
+                    $backoffPolicyDelay = $backoffPolicy.Delay * ($Retry + 1)
                 }
 
                 'Exponential'

--- a/test/CosmosDB.utils.Tests.ps1
+++ b/test/CosmosDB.utils.Tests.ps1
@@ -58,7 +58,7 @@ InModuleScope CosmosDB {
     }
     $script:testResourceGroup = 'testResourceGroup'
     $script:testMaxRetries = 20
-    $script:testMethod = 'Exponential'
+    $script:testMethod = 'Default'
     $script:testDelay = 1
 
     Describe 'Custom types' -Tag 'Unit' {
@@ -730,6 +730,244 @@ InModuleScope CosmosDB {
                     -ParameterFilter $InvokeWebRequest_parameterfilter `
                     -Exactly -Times 1
                 Assert-MockCalled -CommandName Get-Date -Exactly -Times 1
+            }
+        }
+    }
+
+    Describe 'Get-CosmosDbBackoffDelay' -Tag 'Unit' {
+        It 'Should exist' {
+            { Get-Command -Name Get-CosmosDbBackoffDelay -ErrorAction Stop } | Should -Not -Throw
+        }
+
+        Context 'When called with unspecified back-off policy' {
+            Context 'Retry number 1 and RequestedDelay is 100ms' {
+                $script:result = $null
+
+                It 'Should not throw exception' {
+                    $script:backoffPolicy = New-CosmosDbBackoffPolicy
+
+                    $getCosmosDbBackoffDelayParameters = @{
+                        BackoffPolicy  = $script:backoffPolicy
+                        Retry          = 1
+                        RequestedDelay = 100
+                        Verbose        = $true
+                    }
+
+                    { $script:result = Get-CosmosDbBackoffDelay @getCosmosDbBackoffDelayParameters } | Should -Not -Throw
+                }
+
+                It 'Should return 100ms' {
+                    $script:result | Should -Be 100
+                }
+            }
+
+            Context 'Retry number 11 and RequestedDelay is 100ms' {
+                $script:result = $null
+
+                It 'Should not throw exception' {
+                    $script:backoffPolicy = New-CosmosDbBackoffPolicy
+
+                    $getCosmosDbBackoffDelayParameters = @{
+                        BackoffPolicy  = $script:backoffPolicy
+                        Retry          = 11
+                        RequestedDelay = 100
+                        Verbose        = $true
+                    }
+
+                    { $script:result = Get-CosmosDbBackoffDelay @getCosmosDbBackoffDelayParameters } | Should -Not -Throw
+                }
+
+                It 'Should return null' {
+                    $script:result | Should -BeNull
+                }
+            }
+        }
+
+        Context 'When called with Default back-off policy and delay 500ms' {
+            Context 'Retry number 1 and RequestedDelay is 100ms' {
+                $script:result = $null
+
+                It 'Should not throw exception' {
+                    $newCosmosDbContextBackoffPolicyParameters = @{
+                        Delay = 500
+                    }
+
+                    $script:backoffPolicy = New-CosmosDbBackoffPolicy @newCosmosDbContextBackoffPolicyParameters
+
+                    $getCosmosDbBackoffDelayParameters = @{
+                        BackoffPolicy  = $script:backoffPolicy
+                        Retry          = 1
+                        RequestedDelay = 100
+                        Verbose        = $true
+                    }
+
+                    { $script:result = Get-CosmosDbBackoffDelay @getCosmosDbBackoffDelayParameters } | Should -Not -Throw
+                }
+
+                It 'Should return 500ms' {
+                    $script:result | Should -Be 500
+                }
+            }
+
+            Context 'Retry number 1 and RequestedDelay is 2000ms' {
+                $script:result = $null
+
+                It 'Should not throw exception' {
+                    $newCosmosDbContextBackoffPolicyParameters = @{
+                        Delay = 500
+                    }
+
+                    $script:backoffPolicy = New-CosmosDbBackoffPolicy @newCosmosDbContextBackoffPolicyParameters
+
+                    $getCosmosDbBackoffDelayParameters = @{
+                        BackoffPolicy  = $script:backoffPolicy
+                        Retry          = 1
+                        RequestedDelay = 2000
+                        Verbose        = $true
+                    }
+
+                    { $script:result = Get-CosmosDbBackoffDelay @getCosmosDbBackoffDelayParameters } | Should -Not -Throw
+                }
+
+                It 'Should return 2000ms' {
+                    $script:result | Should -Be 2000
+                }
+            }
+        }
+
+        Context 'When called with Additive back-off policy and delay 500ms' {
+            Context 'Retry number 1 and RequestedDelay is 100ms' {
+                $script:result = $null
+
+                It 'Should not throw exception' {
+                    $newCosmosDbContextBackoffPolicyParameters = @{
+                        Method = 'Additive'
+                        Delay  = 500
+                    }
+
+                    $script:backoffPolicy = New-CosmosDbBackoffPolicy @newCosmosDbContextBackoffPolicyParameters
+
+                    $getCosmosDbBackoffDelayParameters = @{
+                        BackoffPolicy  = $script:backoffPolicy
+                        Retry          = 1
+                        RequestedDelay = 100
+                        Verbose        = $true
+                    }
+
+                    { $script:result = Get-CosmosDbBackoffDelay @getCosmosDbBackoffDelayParameters } | Should -Not -Throw
+                }
+
+                It 'Should return 600ms' {
+                    $script:result | Should -Be 600
+                }
+            }
+        }
+
+        Context 'When called with Linear back-off policy and delay 500ms' {
+            Context 'Retry number 0 and RequestedDelay is 100ms' {
+                $script:result = $null
+
+                It 'Should not throw exception' {
+                    $newCosmosDbContextBackoffPolicyParameters = @{
+                        Method = 'Linear'
+                        Delay  = 500
+                    }
+
+                    $script:backoffPolicy = New-CosmosDbBackoffPolicy @newCosmosDbContextBackoffPolicyParameters
+
+                    $getCosmosDbBackoffDelayParameters = @{
+                        BackoffPolicy  = $script:backoffPolicy
+                        Retry          = 0
+                        RequestedDelay = 100
+                        Verbose        = $true
+                    }
+
+                    { $script:result = Get-CosmosDbBackoffDelay @getCosmosDbBackoffDelayParameters } | Should -Not -Throw
+                }
+
+                It 'Should return 500ms' {
+                    $script:result | Should -Be 500
+                }
+            }
+
+            Context 'Retry number 1 and RequestedDelay is 100ms' {
+                $script:result = $null
+
+                It 'Should not throw exception' {
+                    $newCosmosDbContextBackoffPolicyParameters = @{
+                        Method = 'Linear'
+                        Delay  = 500
+                    }
+
+                    $script:backoffPolicy = New-CosmosDbBackoffPolicy @newCosmosDbContextBackoffPolicyParameters
+
+                    $getCosmosDbBackoffDelayParameters = @{
+                        BackoffPolicy  = $script:backoffPolicy
+                        Retry          = 1
+                        RequestedDelay = 100
+                        Verbose        = $true
+                    }
+
+                    { $script:result = Get-CosmosDbBackoffDelay @getCosmosDbBackoffDelayParameters } | Should -Not -Throw
+                }
+
+                It 'Should return 1000ms' {
+                    $script:result | Should -Be 1000
+                }
+            }
+        }
+
+        Context 'When called with Exponential back-off policy and delay 500ms' {
+            Context 'Retry number 0 and RequestedDelay is 100ms' {
+                $script:result = $null
+
+                It 'Should not throw exception' {
+                    $newCosmosDbContextBackoffPolicyParameters = @{
+                        Method = 'Exponential'
+                        Delay  = 500
+                    }
+
+                    $script:backoffPolicy = New-CosmosDbBackoffPolicy @newCosmosDbContextBackoffPolicyParameters
+
+                    $getCosmosDbBackoffDelayParameters = @{
+                        BackoffPolicy  = $script:backoffPolicy
+                        Retry          = 0
+                        RequestedDelay = 100
+                        Verbose        = $true
+                    }
+
+                    { $script:result = Get-CosmosDbBackoffDelay @getCosmosDbBackoffDelayParameters } | Should -Not -Throw
+                }
+
+                It 'Should return 500ms' {
+                    $script:result | Should -Be 500
+                }
+            }
+
+            Context 'Retry number 4 and RequestedDelay is 100ms' {
+                $script:result = $null
+
+                It 'Should not throw exception' {
+                    $newCosmosDbContextBackoffPolicyParameters = @{
+                        Method = 'Exponential'
+                        Delay  = 500
+                    }
+
+                    $script:backoffPolicy = New-CosmosDbBackoffPolicy @newCosmosDbContextBackoffPolicyParameters
+
+                    $getCosmosDbBackoffDelayParameters = @{
+                        BackoffPolicy  = $script:backoffPolicy
+                        Retry          = 4
+                        RequestedDelay = 100
+                        Verbose        = $true
+                    }
+
+                    { $script:result = Get-CosmosDbBackoffDelay @getCosmosDbBackoffDelayParameters } | Should -Not -Throw
+                }
+
+                It 'Should return 12500msms' {
+                    $script:result | Should -Be 12500
+                }
             }
         }
     }

--- a/test/CosmosDB.utils.Tests.ps1
+++ b/test/CosmosDB.utils.Tests.ps1
@@ -55,6 +55,7 @@ InModuleScope CosmosDB {
 '@
     $script:testInvokeWebRequestResult = @{
         Content = $script:testJson
+        Headers = @{ 'x-ms-request-charge' = '5' }
     }
     $script:testResourceGroup = 'testResourceGroup'
     $script:testMaxRetries = 20


### PR DESCRIPTION
This PR adds support for supplying a Back-off Policy within the context so that all functions can be configured to handle 429 responses from the server. The Back-off Policy is configurable to support additional performance profiles and scenarios.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plagueho/cosmosdb/127)
<!-- Reviewable:end -->
