### PR TITLE
Added support for UniqueKeyPolicy in Collections - Fixes #197

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+- Added support for setting Collection uniqueKeyPolicy in
+  `New-CosmosDbCollection` and `Set-CosmosDbCollection` - fixes [Issue #197](https://github.com/PlagueHO/CosmosDB/issues/197).
+
 ## 2.1.11.130
 
 - Renamed `ResourceGroup` parameter to `ResourceGroupName` in

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@
   - [Working with Collections](#working-with-collections)
     - [Creating a Collection with a custom Indexing Policy](#creating-a-collection-with-a-custom-indexing-policy)
     - [Update an existing Collection with a new Indexing Policy](#update-an-existing-collection-with-a-new-indexing-policy)
+    - [Creating a Collection with a custom Unique Key Policy](#creating-a-collection-with-a-custom-unique-key-policy)
+    - [Update an existing Collection with a new Unique Key Policy](#update-an-existing-collection-with-a-new-unique-key-policy)
   - [Working with Documents](#working-with-documents)
     - [Working with Documents in a Partitioned Collection](#working-with-documents-in-a-partitioned-collection)
   - [Using Resource Authorization Tokens](#using-resource-authorization-tokens)
@@ -357,7 +359,41 @@ and then applying it using the `Set-CosmosDbCollection` function:
 $indexStringRange = New-CosmosDbCollectionIncludedPathIndex -Kind Range -DataType String -Precision -1
 $indexIncludedPath = New-CosmosDbCollectionIncludedPath -Path '/*' -Index $indexStringRange
 $indexingPolicy = New-CosmosDbCollectionIndexingPolicy -Automatic $true -IndexingMode Consistent -IncludedPath $indexIncludedPath
-Set-CosmosDbCollection -Context $cosmosDbContext -Id 'MyNewCollection' -IndexingPolicy $indexingPolicy
+Set-CosmosDbCollection -Context $cosmosDbContext -Id 'MyExistingCollection' -IndexingPolicy $indexingPolicy
+```
+
+#### Creating a Collection with a custom Unique Key Policy
+
+You can create a collection with a custom unique key policy by assembling
+a Unique Key Policy object using the functions:
+
+- `New-CosmosDbCollectionUniqueKey`
+- `New-CosmosDbCollectionUniqueKeyPolicy`
+
+For example, to create a unique key policy that contains two unique keys,
+with the first unique key combining '/name' and '/address' and the second
+unique key is set to '/email'.
+
+```powershell
+$uniqueKeyNameAddress = New-CosmosDbCollectionUniqueKey -Path '/name', '/address'
+$uniqueKeyEmail = New-CosmosDbCollectionUniqueKey -Path '/email'
+$uniqueKeyPolicy = New-CosmosDbCollectionUniqueKeyPolicy -UniqueKey $uniqueKeyNameAddress, $uniqueKeyEmail
+New-CosmosDbCollection -Context $cosmosDbContext -Id 'MyNewCollection' -PartitionKey 'account' -UniqueKeyPolicy $uniqueKeyPolicy
+```
+
+For more information on how Cosmos DB indexes documents, see [this page](https://docs.microsoft.com/en-us/azure/cosmos-db/unique-keys).
+
+#### Update an existing Collection with a new Unique Key Policy
+
+You can update an existing collection with a custom unique key policy by
+assembling a Unique Key Policy using the method in the previous section
+and then applying it using the `Set-CosmosDbCollection` function:
+
+```powershell
+$uniqueKeyNameAddress = New-CosmosDbCollectionUniqueKey -Path '/name', '/address'
+$uniqueKeyEmail = New-CosmosDbCollectionUniqueKey -Path '/email'
+$uniqueKeyPolicy = New-CosmosDbCollectionUniqueKeyPolicy -UniqueKey $uniqueKeyNameAddress, $uniqueKeyEmail
+Set-CosmosDbCollection -Context $cosmosDbContext -Id 'MyExistingCollection' -IndexingPolicy $indexingPolicy
 ```
 
 ### Working with Documents

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## What is New in CosmosDB Unreleased
+
+October 30, 2018
+
+- Added support for setting Collection uniqueKeyPolicy in
+  `New-CosmosDbCollection` and `Set-CosmosDbCollection` - fixes [Issue #197](https://github.com/PlagueHO/CosmosDB/issues/197).
+
 ## What is New in CosmosDB 2.1.11.130
 
 October 27, 2018

--- a/docs/CosmosDB.md
+++ b/docs/CosmosDB.md
@@ -162,6 +162,17 @@ added to an Indexing Policy.
 Creates an indexing policy included path index object that
 can be added to an Included Path of an Indexing Policy.
 
+### [New-CosmosDbCollectionUniqueKey](New-CosmosDbCollectionUniqueKey.md)
+
+Creates a unique key object that can be passed to the
+New-CosmosDbCollectionUniqueKeyPolicy function when generating a unique key
+policy.
+
+### [New-CosmosDbCollectionUniqueKeyPolicy](New-CosmosDbCollectionUniqueKeyPolicy.md)
+
+Creates a unique key policy object that can be passed to the
+New-CosmosDbCollection function.
+
 ### [New-CosmosDbCollectionIndexingPolicy](New-CosmosDbCollectionIndexingPolicy.md)
 
 Creates an indexing policy object that can be passed to the

--- a/docs/New-CosmosDbCollection.md
+++ b/docs/New-CosmosDbCollection.md
@@ -18,7 +18,8 @@ Create a new collection in a Cosmos DB database.
 ```powershell
 New-CosmosDbCollection -Context <Context> [-Key <SecureString>] [-KeyType <String>] [-Database <String>]
  -Id <String> [-OfferThroughput <Int32>] [-OfferType <String>] [-PartitionKey <String>]
- [-IndexingPolicy <Policy>] [-DefaultTimeToLive <Int32>] [<CommonParameters>]
+ [-IndexingPolicy <CosmosDB.IndexingPolicy.Policy>] [-DefaultTimeToLive <Int32>]
+ [-UniqueKeyPolicy <CosmosDB.UniqueKeyPolicy.Policy>] [<CommonParameters>]
 ```
 
 ### Account
@@ -26,7 +27,8 @@ New-CosmosDbCollection -Context <Context> [-Key <SecureString>] [-KeyType <Strin
 ```powershell
 New-CosmosDbCollection -Account <String> [-Key <SecureString>] [-KeyType <String>] [-Database <String>]
  -Id <String> [-OfferThroughput <Int32>] [-OfferType <String>] [-PartitionKey <String>]
- [-IndexingPolicy <Policy>] [-DefaultTimeToLive <Int32>] [<CommonParameters>]
+ [-IndexingPolicy <CosmosDB.IndexingPolicy.Policy>] [-DefaultTimeToLive <Int32>]
+ [-UniqueKeyPolicy <CosmosDB.UniqueKeyPolicy.Policy>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -220,7 +222,7 @@ This is an Indexing Policy object that was created by the
 New-CosmosDbCollectionIndexingPolicy function.
 
 ```yaml
-Type: Policy
+Type: CosmosDB.IndexingPolicy.Policy
 Parameter Sets: (All)
 Aliases:
 
@@ -239,6 +241,23 @@ set to -1 then the default time to live will be infinite.
 
 ```yaml
 Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -UniqueKeyPolicy
+
+This is a Unique Key Policy object that was created by the
+New-CosmosDbCollectionUniquePolicy function.
+
+```yaml
+Type: CosmosDB.UniqueKeyPolicy.Policy
 Parameter Sets: (All)
 Aliases:
 

--- a/docs/New-CosmosDbCollectionUniqueKey.md
+++ b/docs/New-CosmosDbCollectionUniqueKey.md
@@ -1,0 +1,76 @@
+---
+external help file: CosmosDB-help.xml
+Module Name: CosmosDB
+online version:
+schema: 2.0.0
+---
+
+# New-CosmosDbCollectionUniqueKey
+
+## SYNOPSIS
+
+Creates a unique key object that can be passed to the
+New-CosmosDbCollectionUniqueKeyPolicy function when generating a unique key
+policy.
+
+## SYNTAX
+
+```powershell
+New-CosmosDbCollectionUniqueKey [-Path] <String[]> [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+This function will return an unique key object that can be passed to the
+New-CosmosDbCollectionUniqueKeyPolicy function to create a custom unique key
+policy.
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+PS C:\> $uniqueKeyNameAddress = New-CosmosDbCollectionUniqueKey -Path '/name', '/address'
+PS C:\> $uniqueKeyEmail = New-CosmosDbCollectionUniqueKey -Path '/email'
+PS C:\> $uniqueKeyPolicy = New-CosmosDbCollectionUniqueKeyPolicy -UniqueKey $uniqueKeyNameAddress, $uniqueKeyEmail
+PS C:\> New-CosmosDbCollection -Context $cosmosDbContext -Id 'MyNewCollection' -PartitionKey 'account' -UniqueKeyPolicy $uniqueKeyPolicy
+```
+
+Create a new collection with a custom unique key policy with two unique
+keys. The first unique key combines '/name' and '/address' and the second
+unique key is set to '/email'.
+
+## PARAMETERS
+
+### -Path
+
+The paths to include in the unique key.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### CosmosDB.UniqueKeyPolicy.UniqueKey
+
+## NOTES
+
+## RELATED LINKS

--- a/docs/New-CosmosDbCollectionUniqueKeyPolicy.md
+++ b/docs/New-CosmosDbCollectionUniqueKeyPolicy.md
@@ -1,0 +1,76 @@
+---
+external help file: CosmosDB-help.xml
+Module Name: CosmosDB
+online version:
+schema: 2.0.0
+---
+
+# New-CosmosDbCollectionUniqueKeyPolicy
+
+## SYNOPSIS
+
+Creates a unique key policy object that can be passed to the
+New-CosmosDbCollection function.
+
+## SYNTAX
+
+```powershell
+New-CosmosDbCollectionUniqueKeyPolicy [-UniqueKey] <CosmosDB.UniqueKeyPolicy.UniqueKey[]> [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+This function will return an unique key policy object that can
+be passed to the New-CosmosDbCollection function to configure
+custom unique key policies on a collection.
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+PS C:\> $uniqueKeyNameAddress = New-CosmosDbCollectionUniqueKey -Path '/name', '/address'
+PS C:\> $uniqueKeyEmail = New-CosmosDbCollectionUniqueKey -Path '/email'
+PS C:\> $uniqueKeyPolicy = New-CosmosDbCollectionUniqueKeyPolicy -UniqueKey $uniqueKeyNameAddress, $uniqueKeyEmail
+PS C:\> New-CosmosDbCollection -Context $cosmosDbContext -Id 'MyNewCollection' -PartitionKey 'account' -UniqueKeyPolicy $uniqueKeyPolicy
+```
+
+Create a new collection with a custom unique key policy with two unique
+keys. The first unique key combines '/name' and '/address' and the second
+unique key is set to '/email'.
+
+## PARAMETERS
+
+### -UniqueKey
+
+The array containing unique keys that will be enforced in the policy.
+The New-CosmosDbCollectionUniqueKey function should be used to generate the unique key.
+
+```yaml
+Type: CosmosDB.UniqueKeyPolicy.UniqueKey[]
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### CosmosDB.UniqueKeyPolicy.Policy
+
+## NOTES
+
+## RELATED LINKS

--- a/docs/Set-CosmosDbCollection.md
+++ b/docs/Set-CosmosDbCollection.md
@@ -17,14 +17,16 @@ Update an existing collection in a Cosmos DB database.
 
 ```powershell
 Set-CosmosDbCollection -Context <Context> [-Key <SecureString>] [-KeyType <String>] [-Database <String>]
- -Id <String> [-IndexingPolicy <Policy>] [-DefaultTimeToLive <Int32>] [-RemoveDefaultTimeToLive <Switch>] [<CommonParameters>]
+ -Id <String> [-IndexingPolicy <CosmosDB.IndexingPolicy.Policy>] [-DefaultTimeToLive <Int32>]
+ [-RemoveDefaultTimeToLive <Switch>] [-UniqueKeyPolicy <CosmosDB.UniqueKeyPolicy.Policy>] [<CommonParameters>]
 ```
 
 ### Account
 
 ```powershell
 Set-CosmosDbCollection -Account <String> [-Key <SecureString>] [-KeyType <String>] [-Database <String>]
- -Id <String> [-IndexingPolicy <Policy>] [-DefaultTimeToLive <Int32>] [-RemoveDefaultTimeToLive <Switch>] [<CommonParameters>]
+ -Id <String> [-IndexingPolicy <CosmosDB.IndexingPolicy.Policy>] [-DefaultTimeToLive <Int32>]
+ [-RemoveDefaultTimeToLive <Switch>] [-UniqueKeyPolicy <CosmosDB.UniqueKeyPolicy.Policy>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -169,7 +171,7 @@ This is an Indexing Policy object that was created by the
 Set-CosmosDbCollectionIndexingPolicy function.
 
 ```yaml
-Type: Policy
+Type: CosmosDB.IndexingPolicy.Policy
 Parameter Sets: (All)
 Aliases:
 
@@ -207,6 +209,23 @@ parameter is specified.
 
 ```yaml
 Type: Switch
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -UniqueKeyPolicy
+
+This is a Unique Key Policy object that was created by the
+New-CosmosDbCollectionUniquePolicy function.
+
+```yaml
+Type: CosmosDB.UniqueKeyPolicy.Policy
 Parameter Sets: (All)
 Aliases:
 

--- a/src/CosmosDB.psd1
+++ b/src/CosmosDB.psd1
@@ -3,7 +3,7 @@
     RootModule        = 'CosmosDB.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '2.1.11.130'
+    ModuleVersion     = '2.1.12.130'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()
@@ -117,6 +117,8 @@
         'New-CosmosDbCollectionIncludedPath'
         'New-CosmosDbCollectionExcludedPath'
         'New-CosmosDbCollectionIndexingPolicy'
+        'New-CosmosDbCollectionUniqueKey'
+        'New-CosmosDbCollectionUniqueKeyPolicy'
         'New-CosmosDbDatabase'
         'New-CosmosDbDocument'
         'New-CosmosDbContext'
@@ -184,6 +186,13 @@
 
             # ReleaseNotes of this module
             ReleaseNotes = '
+## What is New in CosmosDB Unreleased
+
+October 30, 2018
+
+- Added support for setting Collection uniqueKeyPolicy in
+    `New-CosmosDbCollection` and `Set-CosmosDbCollection` - fixes [Issue #197](https://github.com/PlagueHO/CosmosDB/issues/197).
+
 ## What is New in CosmosDB 2.1.11.130
 
 October 27, 2018

--- a/src/CosmosDB.psm1
+++ b/src/CosmosDB.psm1
@@ -76,6 +76,17 @@ namespace CosmosDB {
             public CosmosDB.IndexingPolicy.Path.ExcludedPath[] excludedPaths;
         }
     }
+
+    namespace UniqueKeyPolicy {
+        public class UniqueKey {
+            public System.String[] paths;
+        }
+
+        public class Policy
+        {
+            public CosmosDB.UniqueKeyPolicy.UniqueKey[] uniqueKeys;
+        }
+    }
 }
 '@
     Add-Type -TypeDefinition $typeDefinition

--- a/test/Integration/CosmosDB.integration.Tests.ps1
+++ b/test/Integration/CosmosDB.integration.Tests.ps1
@@ -44,7 +44,8 @@ $script:testDocumentBody = @"
 {
     `"id`": `"$script:testDocumentId`",
     `"content`": `"Some string`",
-    `"more`": `"Some other string`"
+    `"more`": `"Some other string`",
+    `"uniquekey`": `"$([Guid]::NewGuid().ToString())`"
 }
 "@
 $script:testDocumentUTF8Id = [Guid]::NewGuid().ToString()
@@ -438,13 +439,21 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
         }
     }
 
-    Context 'When creating a new collection' {
+    Context 'When creating a new unique key policy' {
+        It 'Should not throw an exception' {
+            $script:uniqueKey = New-CosmosDbCollectionUniqueKey -Path '/uniquekey'
+            $script:uniqueKeyPolicy = New-CosmosDbCollectionUniqueKeyPolicy -UniqueKey $script:uniqueKey
+        }
+    }
+
+    Context 'When creating a new collection with an IndexingPolicy and UniqueKeyPolicy' {
         It 'Should not throw an exception' {
             $script:result = New-CosmosDbCollection `
                 -Context $script:testContext `
                 -Id $script:testCollection `
                 -OfferThroughput 400 `
                 -IndexingPolicy $script:indexingPolicy `
+                -UniqueKeyPolicy $script:uniqueKeyPolicy `
                 -Verbose
         }
 
@@ -469,10 +478,11 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
             $script:result.indexingPolicy.includedPaths.Indexes[1].Precision | Should -Be 3
             $script:result.indexingPolicy.includedPaths.Indexes[2].DataType | Should -Be 'Point'
             $script:result.indexingPolicy.includedPaths.Indexes[2].Kind | Should -Be 'Spatial'
+            $script:result.uniqueKeyPolicy.uniqueKeys[0].paths[0] | Should -Be '/uniquekey'
         }
     }
 
-    Context 'When getting existing collection' {
+    Context 'When getting existing collection with an IndexingPolicy and UniqueKeyPolicy' {
         It 'Should not throw an exception' {
             $script:result = Get-CosmosDbCollection `
                 -Context $script:testContext `
@@ -501,15 +511,17 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
             $script:result.indexingPolicy.includedPaths.Indexes[1].Precision | Should -Be 3
             $script:result.indexingPolicy.includedPaths.Indexes[2].DataType | Should -Be 'Point'
             $script:result.indexingPolicy.includedPaths.Indexes[2].Kind | Should -Be 'Spatial'
+            $script:result.uniqueKeyPolicy.uniqueKeys[0].paths[0] | Should -Be '/uniquekey'
         }
     }
 
-    Context 'When updating an existing collection' {
+    Context 'When updating an existing collection with an IndexingPolicy and UniqueKeyPolicy' {
         It 'Should not throw an exception' {
             $script:result = Set-CosmosDbCollection `
                 -Context $script:testContext `
                 -Id $script:testCollection `
                 -IndexingPolicy $script:indexingPolicy `
+                -UniqueKeyPolicy $script:uniqueKeyPolicy `
                 -Verbose
         }
 
@@ -534,6 +546,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
             $script:result.indexingPolicy.includedPaths.Indexes[1].Precision | Should -Be 3
             $script:result.indexingPolicy.includedPaths.Indexes[2].DataType | Should -Be 'Point'
             $script:result.indexingPolicy.includedPaths.Indexes[2].Kind | Should -Be 'Spatial'
+            $script:result.uniqueKeyPolicy.uniqueKeys[0].paths[0] | Should -Be '/uniquekey'
         }
     }
 
@@ -1094,7 +1107,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
         }
     }
 
-    Context 'When removing existing collection' {
+    Context 'When removing existing collection with an IndexingPolicy and UniqueKeyPolicy' {
         It 'Should not throw an exception' {
             $script:result = Remove-CosmosDbCollection -Context $script:testContext -Id $script:testCollection -Verbose
         }

--- a/test/Unit/CosmosDB.utils.Tests.ps1
+++ b/test/Unit/CosmosDB.utils.Tests.ps1
@@ -109,6 +109,18 @@ console.log("done");
                 ([System.Management.Automation.PSTypeName]'CosmosDB.IndexingPolicy.Path.ExcludedPath').Type | Should -Be $True
             }
         }
+
+        Context 'CosmosDB.UniqueKeyPolicy.UniqueKey' {
+            It 'Should exist' {
+                ([System.Management.Automation.PSTypeName]'CosmosDB.UniqueKeyPolicy.UniqueKey').Type | Should -Be $True
+            }
+        }
+
+        Context 'CosmosDB.UniqueKeyPolicy.Policy' {
+            It 'Should exist' {
+                ([System.Management.Automation.PSTypeName]'CosmosDB.UniqueKeyPolicy.Policy').Type | Should -Be $True
+            }
+        }
     }
 
     Describe 'New-CosmosDbBackoffPolicy' -Tag 'Unit' {


### PR DESCRIPTION
This PR adds support for creating and updating Unique Key Policies in Cosmos DB collections.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plagueho/cosmosdb/204)
<!-- Reviewable:end -->
