### PR TITLE
Added Get-CosmosDbAccountConnectionString Function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## Unreleased
 
 - Improved unit test reliability on MacOS and Linux.
+- Improved unit tests for account functions to include parameter filters on mock assertions.
+- Added `Get-CosmosDbAccountConnectionString` function for retrieving the connection strings
+  of an existing account in Azure - fixes [Issue #163](https://github.com/PlagueHO/CosmosDB/issues/163).
+  This function is not currently working due to an issue with the Microsoft\DocumentDB provider
+  in Azure - see [this issue](https://github.com/Azure/azure-powershell/issues/3650) for more information.
 
 ## 2.1.8.59
 

--- a/README.md
+++ b/README.md
@@ -199,6 +199,16 @@ Get the properties of an existing Cosmos DB account in Azure:
 Get-CosmosDbAccount -Name 'MyAzureCosmosDB' -ResourceGroup 'MyCosmosDbResourceGroup'
 ```
 
+Get the connection strings used to connect to an existing Cosmos DB
+account in Azure:
+
+| Note: This function is not currently working due to an issue in the Microsoft/DocumentDB
+| Provider. See [this issue](https://github.com/Azure/azure-powershell/issues/3650) for more information.
+
+```powershell
+Get-CosmosDbAccountConnectionString -Name 'MyAzureCosmosDB' -ResourceGroup 'MyCosmosDbResourceGroup'
+```
+
 Update an existing Cosmos DB account in Azure:
 
 ```powershell

--- a/docs/Get-CosmosDbAccountConnectionString.md
+++ b/docs/Get-CosmosDbAccountConnectionString.md
@@ -5,39 +5,39 @@ online version:
 schema: 2.0.0
 ---
 
-# Get-CosmosDbAccount
+# Get-CosmosDbAccountConnectionString
 
 ## SYNOPSIS
 
-Get the properties of a Cosmos DB account in Azure.
+Get the connection strings for a Cosmos DB account in Azure.
 
 ## SYNTAX
 
 ```powershell
-Get-CosmosDbAccount [-Name] <String> [-ResourceGroupName] <String> [<CommonParameters>]
+Get-CosmosDbAccountConnectionString [-Name] <String> [-ResourceGroupName] <String> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-This will return the properties of an existing Cosmos DB
-account in Azure.
+This will return the connection strings for using to connect to an existing
+Cosmos DB account in Azure.
 
 ## EXAMPLES
 
 ### Example 1
 
 ```powershell
-PS C:\> Get-CosmosDbAccount -Name 'MyCosmosDBAccount' -ResourceGroupName 'MyResourceGroup'
+PS C:\> Get-CosmosDbAccountConnectionString -Name 'MyCosmosDBAccount' -ResourceGroupName 'MyResourceGroup'
 ```
 
-Return the properties of a Cosmos DB account named 'MyCosmosDBAccount' in
+Return the connection strings for a Cosmos DB account named 'MyCosmosDBAccount' in
 the resource group 'MyResourceGroup'.
 
 ## PARAMETERS
 
 ### -Name
 
-The name of the Cosmos DB account to return the properties for.
+The name of the Cosmos DB account to return the connection strings for.
 
 ```yaml
 Type: String

--- a/src/CosmosDB.psd1
+++ b/src/CosmosDB.psd1
@@ -84,6 +84,7 @@
     # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
     FunctionsToExport = @(
         'Get-CosmosDbAccount'
+        'Get-CosmosDbAccountConnectionString'
         'Get-CosmosDbAttachment'
         'Get-CosmosDbAttachmentResourcePath'
         'Get-CosmosDbCollection'

--- a/src/en-US/CosmosDB.strings.psd1
+++ b/src/en-US/CosmosDB.strings.psd1
@@ -8,6 +8,7 @@ ConvertFrom-StringData -StringData @'
     NoMatchingUnexpiredResourceTokenInContext = At least one matching context token with resource '{0}' was found, but all are expired.
     CreateAuthorizationToken = Creating authorization token: Method = '{0}', ResourceType = '{1}', ResourceId = '{2}', Date = '{3}'.
     GettingAzureCosmosDBAccount = Getting Azure Cosmos DB account '{0}' in resource group '{1}'.
+    GettingAzureCosmosDBAccountConnectionString = Getting connection string for Azure Cosmos DB account '{0}' in resource group '{1}'.
     CreatingAzureCosmosDBAccount = Creating Azure Cosmos DB account '{0}' in resource group '{1}' located in '{2}'.
     UpdatingAzureCosmosDBAccount = Updating Azure Cosmos DB account '{0}' in resource group '{1}'.
     RemovingAzureCosmosDBAccount = Removing Azure Cosmos DB account '{0}' in resource group '{1}'.
@@ -30,4 +31,5 @@ ConvertFrom-StringData -StringData @'
     ShouldCreateAzureCosmosDBAccount = Create an Azure Cosmos DB account '{0}' in resource group '{1}' located in '{2}'
     ShouldUpdateAzureCosmosDBAccount = Update an Azure Cosmos DB account '{0}' in resource group '{1}'
     ShouldRemoveAzureCosmosDBAccount = Remove the Azure Cosmos DB account '{0}' in resource group '{1}'
+    GettingAzureCosmosDBAccountConnectionStringWarning = The Get-CosmosDbAccountConnectionString function does not currently work due to an issue with the Microsoft/DocumentDB provider. The connection strings will not be returned.
 '@

--- a/src/lib/accounts.ps1
+++ b/src/lib/accounts.ps1
@@ -16,15 +16,14 @@ function Get-CosmosDbAccount
     )
 
     $getAzureRmResource_parameters = $PSBoundParameters + @{
-        ResourceType      = 'Microsoft.DocumentDb/databaseAccounts'
-        ApiVersion        = '2015-04-08'
+        ResourceType = 'Microsoft.DocumentDb/databaseAccounts'
+        ApiVersion   = '2015-04-08'
     }
 
     Write-Verbose -Message $($LocalizedData.GettingAzureCosmosDBAccount -f $Name, $ResourceGroupName)
 
     return Get-AzureRmResource @getAzureRmResource_parameters
 }
-
 
 function New-CosmosDbAccount
 {
@@ -120,9 +119,9 @@ function New-CosmosDbAccount
     $null = $PSBoundParameters.Remove('IpRangeFilter')
 
     $newAzureRmResource_parameters = $PSBoundParameters + @{
-        ResourceType      = 'Microsoft.DocumentDb/databaseAccounts'
-        ApiVersion        = '2015-04-08'
-        Properties        = $cosmosDBProperties
+        ResourceType = 'Microsoft.DocumentDb/databaseAccounts'
+        ApiVersion   = '2015-04-08'
+        Properties   = $cosmosDBProperties
     }
 
     if ($PSCmdlet.ShouldProcess('Azure', ($LocalizedData.ShouldCreateAzureCosmosDBAccount -f $Name, $ResourceGroupName, $Location)))
@@ -274,9 +273,9 @@ function Set-CosmosDbAccount
     $null = $PSBoundParameters.Remove('IpRangeFilter')
 
     $setAzureRmResource_parameters = $PSBoundParameters + @{
-        ResourceType      = 'Microsoft.DocumentDb/databaseAccounts'
-        ApiVersion        = '2015-04-08'
-        Properties        = $cosmosDBProperties
+        ResourceType = 'Microsoft.DocumentDb/databaseAccounts'
+        ApiVersion   = '2015-04-08'
+        Properties   = $cosmosDBProperties
     }
 
     if ($PSCmdlet.ShouldProcess('Azure', ($LocalizedData.ShouldUpdateAzureCosmosDBAccount -f $Name, $ResourceGroupName)))
@@ -315,8 +314,8 @@ function Remove-CosmosDbAccount
     )
 
     $removeAzureRmResource_parameters = $PSBoundParameters + @{
-        ResourceType      = 'Microsoft.DocumentDb/databaseAccounts'
-        ApiVersion        = '2015-04-08'
+        ResourceType = 'Microsoft.DocumentDb/databaseAccounts'
+        ApiVersion   = '2015-04-08'
     }
 
     if ($Force -or `
@@ -326,4 +325,34 @@ function Remove-CosmosDbAccount
 
         $null = Remove-AzureRmResource @removeAzureRmResource_parameters
     }
+}
+
+function Get-CosmosDbAccountConnectionString
+{
+    [CmdletBinding()]
+    [OutputType([Object])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $Name,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $ResourceGroupName
+    )
+
+    $invokeAzureRmResourceAction_parameters = $PSBoundParameters + @{
+        ResourceType = 'Microsoft.DocumentDb/databaseAccounts'
+        ApiVersion   = '2015-04-08'
+        Action       = 'listConnectionStrings'
+        Force        = $true
+    }
+
+    Write-Verbose -Message $($LocalizedData.GettingAzureCosmosDBAccountConnectionString -f $Name, $ResourceGroupName)
+    Write-Warning -Message $LocalizedData.GettingAzureCosmosDBAccountConnectionStringWarning
+
+    return Invoke-AzureRmResourceAction @invokeAzureRmResourceAction_parameters
 }

--- a/test/CosmosDB.accounts.Tests.ps1
+++ b/test/CosmosDB.accounts.Tests.ps1
@@ -85,7 +85,7 @@ InModuleScope CosmosDB {
             $getAzureRmResource_parameterFilter = {
                 ($ResourceType -eq 'Microsoft.DocumentDb/databaseAccounts') -and `
                 ($ApiVersion -eq '2015-04-08') -and `
-                ($ResourceName -eq $script:testName) -and `
+                (($ResourceName -eq $script:testName) -or ($Name -eq $script:testName)) -and `
                 ($ResourceGroupName -eq $script:testResourceGroupName)
             }
 

--- a/test/CosmosDB.accounts.Tests.ps1
+++ b/test/CosmosDB.accounts.Tests.ps1
@@ -82,6 +82,10 @@ InModuleScope CosmosDB {
         Context 'When called with a Name and ResourceGroupName' {
             $script:result = $null
 
+            <#
+                Due to the inconsistent name of the ResourceName parameter in Get-CosmosDbAccount
+                in different versions we need to look for both in the mock.
+            #>
             $getAzureRmResource_parameterFilter = {
                 ($ResourceType -eq 'Microsoft.DocumentDb/databaseAccounts') -and `
                 ($ApiVersion -eq '2015-04-08') -and `

--- a/test/CosmosDB.accounts.Tests.ps1
+++ b/test/CosmosDB.accounts.Tests.ps1
@@ -82,17 +82,16 @@ InModuleScope CosmosDB {
         Context 'When called with a Name and ResourceGroupName' {
             $script:result = $null
 
-            $getAzurRmResource_parameterFilter = {
+            $getAzureRmResource_parameterFilter = {
                 ($ResourceType -eq 'Microsoft.DocumentDb/databaseAccounts') -and `
                 ($ApiVersion -eq '2015-04-08') -and `
-                ($Name -eq $script:testName) -and `
+                ($ResourceName -eq $script:testName) -and `
                 ($ResourceGroupName -eq $script:testResourceGroupName)
             }
 
             Mock `
                 -CommandName Get-AzureRmResource `
-                -MockWith { 'Account' } `
-                -Verifiable
+                -MockWith { 'Account' }
 
             It 'Should not throw exception' {
                 $getCosmosDbAccountParameters = @{
@@ -109,7 +108,10 @@ InModuleScope CosmosDB {
             }
 
             It 'Should call expected mocks' {
-                Assert-VerifiableMock
+                Assert-MockCalled `
+                    -CommandName Get-AzureRmResource `
+                    -ParameterFilter $getAzureRmResource_parameterFilter `
+                    -Exactly -Times 1
             }
         }
     }
@@ -140,7 +142,7 @@ InModuleScope CosmosDB {
             $newAzurRmResource_parameterFilter = {
                 ($ResourceType -eq 'Microsoft.DocumentDb/databaseAccounts') -and `
                 ($ApiVersion -eq '2015-04-08') -and `
-                ($Name -eq $script:testName) -and `
+                ($ResourceName -eq $script:testName) -and `
                 ($ResourceGroupName -eq $script:testResourceGroupName) -and `
                 ($Location -eq $script:testLocation) -and `
                 ($Force -eq $true) -and `
@@ -149,8 +151,7 @@ InModuleScope CosmosDB {
 
             Mock `
                 -CommandName New-AzureRmResource `
-                -MockWith { 'Account' } `
-                -Verifiable
+                -MockWith { 'Account' }
 
             It 'Should not throw exception' {
                 $newCosmosDbAccountParameters = @{
@@ -168,7 +169,10 @@ InModuleScope CosmosDB {
             }
 
             It 'Should call expected mocks' {
-                Assert-VerifiableMock
+                Assert-MockCalled `
+                    -CommandName New-AzureRmResource `
+                    -ParameterFilter $newAzurRmResource_parameterFilter `
+                    -Exactly -Times 1
             }
         }
 
@@ -193,7 +197,7 @@ InModuleScope CosmosDB {
             $newAzurRmResource_parameterFilter = {
                 ($ResourceType -eq 'Microsoft.DocumentDb/databaseAccounts') -and `
                 ($ApiVersion -eq '2015-04-08') -and `
-                ($Name -eq $script:testName) -and `
+                ($ResourceName -eq $script:testName) -and `
                 ($ResourceGroupName -eq $script:testResourceGroupName) -and `
                 ($Location -eq $script:testLocation) -and `
                 ($Force -eq $true) -and `
@@ -203,8 +207,7 @@ InModuleScope CosmosDB {
 
             Mock `
                 -CommandName New-AzureRmResource `
-                -MockWith { 'Account' } `
-                -Verifiable
+                -MockWith { 'Account' }
 
             It 'Should not throw exception' {
                 $newCosmosDbAccountParameters = @{
@@ -223,7 +226,10 @@ InModuleScope CosmosDB {
             }
 
             It 'Should call expected mocks' {
-                Assert-VerifiableMock
+                Assert-MockCalled `
+                    -CommandName New-AzureRmResource `
+                    -ParameterFilter $newAzurRmResource_parameterFilter `
+                    -Exactly -Times 1
             }
         }
 
@@ -252,7 +258,7 @@ InModuleScope CosmosDB {
             $newAzurRmResource_parameterFilter = {
                 ($ResourceType -eq 'Microsoft.DocumentDb/databaseAccounts') -and `
                 ($ApiVersion -eq '2015-04-08') -and `
-                ($Name -eq $script:testName) -and `
+                ($ResourceName -eq $script:testName) -and `
                 ($ResourceGroupName -eq $script:testResourceGroupName) -and `
                 ($Location -eq $script:testLocation) -and `
                 ($Force -eq $true) -and `
@@ -261,8 +267,7 @@ InModuleScope CosmosDB {
 
             Mock `
                 -CommandName New-AzureRmResource `
-                -MockWith { 'Account' } `
-                -Verifiable
+                -MockWith { 'Account' }
 
             It 'Should not throw exception' {
                 $newCosmosDbAccountParameters = @{
@@ -281,7 +286,10 @@ InModuleScope CosmosDB {
             }
 
             It 'Should call expected mocks' {
-                Assert-VerifiableMock
+                Assert-MockCalled `
+                    -CommandName New-AzureRmResource `
+                    -ParameterFilter $newAzurRmResource_parameterFilter `
+                    -Exactly -Times 1
             }
         }
 
@@ -314,7 +322,7 @@ InModuleScope CosmosDB {
             $newAzurRmResource_parameterFilter = {
                 ($ResourceType -eq 'Microsoft.DocumentDb/databaseAccounts') -and `
                 ($ApiVersion -eq '2015-04-08') -and `
-                ($Name -eq $script:testName) -and `
+                ($ResourceName -eq $script:testName) -and `
                 ($ResourceGroupName -eq $script:testResourceGroupName) -and `
                 ($Location -eq $script:testLocation) -and `
                 ($Force -eq $true) -and `
@@ -323,8 +331,7 @@ InModuleScope CosmosDB {
 
             Mock `
                 -CommandName New-AzureRmResource `
-                -MockWith { 'Account' } `
-                -Verifiable
+                -MockWith { 'Account' }
 
             It 'Should not throw exception' {
                 $newCosmosDbAccountParameters = @{
@@ -343,7 +350,10 @@ InModuleScope CosmosDB {
             }
 
             It 'Should call expected mocks' {
-                Assert-VerifiableMock
+                Assert-MockCalled `
+                    -CommandName New-AzureRmResource `
+                    -ParameterFilter $newAzurRmResource_parameterFilter `
+                    -Exactly -Times 1
             }
         }
 
@@ -368,7 +378,7 @@ InModuleScope CosmosDB {
             $newAzurRmResource_parameterFilter = {
                 ($ResourceType -eq 'Microsoft.DocumentDb/databaseAccounts') -and `
                 ($ApiVersion -eq '2015-04-08') -and `
-                ($Name -eq $script:testName) -and `
+                ($ResourceName -eq $script:testName) -and `
                 ($ResourceGroupName -eq $script:testResourceGroupName) -and `
                 ($Location -eq $script:testLocation) -and `
                 ($Force -eq $true) -and `
@@ -377,8 +387,7 @@ InModuleScope CosmosDB {
 
             Mock `
                 -CommandName New-AzureRmResource `
-                -MockWith { 'Account' } `
-                -Verifiable
+                -MockWith { 'Account' }
 
             It 'Should not throw exception' {
                 $newCosmosDbAccountParameters = @{
@@ -397,7 +406,10 @@ InModuleScope CosmosDB {
             }
 
             It 'Should call expected mocks' {
-                Assert-VerifiableMock
+                Assert-MockCalled `
+                    -CommandName New-AzureRmResource `
+                    -ParameterFilter $newAzurRmResource_parameterFilter `
+                    -Exactly -Times 1
             }
         }
 
@@ -422,7 +434,7 @@ InModuleScope CosmosDB {
             $newAzurRmResource_parameterFilter = {
                 ($ResourceType -eq 'Microsoft.DocumentDb/databaseAccounts') -and `
                 ($ApiVersion -eq '2015-04-08') -and `
-                ($Name -eq $script:testName) -and `
+                ($ResourceName -eq $script:testName) -and `
                 ($ResourceGroupName -eq $script:testResourceGroupName) -and `
                 ($Location -eq $script:testLocation) -and `
                 ($Force -eq $true) -and `
@@ -431,8 +443,7 @@ InModuleScope CosmosDB {
 
             Mock `
                 -CommandName New-AzureRmResource `
-                -MockWith { 'Account' } `
-                -Verifiable
+                -MockWith { 'Account' }
 
             It 'Should not throw exception' {
                 $newCosmosDbAccountParameters = @{
@@ -453,7 +464,10 @@ InModuleScope CosmosDB {
             }
 
             It 'Should call expected mocks' {
-                Assert-VerifiableMock
+                Assert-MockCalled `
+                    -CommandName New-AzureRmResource `
+                    -ParameterFilter $newAzurRmResource_parameterFilter `
+                    -Exactly -Times 1
             }
         }
     }
@@ -484,7 +498,7 @@ InModuleScope CosmosDB {
             $setAzurRmResource_parameterFilter = {
                 ($ResourceType -eq 'Microsoft.DocumentDb/databaseAccounts') -and `
                 ($ApiVersion -eq '2015-04-08') -and `
-                ($Name -eq $script:testName) -and `
+                ($ResourceName -eq $script:testName) -and `
                 ($ResourceGroupName -eq $script:testResourceGroupName) -and `
                 ($Force -eq $true) -and `
                 (ConvertTo-Json -InputObject $Properties) -eq (ConvertTo-Json -InputObject $testCosmosDBProperties)
@@ -492,8 +506,7 @@ InModuleScope CosmosDB {
 
             Mock `
                 -CommandName Set-AzureRmResource `
-                -MockWith { 'Account' } `
-                -Verifiable
+                -MockWith { 'Account' }
 
             $getCosmosDbAccount_parameterFilter = {
                 ($Name -eq $script:testName) -and `
@@ -502,9 +515,7 @@ InModuleScope CosmosDB {
 
             Mock `
                 -CommandName Get-CosmosDbAccount `
-                -ParameterFilter $getCosmosDbAccount_parameterFilter `
-                -MockWith { $script:mockGetAzureRmResource } `
-                -Verifiable
+                -MockWith { $script:mockGetAzureRmResource }
 
             It 'Should not throw exception' {
                 $setCosmosDbAccountParameters = @{
@@ -522,7 +533,15 @@ InModuleScope CosmosDB {
             }
 
             It 'Should call expected mocks' {
-                Assert-VerifiableMock
+                Assert-MockCalled `
+                    -CommandName Set-AzureRmResource `
+                    -ParameterFilter $setAzurRmResource_parameterFilter `
+                    -Exactly -Times 1
+
+                Assert-MockCalled `
+                    -CommandName Get-CosmosDbAccount `
+                    -ParameterFilter $getCosmosDbAccount_parameterFilter `
+                    -Exactly -Times 1
             }
         }
 
@@ -547,9 +566,8 @@ InModuleScope CosmosDB {
             $setAzurRmResource_parameterFilter = {
                 ($ResourceType -eq 'Microsoft.DocumentDb/databaseAccounts') -and `
                 ($ApiVersion -eq '2015-04-08') -and `
-                ($Name -eq $script:testName) -and `
+                ($ResourceName -eq $script:testName) -and `
                 ($ResourceGroupName -eq $script:testResourceGroupName) -and `
-                ($Location -eq $script:testLocation) -and `
                 ($Force -eq $true) -and `
                 ($AsJob -eq $true) -and `
                 (ConvertTo-Json -InputObject $Properties) -eq (ConvertTo-Json -InputObject $testCosmosDBProperties)
@@ -557,8 +575,7 @@ InModuleScope CosmosDB {
 
             Mock `
                 -CommandName Set-AzureRmResource `
-                -MockWith { 'Account' } `
-                -Verifiable
+                -MockWith { 'Account' }
 
             $getCosmosDbAccount_parameterFilter = {
                 ($Name -eq $script:testName) -and `
@@ -567,8 +584,7 @@ InModuleScope CosmosDB {
 
             Mock `
                 -CommandName Get-CosmosDbAccount `
-                -MockWith { $script:mockGetAzureRmResource } `
-                -Verifiable
+                -MockWith { $script:mockGetAzureRmResource }
 
             It 'Should not throw exception' {
                 $setCosmosDbAccountParameters = @{
@@ -587,7 +603,15 @@ InModuleScope CosmosDB {
             }
 
             It 'Should call expected mocks' {
-                Assert-VerifiableMock
+                Assert-MockCalled `
+                    -CommandName Set-AzureRmResource `
+                    -ParameterFilter $setAzurRmResource_parameterFilter `
+                    -Exactly -Times 1
+
+                Assert-MockCalled `
+                    -CommandName Get-CosmosDbAccount `
+                    -ParameterFilter $getCosmosDbAccount_parameterFilter `
+                    -Exactly -Times 1
             }
         }
 
@@ -616,17 +640,15 @@ InModuleScope CosmosDB {
             $setAzurRmResource_parameterFilter = {
                 ($ResourceType -eq 'Microsoft.DocumentDb/databaseAccounts') -and `
                 ($ApiVersion -eq '2015-04-08') -and `
-                ($Name -eq $script:testName) -and `
+                ($ResourceName -eq $script:testName) -and `
                 ($ResourceGroupName -eq $script:testResourceGroupName) -and `
-                ($Location -eq $script:testLocation) -and `
                 ($Force -eq $true) -and `
                 (ConvertTo-Json -InputObject $Properties) -eq (ConvertTo-Json -InputObject $testCosmosDBProperties)
             }
 
             Mock `
                 -CommandName Set-AzureRmResource `
-                -MockWith { 'Account' } `
-                -Verifiable
+                -MockWith { 'Account' }
 
             $getCosmosDbAccount_parameterFilter = {
                 ($Name -eq $script:testName) -and `
@@ -635,8 +657,7 @@ InModuleScope CosmosDB {
 
             Mock `
                 -CommandName Get-CosmosDbAccount `
-                -MockWith { $script:mockGetAzureRmResource } `
-                -Verifiable
+                -MockWith { $script:mockGetAzureRmResource }
 
             It 'Should not throw exception' {
                 $setCosmosDbAccountParameters = @{
@@ -655,7 +676,15 @@ InModuleScope CosmosDB {
             }
 
             It 'Should call expected mocks' {
-                Assert-VerifiableMock
+                Assert-MockCalled `
+                    -CommandName Set-AzureRmResource `
+                    -ParameterFilter $setAzurRmResource_parameterFilter `
+                    -Exactly -Times 1
+
+                Assert-MockCalled `
+                    -CommandName Get-CosmosDbAccount `
+                    -ParameterFilter $getCosmosDbAccount_parameterFilter `
+                    -Exactly -Times 1
             }
         }
 
@@ -688,17 +717,15 @@ InModuleScope CosmosDB {
             $setAzurRmResource_parameterFilter = {
                 ($ResourceType -eq 'Microsoft.DocumentDb/databaseAccounts') -and `
                 ($ApiVersion -eq '2015-04-08') -and `
-                ($Name -eq $script:testName) -and `
+                ($ResourceName -eq $script:testName) -and `
                 ($ResourceGroupName -eq $script:testResourceGroupName) -and `
-                ($Location -eq $script:testLocation) -and `
                 ($Force -eq $true) -and `
                 (ConvertTo-Json -InputObject $Properties) -eq (ConvertTo-Json -InputObject $testCosmosDBProperties)
             }
 
             Mock `
                 -CommandName Set-AzureRmResource `
-                -MockWith { 'Account' } `
-                -Verifiable
+                -MockWith { 'Account' }
 
             $getCosmosDbAccount_parameterFilter = {
                 ($Name -eq $script:testName) -and `
@@ -707,8 +734,7 @@ InModuleScope CosmosDB {
 
             Mock `
                 -CommandName Get-CosmosDbAccount `
-                -MockWith { $script:mockGetAzureRmResource } `
-                -Verifiable
+                -MockWith { $script:mockGetAzureRmResource }
 
             It 'Should not throw exception' {
                 $setCosmosDbAccountParameters = @{
@@ -727,7 +753,15 @@ InModuleScope CosmosDB {
             }
 
             It 'Should call expected mocks' {
-                Assert-VerifiableMock
+                Assert-MockCalled `
+                    -CommandName Set-AzureRmResource `
+                    -ParameterFilter $setAzurRmResource_parameterFilter `
+                    -Exactly -Times 1
+
+                Assert-MockCalled `
+                    -CommandName Get-CosmosDbAccount `
+                    -ParameterFilter $getCosmosDbAccount_parameterFilter `
+                    -Exactly -Times 1
             }
         }
 
@@ -752,17 +786,15 @@ InModuleScope CosmosDB {
             $setAzurRmResource_parameterFilter = {
                 ($ResourceType -eq 'Microsoft.DocumentDb/databaseAccounts') -and `
                 ($ApiVersion -eq '2015-04-08') -and `
-                ($Name -eq $script:testName) -and `
+                ($ResourceName -eq $script:testName) -and `
                 ($ResourceGroupName -eq $script:testResourceGroupName) -and `
-                ($Location -eq $script:testLocation) -and `
                 ($Force -eq $true) -and `
                 (ConvertTo-Json -InputObject $Properties) -eq (ConvertTo-Json -InputObject $testCosmosDBProperties)
             }
 
             Mock `
                 -CommandName Set-AzureRmResource `
-                -MockWith { 'Account' } `
-                -Verifiable
+                -MockWith { 'Account' }
 
             $getCosmosDbAccount_parameterFilter = {
                 ($Name -eq $script:testName) -and `
@@ -771,8 +803,7 @@ InModuleScope CosmosDB {
 
             Mock `
                 -CommandName Get-CosmosDbAccount `
-                -MockWith { $script:mockGetAzureRmResource } `
-                -Verifiable
+                -MockWith { $script:mockGetAzureRmResource }
 
             It 'Should not throw exception' {
                 $setCosmosDbAccountParameters = @{
@@ -791,7 +822,15 @@ InModuleScope CosmosDB {
             }
 
             It 'Should call expected mocks' {
-                Assert-VerifiableMock
+                Assert-MockCalled `
+                    -CommandName Set-AzureRmResource `
+                    -ParameterFilter $setAzurRmResource_parameterFilter `
+                    -Exactly -Times 1
+
+                Assert-MockCalled `
+                    -CommandName Get-CosmosDbAccount `
+                    -ParameterFilter $getCosmosDbAccount_parameterFilter `
+                    -Exactly -Times 1
             }
         }
 
@@ -816,7 +855,7 @@ InModuleScope CosmosDB {
             $setAzurRmResource_parameterFilter = {
                 ($ResourceType -eq 'Microsoft.DocumentDb/databaseAccounts') -and `
                 ($ApiVersion -eq '2015-04-08') -and `
-                ($Name -eq $script:testName) -and `
+                ($ResourceName -eq $script:testName) -and `
                 ($ResourceGroupName -eq $script:testResourceGroupName) -and `
                 ($Force -eq $true) -and `
                 (ConvertTo-Json -InputObject $Properties) -eq (ConvertTo-Json -InputObject $testCosmosDBProperties)
@@ -824,8 +863,7 @@ InModuleScope CosmosDB {
 
             Mock `
                 -CommandName Set-AzureRmResource `
-                -MockWith { 'Account' } `
-                -Verifiable
+                -MockWith { 'Account' }
 
             $getCosmosDbAccount_parameterFilter = {
                 ($Name -eq $script:testName) -and `
@@ -834,8 +872,7 @@ InModuleScope CosmosDB {
 
             Mock `
                 -CommandName Get-CosmosDbAccount `
-                -MockWith { $script:mockGetAzureRmResource } `
-                -Verifiable
+                -MockWith { $script:mockGetAzureRmResource }
 
             It 'Should not throw exception' {
                 $setCosmosDbAccountParameters = @{
@@ -851,59 +888,69 @@ InModuleScope CosmosDB {
                 { $script:result = Set-CosmosDbAccount @setCosmosDbAccountParameters } | Should -Not -Throw
             }
 
-            Context 'When called with a Location and DefaultConsistencyLevel specified' {
-                $script:result = $null
-                $testCosmosDBProperties = @{
-                    databaseAccountOfferType = 'Standard'
-                    locations                = @(
-                        @{
-                            locationName     = $script:testLocation
-                            failoverPriority = 0
-                        }
-                    )
-                    consistencyPolicy        = @{
-                        defaultConsistencyLevel = $script:testConsistencyLevel
-                        maxIntervalInSeconds    = 5
-                        maxStalenessPrefix      = 100
-                    }
-                    ipRangeFilter            = ''
-                }
-
-                $setAzurRmResource_parameterFilter = {
-                    ($ResourceType -eq 'Microsoft.DocumentDb/databaseAccounts') -and `
-                    ($ApiVersion -eq '2015-04-08') -and `
-                    ($Name -eq $script:testName) -and `
-                    ($ResourceGroupName -eq $script:testResourceGroupName) -and `
-                    ($Force -eq $true) -and `
-                    (ConvertTo-Json -InputObject $Properties) -eq (ConvertTo-Json -InputObject $testCosmosDBProperties)
-                }
-
-                Mock `
+            It 'Should call expected mocks' {
+                Assert-MockCalled `
                     -CommandName Set-AzureRmResource `
-                    -MockWith { 'Account' } `
-                    -Verifiable
+                    -ParameterFilter $setAzurRmResource_parameterFilter `
+                    -Exactly -Times 1
 
-                $getCosmosDbAccount_parameterFilter = {
-                    ($Name -eq $script:testName) -and `
-                    ($ResourceGroupName -eq $script:testResourceGroupName)
-                }
-
-                Mock `
+                Assert-MockCalled `
                     -CommandName Get-CosmosDbAccount `
-                    -MockWith { $script:mockGetAzureRmResource } `
-                    -Verifiable
+                    -ParameterFilter $getCosmosDbAccount_parameterFilter `
+                    -Exactly -Times 1
+            }
+        }
 
-                It 'Should not throw exception' {
-                    $setCosmosDbAccountParameters = @{
-                        Name                    = $script:testName
-                        ResourceGroupName       = $script:testResourceGroupName
-                        Location                = $script:testLocation
-                        DefaultConsistencyLevel = $script:testConsistencyLevel
-                        Verbose                 = $true
+        Context 'When called with a Location and DefaultConsistencyLevel specified' {
+            $script:result = $null
+            $testCosmosDBProperties = @{
+                databaseAccountOfferType = 'Standard'
+                locations                = @(
+                    @{
+                        locationName     = $script:testLocation
+                        failoverPriority = 0
                     }
-
-                    { $script:result = Set-CosmosDbAccount @setCosmosDbAccountParameters } | Should -Not -Throw
+                )
+                consistencyPolicy        = @{
+                    defaultConsistencyLevel = $script:testConsistencyLevel
+                    maxIntervalInSeconds    = 5
+                    maxStalenessPrefix      = 100
                 }
+                ipRangeFilter            = ''
+            }
+
+            $setAzurRmResource_parameterFilter = {
+                ($ResourceType -eq 'Microsoft.DocumentDb/databaseAccounts') -and `
+                ($ApiVersion -eq '2015-04-08') -and `
+                ($ResourceName -eq $script:testName) -and `
+                ($ResourceGroupName -eq $script:testResourceGroupName) -and `
+                ($Force -eq $true) -and `
+                (ConvertTo-Json -InputObject $Properties) -eq (ConvertTo-Json -InputObject $testCosmosDBProperties)
+            }
+
+            Mock `
+                -CommandName Set-AzureRmResource `
+                -MockWith { 'Account' }
+
+            $getCosmosDbAccount_parameterFilter = {
+                ($Name -eq $script:testName) -and `
+                ($ResourceGroupName -eq $script:testResourceGroupName)
+            }
+
+            Mock `
+                -CommandName Get-CosmosDbAccount `
+                -MockWith { $script:mockGetAzureRmResource }
+
+            It 'Should not throw exception' {
+                $setCosmosDbAccountParameters = @{
+                    Name                    = $script:testName
+                    ResourceGroupName       = $script:testResourceGroupName
+                    Location                = $script:testLocation
+                    DefaultConsistencyLevel = $script:testConsistencyLevel
+                    Verbose                 = $true
+                }
+
+                { $script:result = Set-CosmosDbAccount @setCosmosDbAccountParameters } | Should -Not -Throw
             }
 
             It 'Should return expected result' {
@@ -911,7 +958,15 @@ InModuleScope CosmosDB {
             }
 
             It 'Should call expected mocks' {
-                Assert-VerifiableMock
+                Assert-MockCalled `
+                    -CommandName Set-AzureRmResource `
+                    -ParameterFilter $setAzurRmResource_parameterFilter `
+                    -Exactly -Times 1
+
+                Assert-MockCalled `
+                    -CommandName Get-CosmosDbAccount `
+                    -ParameterFilter $getCosmosDbAccount_parameterFilter `
+                    -Exactly -Times 1
             }
         }
 
@@ -936,7 +991,7 @@ InModuleScope CosmosDB {
             $setAzurRmResource_parameterFilter = {
                 ($ResourceType -eq 'Microsoft.DocumentDb/databaseAccounts') -and `
                 ($ApiVersion -eq '2015-04-08') -and `
-                ($Name -eq $script:testName) -and `
+                ($ResourceName -eq $script:testName) -and `
                 ($ResourceGroupName -eq $script:testResourceGroupName) -and `
                 ($Force -eq $true) -and `
                 (ConvertTo-Json -InputObject $Properties) -eq (ConvertTo-Json -InputObject $testCosmosDBProperties)
@@ -959,14 +1014,26 @@ InModuleScope CosmosDB {
 
             It 'Should not throw exception' {
                 $setCosmosDbAccountParameters = @{
-                    Name                    = $script:testName
-                    ResourceGroupName       = $script:testResourceGroupName
-                    Location                = $script:testLocation
-                    MaxIntervalInSeconds    = $script:testMaxIntervalInSeconds
-                    Verbose                 = $true
+                    Name                 = $script:testName
+                    ResourceGroupName    = $script:testResourceGroupName
+                    Location             = $script:testLocation
+                    MaxIntervalInSeconds = $script:testMaxIntervalInSeconds
+                    Verbose              = $true
                 }
 
                 { $script:result = Set-CosmosDbAccount @setCosmosDbAccountParameters } | Should -Not -Throw
+            }
+
+            It 'Should call expected mocks' {
+                Assert-MockCalled `
+                    -CommandName Set-AzureRmResource `
+                    -ParameterFilter $setAzurRmResource_parameterFilter `
+                    -Exactly -Times 1
+
+                Assert-MockCalled `
+                    -CommandName Get-CosmosDbAccount `
+                    -ParameterFilter $getCosmosDbAccount_parameterFilter `
+                    -Exactly -Times 1
             }
         }
     }
@@ -982,14 +1049,13 @@ InModuleScope CosmosDB {
             $removeAzurRmResource_parameterFilter = {
                 ($ResourceType -eq 'Microsoft.DocumentDb/databaseAccounts') -and `
                 ($ApiVersion -eq '2015-04-08') -and `
-                ($Name -eq $script:testName) -and `
+                ($ResourceName -eq $script:testName) -and `
                 ($ResourceGroupName -eq $script:testResourceGroupName) -and `
                 ($Force -eq $true)
             }
 
             Mock `
-                -CommandName Remove-AzureRmResource `
-                -Verifiable
+                -CommandName Remove-AzureRmResource
 
             It 'Should not throw exception' {
                 $removeCosmosDbAccountParameters = @{
@@ -1003,7 +1069,10 @@ InModuleScope CosmosDB {
             }
 
             It 'Should call expected mocks' {
-                Assert-VerifiableMock
+                Assert-MockCalled `
+                    -CommandName Remove-AzureRmResource `
+                    -ParameterFilter $removeAzurRmResource_parameterFilter `
+                    -Exactly -Times 1
             }
         }
 
@@ -1013,15 +1082,14 @@ InModuleScope CosmosDB {
             $removeAzurRmResource_parameterFilter = {
                 ($ResourceType -eq 'Microsoft.DocumentDb/databaseAccounts') -and `
                 ($ApiVersion -eq '2015-04-08') -and `
-                ($Name -eq $script:testName) -and `
+                ($ResourceName -eq $script:testName) -and `
                 ($ResourceGroupName -eq $script:testResourceGroupName) -and `
                 ($AsJob -eq $true) -and `
                 ($Force -eq $true)
             }
 
             Mock `
-                -CommandName Remove-AzureRmResource `
-                -Verifiable
+                -CommandName Remove-AzureRmResource
 
             It 'Should not throw exception' {
                 $removeCosmosDbAccountParameters = @{
@@ -1036,7 +1104,54 @@ InModuleScope CosmosDB {
             }
 
             It 'Should call expected mocks' {
-                Assert-VerifiableMock
+                Assert-MockCalled `
+                    -CommandName Remove-AzureRmResource `
+                    -ParameterFilter $removeAzurRmResource_parameterFilter `
+                    -Exactly -Times 1
+            }
+        }
+    }
+
+    Describe 'Get-CosmosDbAccountConnectionString' -Tag 'Unit' {
+        It 'Should exist' {
+            { Get-Command -Name Get-CosmosDbAccountConnectionString -ErrorAction Stop } | Should -Not -Throw
+        }
+
+        Context 'When called with a Name and ResourceGroupName' {
+            $script:result = $null
+
+            $invokeAzureRmResourceAction_parameterFilter = {
+                ($ResourceType -eq 'Microsoft.DocumentDb/databaseAccounts') -and `
+                ($ApiVersion -eq '2015-04-08') -and `
+                ($ResourceName -eq $script:testName) -and `
+                ($ResourceGroupName -eq $script:testResourceGroupName) -and `
+                ($Action -eq 'listConnectionStrings') -and `
+                ($Force -eq $true)
+            }
+
+            Mock `
+                -CommandName Invoke-AzureRmResourceAction `
+                -MockWith { 'ConnectionString' }
+
+            It 'Should not throw exception' {
+                $getCosmosDbAccountConnectionStringParameters = @{
+                    Name              = $script:testName
+                    ResourceGroupName = $script:testResourceGroupName
+                    Verbose           = $true
+                }
+
+                { $script:result = Get-CosmosDbAccountConnectionString @getCosmosDbAccountConnectionStringParameters } | Should -Not -Throw
+            }
+
+            It 'Should return expected result' {
+                $script:result | Should -Be 'ConnectionString'
+            }
+
+            It 'Should call expected mocks' {
+                Assert-MockCalled `
+                    -CommandName Invoke-AzureRmResourceAction `
+                    -ParameterFilter $invokeAzureRmResourceAction_parameterFilter `
+                    -Exactly -Times 1
             }
         }
     }

--- a/test/CosmosDB.integration.Tests.ps1
+++ b/test/CosmosDB.integration.Tests.ps1
@@ -215,6 +215,18 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
         }
     }
 
+    Context 'When getting the new Azure Cosmos DB Account Connection Strings' {
+        It 'Should not throw an exception' {
+            $script:result = Get-CosmosDbAccountConnectionString `
+                -Name $script:testAccountName `
+                -ResourceGroupName $script:testResourceGroupName `
+                -Verbose
+        }
+
+        It 'Should return expected object' {
+        }
+    }
+
     Context 'When creating a new context from Azure using the PrimaryMasterKey Key' {
         It 'Should not throw an exception' {
             $script:testContext = New-CosmosDbContext `


### PR DESCRIPTION
This PR adds the `Get-CosmosDbAccountConnectionString` function. However, this function does not currently return anything due to a bug in the Microsoft/DocumentDB Provider in Azure. See [this issue](https://github.com/Azure/azure-powershell/issues/3650).

The function will display a warning stating that this function does not currently return the connection strings as expected.

I will leave issue #163 open until this is fixed.

# Improvements / Enhancements

- Enhancement #163

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plagueho/cosmosdb/187)
<!-- Reviewable:end -->
