### PR TITLE
Changed New-CosmosDbStoredProcedure & Set-CosmosDbStoredProcedure commandlets to use serialization. Fixes #137.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## Unreleased
+
+- Changed `New-CosmosDbStoredProcedure` & `Set-CosmosDbStoredProcedure` to use serialization
+  instead of tricky request body conversion - fixes
+  [Issue #137](https://github.com/PlagueHO/CosmosDB/issues/137)
+
+
 ## 2.1.2.514
 
 - Changed `New-CosmosDBContext` so that Read Only keys will use the

--- a/src/lib/storedprocedures.ps1
+++ b/src/lib/storedprocedures.ps1
@@ -276,13 +276,16 @@ function New-CosmosDbStoredProcedure
 
     $resourcePath = ('colls/{0}/sprocs' -f $CollectionId)
 
-    $StoredProcedureBody = ((($StoredProcedureBody -replace '`n', '\n') -replace '`r', '\r') -replace '"', '\"')
+    $requestBody = Convert-CosmosDbRequestBody -RequestBodyObject @{
+        id = $id
+        body = $StoredProcedureBody
+    }
 
     $result = Invoke-CosmosDbRequest @PSBoundParameters `
         -Method 'Post' `
         -ResourceType 'sprocs' `
         -ResourcePath $resourcePath `
-        -Body "{ `"id`": `"$id`", `"body`" : `"$StoredProcedureBody`" }"
+        -Body $requestBody
 
     $storedProcedure = ConvertFrom-Json -InputObject $result.Content
 
@@ -399,13 +402,16 @@ function Set-CosmosDbStoredProcedure
 
     $resourcePath = ('colls/{0}/sprocs/{1}' -f $CollectionId, $Id)
 
-    $StoredProcedureBody = ((($StoredProcedureBody -replace '`n', '\n') -replace '`r', '\r') -replace '"', '\"')
+    $requestBody = Convert-CosmosDbRequestBody -RequestBodyObject @{
+        id = $id
+        body = $StoredProcedureBody
+    }
 
     $result = Invoke-CosmosDbRequest @PSBoundParameters `
         -Method 'Put' `
         -ResourceType 'sprocs' `
         -ResourcePath $resourcePath `
-        -Body "{ `"id`": `"$id`", `"body`" : `"$StoredProcedureBody`" }"
+        -Body $requestBody
 
     $storedProcedure = ConvertFrom-Json -InputObject $result.Content
 

--- a/src/lib/utils.ps1
+++ b/src/lib/utils.ps1
@@ -768,3 +768,18 @@ function New-CosmosDbInvalidOperationException
     $errorRecordToThrow = New-Object @newObjectParams
     throw $errorRecordToThrow
 }
+
+function Convert-CosmosDbRequestBody
+{
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNull()]
+        [System.Object]
+        $RequestBodyObject
+    )
+
+    return ConvertTo-Json -InputObject $RequestBodyObject -Depth 100 -Compress
+}

--- a/test/CosmosDB.utils.Tests.ps1
+++ b/test/CosmosDB.utils.Tests.ps1
@@ -61,6 +61,16 @@ InModuleScope CosmosDB {
     $script:testMaxRetries = 20
     $script:testMethod = 'Default'
     $script:testDelay = 1
+    $script:testRequestObject = @{
+        "Tricky Body" = @'
+if (entityAlreadyExists)
+    throw new Error(`root entity # ${entity.id} already created`);
+console.log(`new entity "${entity.id}" is about to be created...`);
+let a = 'some value';
+console.log("done");
+'@
+    }
+    $script:testRequestBodyJson = '{"Tricky Body":"if (entityAlreadyExists)\r\n    throw new Error(`root entity # ${entity.id} already created`);\r\nconsole.log(`new entity \"${entity.id}\" is about to be created...`);\r\nlet a = \u0027some value\u0027;\r\nconsole.log(\"done\");"}'
 
     Describe 'Custom types' -Tag 'Unit' {
         Context 'CosmosDB.Context' {
@@ -1015,6 +1025,29 @@ InModuleScope CosmosDB {
                 It 'Should return 12500msms' {
                     $script:result | Should -Be 12500
                 }
+            }
+        }
+    }
+
+    Describe 'Convert-CosmosDbRequestBody' -Tag 'Unit' {
+        It 'Should exist' {
+            { Get-Command -Name Convert-CosmosDbRequestBody -ErrorAction Stop } | Should -Not -Throw
+        }
+
+        Context 'When called with paramters' {
+            $script:result = $null
+
+            It 'Should not throw exception' {
+                $convertCosmosDbRequestBodyParameters = @{
+                    RequestBodyObject = $script:testRequestObject
+                    Verbose           = $true
+                }
+
+                { $script:result = Convert-CosmosDbRequestBody @convertCosmosDbRequestBodyParameters } | Should -Not -Throw
+            }
+
+            It 'Should return expected result' {
+                $script:result | Should -Be $script:testRequestBodyJson
             }
         }
     }


### PR DESCRIPTION
- Changed `New-CosmosDbStoredProcedure` & `Set-CosmosDbStoredProcedure` commandlets to use serialization instead of tricky request body conversion.
- Extracted request body serialization function `Convert-CosmosDbRequestBody` for that. That function can also be used in other places where request body is built.
- Added simple unit tests for `Convert-CosmosDbRequestBody` function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plagueho/cosmosdb/138)
<!-- Reviewable:end -->
