### PR TITLE
Extend Account Name limit to 50 characters - Fixes #241

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+- Extended maximum length of Account Name parameter to be 50 characters - fixes
+  [Issue #201](https://github.com/PlagueHO/CosmosDB/issues/201).
+
 ## 2.1.13.214
 
 - Added new integration tests for testing simple index policies.

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## What is New in CosmosDB Unreleased
+
+November 15, 2018
+
+- Extended maximum length of Account Name parameter to be 50 characters - fixes
+  [Issue #201](https://github.com/PlagueHO/CosmosDB/issues/201).
+
 ## What is New in CosmosDB 2.1.13.214
 
 November 4, 2018

--- a/src/CosmosDB.psd1
+++ b/src/CosmosDB.psd1
@@ -3,7 +3,7 @@
     RootModule        = 'CosmosDB.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '2.1.13.214'
+    ModuleVersion     = '2.1.14.214'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()
@@ -186,6 +186,13 @@
 
             # ReleaseNotes of this module
             ReleaseNotes = '
+## What is New in CosmosDB Unreleased
+
+November 15, 2018
+
+- Extended maximum length of Account Name parameter to be 50 characters - fixes
+    [Issue #201](https://github.com/PlagueHO/CosmosDB/issues/201).
+
 ## What is New in CosmosDB 2.1.13.214
 
 November 4, 2018

--- a/src/en-US/CosmosDB.strings.psd1
+++ b/src/en-US/CosmosDB.strings.psd1
@@ -34,7 +34,7 @@ ConvertFrom-StringData -StringData @'
     ShouldUpdateAzureCosmosDBAccount = Update an Azure Cosmos DB account '{0}' in resource group '{1}'
     ShouldRemoveAzureCosmosDBAccount = Remove the Azure Cosmos DB account '{0}' in resource group '{1}'
     GettingAzureCosmosDBAccountConnectionStringWarning = The Get-CosmosDbAccountConnectionString function does not currently work due to an issue with the Microsoft/DocumentDB provider. The connection strings will not be returned.
-    AccountNameInvalid = The Account Name '{0}' is invalid. The name can contain only lowercase letters, numbers and the '-' character, and must be between 3 and 31 characters.
+    AccountNameInvalid = The Account Name '{0}' is invalid. The name can contain only lowercase letters, numbers and the '-' character, and must be between 3 and 50 characters.
     ResourceGroupNameInvalid = The Resource Group Name '{0}' is invalid. Resource group names only allow alphanumeric characters, periods, underscores, hyphens and parenthesis, cannot end in a period and must be 90 characters or less.
     AttachmentIdInvalid = The Attachment Id '{0}' is invalid. An Attachment Id must not contain characters '\','/','#' or '?', end with a space or be longer than 255 characters.
     CollectionIdInvalid = The Collection Id '{0}' is invalid. A Collection Id must not contain characters '\','/','#' or '?', end with a space or be longer than 255 characters.

--- a/src/lib/accounts/Assert-CosmosDbAccountNameValid.ps1
+++ b/src/lib/accounts/Assert-CosmosDbAccountNameValid.ps1
@@ -20,7 +20,7 @@ function Assert-CosmosDbAccountNameValid
         $ArgumentName = 'Name'
     )
 
-    $matches = [regex]::Match($Name,"[A-Za-z0-9\-]{3,31}")
+    $matches = [regex]::Match($Name,"[A-Za-z0-9\-]{3,50}")
     if ($matches.value -ne $Name)
     {
         New-CosmosDbInvalidArgumentException `

--- a/test/Unit/CosmosDB.accounts.Tests.ps1
+++ b/test/Unit/CosmosDB.accounts.Tests.ps1
@@ -102,14 +102,14 @@ InModuleScope CosmosDB {
             }
         }
 
-        Context 'When called with a 32 character name' {
+        Context 'When called with a 51 character name' {
             It 'Should throw expected exception' {
                 $errorRecord = Get-InvalidArgumentRecord `
-                    -Message ($LocalizedData.AccountNameInvalid -f ('a' * 32)) `
+                    -Message ($LocalizedData.AccountNameInvalid -f ('a' * 51)) `
                     -ArgumentName 'Name'
 
                 {
-                    Assert-CosmosDbAccountNameValid -Name ('a' * 32)
+                    Assert-CosmosDbAccountNameValid -Name ('a' * 51)
                 } | Should -Throw $errorRecord
             }
         }


### PR DESCRIPTION
This PR extends the account name character limit to 50 chars, even though the portal reports the limit as 31 chars. This PR fixes #241.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plagueho/cosmosdb/242)
<!-- Reviewable:end -->
