### PR TITLE
Trim leading slashes off of partition key value in lib\collections.ps1. Fixes: #153

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## Unreleased
+ - Updated partition key handling when creating collections to allow for leading '/' characters in the partition key - fixes [Issue #153]((https://github.com/PlagueHO/CosmosDB/issues/153)
+
 ## 2.1.5.548
 
 - Changed references to `CosmosDB` to `Cosmos DB` in documentation - fixes [Issue #147](https://github.com/PlagueHO/CosmosDB/issues/147)

--- a/src/lib/collections.ps1
+++ b/src/lib/collections.ps1
@@ -437,7 +437,7 @@ function New-CosmosDbCollection
     {
         $bodyObject += @{
             partitionKey = @{
-                paths = @('/{0}' -f $PartitionKey)
+                paths = @('/{0}' -f $PartitionKey.TrimStart("/"))
                 kind  = 'Hash'
             }
         }


### PR DESCRIPTION
# Bug Fixes
- Fixes #153

# Improvements / Enhancements
 - N/A

@PlagueHO Here's the fix for that trivial partition key issue I opened last week

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plagueho/cosmosdb/154)
<!-- Reviewable:end -->
