### PR TITLE
Fix New-CosmosDBTrigger and Set-CosmosDBTrigger Create Operation - Fixes #129

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+- Changed trigger operation type `Insert` to `Create` in `New-CosmosDBTrigger`
+  and `Set-CosmosDBTrigger` functions - fixes [Issue #129](https://github.com/PlagueHO/CosmosDB/issues/129)
+
 ## 2.1.0.487
 
 - Removed `UseWebRequest` parameter from `Invoke-CosmosDbReuest` function

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## What is New in CosmosDB Unreleased
+
+June 26, 2018
+
+- Changed trigger operation type `Insert` to `Create` in `New-CosmosDBTrigger`
+  and `Set-CosmosDBTrigger` functions - fixes [Issue #129](https://github.com/PlagueHO/CosmosDB/issues/129)
+
 ## What is New in CosmosDB 2.1.0.487
 
 June 23, 2018

--- a/src/CosmosDB.psd1
+++ b/src/CosmosDB.psd1
@@ -3,7 +3,7 @@
     RootModule        = 'CosmosDB.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '2.1.0.487'
+    ModuleVersion     = '2.1.1.487'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()
@@ -177,6 +177,13 @@
 
             # ReleaseNotes of this module
             ReleaseNotes = '
+## What is New in CosmosDB Unreleased
+
+June 26, 2018
+
+- Changed trigger operation type `Insert` to `Create` in `New-CosmosDBTrigger`
+  and `Set-CosmosDBTrigger` functions - fixes [Issue #129](https://github.com/PlagueHO/CosmosDB/issues/129)
+
 ## What is New in CosmosDB 2.1.0.487
 
 June 23, 2018

--- a/src/lib/triggers.ps1
+++ b/src/lib/triggers.ps1
@@ -163,7 +163,7 @@ function New-CosmosDbTrigger
         $TriggerBody,
 
         [Parameter(Mandatory = $true)]
-        [ValidateSet('All', 'Insert', 'Replace', 'Delete')]
+        [ValidateSet('All', 'Create', 'Replace', 'Delete')]
         [System.String]
         $TriggerOperation,
 
@@ -298,7 +298,7 @@ function Set-CosmosDbTrigger
         $TriggerBody,
 
         [Parameter(Mandatory = $true)]
-        [ValidateSet('All', 'Insert', 'Replace', 'Delete')]
+        [ValidateSet('All', 'Create', 'Replace', 'Delete')]
         [System.String]
         $TriggerOperation,
 

--- a/test/CosmosDB.integration.Tests.ps1
+++ b/test/CosmosDB.integration.Tests.ps1
@@ -710,62 +710,65 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
         }
     }
 
-    Context 'Add a trigger to the collection' {
-        It 'Should not throw an exception' {
-            {
-                $script:result = New-CosmosDbTrigger `
-                    -Context $script:testContext `
-                    -CollectionId $script:testCollection `
-                    -Id $script:testTriggerId `
-                    -TriggerBody $script:testTriggerBody `
-                    -TriggerOperation 'All' `
-                    -TriggerType 'Pre' `
-                    -Verbose
-            } | Should -Not -Throw
+    foreach ($operation in 'All', 'Create', 'Replace', 'Delete')
+    {
+        Context "Add a $operation trigger to the collection" {
+            It 'Should not throw an exception' {
+                {
+                    $script:result = New-CosmosDbTrigger `
+                        -Context $script:testContext `
+                        -CollectionId $script:testCollection `
+                        -Id $script:testTriggerId `
+                        -TriggerBody $script:testTriggerBody `
+                        -TriggerOperation 'Create' `
+                        -TriggerType 'Pre' `
+                        -Verbose
+                } | Should -Not -Throw
+            }
+
+            It 'Should return expected object' {
+                $script:result.Timestamp | Should -BeOfType [System.DateTime]
+                $script:result.Etag | Should -BeOfType [System.String]
+                $script:result.ResourceId | Should -BeOfType [System.String]
+                $script:result.Uri | Should -BeOfType [System.String]
+                $script:result.Id | Should -Be $script:testTriggerId
+                $script:result.TriggerOperation | Should -Be 'Create'
+                $script:result.TriggerType | Should -Be 'Pre'
+            }
         }
 
-        It 'Should return expected object' {
-            $script:result.Timestamp | Should -BeOfType [System.DateTime]
-            $script:result.Etag | Should -BeOfType [System.String]
-            $script:result.ResourceId | Should -BeOfType [System.String]
-            $script:result.Uri | Should -BeOfType [System.String]
-            $script:result.Id | Should -Be $script:testTriggerId
-            $script:result.TriggerOperation | Should -Be 'All'
-            $script:result.TriggerType | Should -Be 'Pre'
-        }
-    }
+        Context "Get the $operation trigger from the collection" {
+            It 'Should not throw an exception' {
+                {
+                    $script:result = Get-CosmosDbTrigger `
+                        -Context $script:testContext `
+                        -CollectionId $script:testCollection `
+                        -Id $script:testTriggerId `
+                        -Verbose
+                } | Should -Not -Throw
+            }
 
-    Context 'Get the trigger from the collection' {
-        It 'Should not throw an exception' {
-            {
-                $script:result = Get-CosmosDbTrigger `
-                    -Context $script:testContext `
-                    -CollectionId $script:testCollection `
-                    -Id $script:testTriggerId `
-                    -Verbose
-            } | Should -Not -Throw
+            It 'Should return expected object' {
+                $script:result.Timestamp | Should -BeOfType [System.DateTime]
+                $script:result.Etag | Should -BeOfType [System.String]
+                $script:result.ResourceId | Should -BeOfType [System.String]
+                $script:result.Uri | Should -BeOfType [System.String]
+                $script:result.Id | Should -Be $script:testTriggerId
+                $script:result.TriggerOperation | Should -Be $operation
+                $script:result.TriggerType | Should -Be 'Pre'
+            }
         }
 
-        It 'Should return expected object' {
-            $script:result.Timestamp | Should -BeOfType [System.DateTime]
-            $script:result.Etag | Should -BeOfType [System.String]
-            $script:result.ResourceId | Should -BeOfType [System.String]
-            $script:result.Uri | Should -BeOfType [System.String]
-            $script:result.Id | Should -Be $script:testTriggerId
-            $script:result.TriggerOperation | Should -Be 'All'
-            $script:result.TriggerType | Should -Be 'Pre'
-        }
-    }
-
-    Context 'Remove the trigger from the collection' {
-        It 'Should not throw an exception' {
-            {
-                $script:result = Remove-CosmosDbTrigger `
-                    -Context $script:testContext `
-                    -CollectionId $script:testCollection `
-                    -Id $script:testTriggerId `
-                    -Verbose
-            } | Should -Not -Throw
+        Context "Remove the $operation trigger from the collection" {
+            It 'Should not throw an exception' {
+                {
+                    $script:result = Remove-CosmosDbTrigger `
+                        -Context $script:testContext `
+                        -CollectionId $script:testCollection `
+                        -Id $script:testTriggerId `
+                        -Verbose
+                } | Should -Not -Throw
+            }
         }
     }
 

--- a/test/CosmosDB.integration.Tests.ps1
+++ b/test/CosmosDB.integration.Tests.ps1
@@ -732,7 +732,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
                 $script:result.ResourceId | Should -BeOfType [System.String]
                 $script:result.Uri | Should -BeOfType [System.String]
                 $script:result.Id | Should -Be $script:testTriggerId
-                $script:result.TriggerOperation | Should -Be 'Create'
+                $script:result.TriggerOperation | Should -Be $operation
                 $script:result.TriggerType | Should -Be 'Pre'
             }
         }


### PR DESCRIPTION
This PR renames the `Insert` trigger operation type to `Create` in the `New-CosmosDBTrigger` and `Set-CosmosDBTrigger`.