### PR TITLE
Renamed ResourceGroup parameter to ResourceGroupName in New-CosmosDBContext - Fixes #158

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Renamed `ResourceGroup` parameter to `ResourceGroupName` in
   `New-CosmosDbContext` function - fixes [Issue #158](https://github.com/PlagueHO/CosmosDB/issues/158).
+- Correct `*-CosmosDbAccount` functions examples in README.MD to show
+  `ResourceGroupName` parameter.
 
 ## 2.1.10.103
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+- Renamed `ResourceGroup` parameter to `ResourceGroupName` in
+  `New-CosmosDbContext` function - fixes [Issue #158](https://github.com/PlagueHO/CosmosDB/issues/158).
+
 ## 2.1.10.103
 
 - Added support for creating and updating documents containing

--- a/README.md
+++ b/README.md
@@ -90,14 +90,14 @@ This module supports the following:
 
 - Windows PowerShell 5.x:
   - **AzureRM.Profile** and **AzureRM.Resources** PowerShell modules
-    are required if using `New-CosmosDbContext -ResourceGroup $resourceGroup`
+    are required if using `New-CosmosDbContext -ResourceGroupName $resourceGroup`
     or `*-CosmosDbAccount` functions.
 
 or:
 
 - PowerShell Core 6.x:
   - **AzureRM.NetCore.Profile** and **AzureRM.NetCore.Resources** PowerShell
-    modules are required if using `New-CosmosDbContext -ResourceGroup $resourceGroup`
+    modules are required if using `New-CosmosDbContext -ResourceGroupName $resourceGroup`
     or `*-CosmosDbAccount` functions.
 
 ## Installation
@@ -143,7 +143,7 @@ retrieves the primary or secondary key from the Azure Management
 Portal, use the following command:
 
 ```powershell
-$cosmosDbContext = New-CosmosDbContext -Account 'MyAzureCosmosDB' -Database 'MyDatabase' -ResourceGroup 'MyCosmosDbResourceGroup' -MasterKeyType 'SecondaryMasterKey'
+$cosmosDbContext = New-CosmosDbContext -Account 'MyAzureCosmosDB' -Database 'MyDatabase' -ResourceGroupName 'MyCosmosDbResourceGroup' -MasterKeyType 'SecondaryMasterKey'
 ```
 
 _Note: if PowerShell is not connected to Azure then an interactive
@@ -190,13 +190,13 @@ _Note: You must have first logged PowerShell into Azure using the
 Create a new Cosmos DB account in Azure:
 
 ```powershell
-New-CosmosDbAccount -Name 'MyAzureCosmosDB' -ResourceGroup 'MyCosmosDbResourceGroup' -Location 'WestUS'
+New-CosmosDbAccount -Name 'MyAzureCosmosDB' -ResourceGroupName 'MyCosmosDbResourceGroup' -Location 'WestUS'
 ```
 
 Get the properties of an existing Cosmos DB account in Azure:
 
 ```powershell
-Get-CosmosDbAccount -Name 'MyAzureCosmosDB' -ResourceGroup 'MyCosmosDbResourceGroup'
+Get-CosmosDbAccount -Name 'MyAzureCosmosDB' -ResourceGroupName 'MyCosmosDbResourceGroup'
 ```
 
 Get the connection strings used to connect to an existing Cosmos DB
@@ -206,19 +206,19 @@ account in Azure:
 | Provider. See [this issue](https://github.com/Azure/azure-powershell/issues/3650) for more information.
 
 ```powershell
-Get-CosmosDbAccountConnectionString -Name 'MyAzureCosmosDB' -ResourceGroup 'MyCosmosDbResourceGroup'
+Get-CosmosDbAccountConnectionString -Name 'MyAzureCosmosDB' -ResourceGroupName 'MyCosmosDbResourceGroup'
 ```
 
 Update an existing Cosmos DB account in Azure:
 
 ```powershell
-Set-CosmosDbAccount -Name 'MyAzureCosmosDB' -ResourceGroup 'MyCosmosDbResourceGroup' -Location 'WestUS' -DefaultConsistencyLevel 'Strong'
+Set-CosmosDbAccount -Name 'MyAzureCosmosDB' -ResourceGroupName 'MyCosmosDbResourceGroup' -Location 'WestUS' -DefaultConsistencyLevel 'Strong'
 ```
 
 Delete an existing Cosmos DB account in Azure:
 
 ```powershell
-Remove-CosmosDbAccount -Name 'MyAzureCosmosDB' -ResourceGroup 'MyCosmosDbResourceGroup'
+Remove-CosmosDbAccount -Name 'MyAzureCosmosDB' -ResourceGroupName 'MyCosmosDbResourceGroup'
 ```
 
 ### Working with Databases

--- a/docs/New-CosmosDbContext.md
+++ b/docs/New-CosmosDbContext.md
@@ -24,7 +24,7 @@ New-CosmosDbContext -Account <String> [-Database <String>] -Key <SecureString> [
 ### Azure
 
 ```powershell
-New-CosmosDbContext -Account <String> [-Database <String>] -ResourceGroup <String> [-MasterKeyType <String>]
+New-CosmosDbContext -Account <String> [-Database <String>] -ResourceGroupName <String> [-MasterKeyType <String>]
  [-BackoffPolicy <CosmosDB.BackoffPolicy>] [<CommonParameters>]
 ```
 
@@ -70,7 +70,7 @@ Creates a CosmosDB context specifying the master key manually.
 
 ```powershell
 PS C:\> Add-AzureRmAccount
-PS C:\> $cosmosDbContext = New-CosmosDbContext -Account 'MyAzureCosmosDB' -Database 'MyDatabase' -ResourceGroup 'MyCosmosDbResourceGroup' -MasterKeyType 'PrimaryMasterKey'
+PS C:\> $cosmosDbContext = New-CosmosDbContext -Account 'MyAzureCosmosDB' -Database 'MyDatabase' -ResourceGroupName 'MyCosmosDbResourceGroup' -MasterKeyType 'PrimaryMasterKey'
 ```
 
 Creates a Cosmos DB context by logging into Azure and getting
@@ -179,7 +179,7 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -ResourceGroup
+### -ResourceGroupName
 
 This is the name of the Azure Resouce Group containing the
 Cosmos DB.
@@ -187,7 +187,7 @@ Cosmos DB.
 ```yaml
 Type: String
 Parameter Sets: AzureAccount
-Aliases:
+Aliases: ResourceGroup
 
 Required: True
 Position: Named

--- a/src/lib/utils.ps1
+++ b/src/lib/utils.ps1
@@ -96,10 +96,11 @@ function New-CosmosDbContext
         [System.String]
         $KeyType = 'master',
 
+        [Alias("ResourceGroup")]
         [Parameter(Mandatory = $true, ParameterSetName = 'AzureAccount')]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $ResourceGroup,
+        $ResourceGroupName,
 
         [Parameter(ParameterSetName = 'AzureAccount')]
         [ValidateSet('PrimaryMasterKey', 'SecondaryMasterKey', 'PrimaryReadonlyMasterKey', 'SecondaryReadonlyMasterKey')]
@@ -167,7 +168,7 @@ function New-CosmosDbContext
             }
 
             $resource = Invoke-AzureRmResourceAction `
-                -ResourceGroupName $ResourceGroup `
+                -ResourceGroupName $ResourceGroupName `
                 -Name $Account `
                 -ResourceType "Microsoft.DocumentDb/databaseAccounts" `
                 -ApiVersion "2015-04-08" `

--- a/test/Integration/CosmosDB.integration.Tests.ps1
+++ b/test/Integration/CosmosDB.integration.Tests.ps1
@@ -247,7 +247,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
             $script:testContext = New-CosmosDbContext `
                 -Account $script:testAccountName `
                 -Database $script:testDatabase `
-                -ResourceGroup $script:testResourceGroupName `
+                -ResourceGroupName $script:testResourceGroupName `
                 -MasterKeyType 'PrimaryMasterKey'
         }
     }
@@ -257,7 +257,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
             $script:testReadOnlyContext = New-CosmosDbContext `
                 -Account $script:testAccountName `
                 -Database $script:testDatabase `
-                -ResourceGroup $script:testResourceGroupName `
+                -ResourceGroupName $script:testResourceGroupName `
                 -MasterKeyType 'PrimaryReadonlyMasterKey'
         }
     }

--- a/test/Unit/CosmosDB.utils.Tests.ps1
+++ b/test/Unit/CosmosDB.utils.Tests.ps1
@@ -59,7 +59,7 @@ InModuleScope CosmosDB {
         Content = $script:testJson
         Headers = @{ 'x-ms-request-charge' = '5' }
     }
-    $script:testResourceGroup = 'testResourceGroup'
+    $script:testResourceGroupName = 'testResourceGroup'
     $script:testMaxRetries = 20
     $script:testMethod = 'Default'
     $script:testDelay = 1
@@ -240,10 +240,10 @@ console.log("done");
 
             It 'Should not throw exception' {
                 $newCosmosDbContextParameters = @{
-                    Account       = $script:testAccount
-                    Database      = $script:testDatabase
-                    ResourceGroup = $script:testResourceGroup
-                    MasterKeyType = 'PrimaryMasterKey'
+                    Account           = $script:testAccount
+                    Database          = $script:testDatabase
+                    ResourceGroupName = $script:testResourceGroupName
+                    MasterKeyType     = 'PrimaryMasterKey'
                 }
 
                 { $script:result = New-CosmosDbContext @newCosmosDbContextParameters } | Should -Not -Throw
@@ -279,10 +279,10 @@ console.log("done");
 
             It 'Should not throw exception' {
                 $newCosmosDbContextParameters = @{
-                    Account       = $script:testAccount
-                    Database      = $script:testDatabase
-                    ResourceGroup = $script:testResourceGroup
-                    MasterKeyType = 'PrimaryReadonlyMasterKey'
+                    Account           = $script:testAccount
+                    Database          = $script:testDatabase
+                    ResourceGroupName = $script:testResourceGroupName
+                    MasterKeyType     = 'PrimaryReadonlyMasterKey'
                 }
 
                 { $script:result = New-CosmosDbContext @newCosmosDbContextParameters } | Should -Not -Throw
@@ -321,9 +321,9 @@ console.log("done");
 
             It 'Should not throw exception' {
                 $newCosmosDbContextParameters = @{
-                    Account       = $script:testAccount
-                    Database      = $script:testDatabase
-                    ResourceGroup = $script:testResourceGroup
+                    Account           = $script:testAccount
+                    Database          = $script:testDatabase
+                    ResourceGroupName = $script:testResourceGroupName
                 }
 
                 { $script:result = New-CosmosDbContext @newCosmosDbContextParameters } | Should -Not -Throw
@@ -761,8 +761,8 @@ console.log("done");
         Context 'When called with Get method and ResourceType is ''colls'' and a resource token context without matching token and no master key' {
             $InvokeWebRequest_parameterfilter = {
                 $Method -eq 'Get' -and `
-                $ContentType -eq 'application/json' -and `
-                $Uri -eq ('{0}dbs/{1}/colls/{2}' -f $script:testContext.BaseUri, $script:testContext.Database, 'anotherCollection')
+                    $ContentType -eq 'application/json' -and `
+                    $Uri -eq ('{0}dbs/{1}/colls/{2}' -f $script:testContext.BaseUri, $script:testContext.Database, 'anotherCollection')
             }
 
             Mock `
@@ -799,8 +799,8 @@ console.log("done");
         Context 'When called with context parameter and Post method' {
             $InvokeWebRequest_parameterfilter = {
                 $Method -eq 'Post' -and `
-                $ContentType -eq 'application/query+json' -and `
-                $Uri -eq ('{0}dbs/{1}/{2}' -f $script:testContext.BaseUri, $script:testContext.Database, 'users')
+                    $ContentType -eq 'application/query+json' -and `
+                    $Uri -eq ('{0}dbs/{1}/{2}' -f $script:testContext.BaseUri, $script:testContext.Database, 'users')
             }
 
             Mock `
@@ -838,8 +838,8 @@ console.log("done");
         Context 'When called with context parameter and Post method and Encoding set to UTF-8' {
             $InvokeWebRequest_parameterfilter = {
                 $Method -eq 'Post' -and `
-                $ContentType -eq 'application/json; charset=UTF-8' -and `
-                $Uri -eq ('{0}dbs/{1}/colls/{2}/docs' -f $script:testContext.BaseUri, $script:testContext.Database, 'anotherCollection')
+                    $ContentType -eq 'application/json; charset=UTF-8' -and `
+                    $Uri -eq ('{0}dbs/{1}/colls/{2}/docs' -f $script:testContext.BaseUri, $script:testContext.Database, 'anotherCollection')
             }
 
             Mock `


### PR DESCRIPTION
This PR renames the ResourceGroup parameter to ResourceGroupName in the New-CosmosDBContext function. This is to enable consistency with Azure PowerShell modules.