### PR TITLE
Fix Notes display in Markdown and Index Policy - Fixes #269

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Fix `Notes` display in Readme Markdown - fixes [Issue #269](https://github.com/PlagueHO/CosmosDB/issues/269).
 - Update `cosmosdb.psdepend.psd1` to install modules `Az` 1.2.1 and
   `Pester` 4.7.0.
+- Deprecate `Hash` index policy kind and throw exception when used
+  in `New-CosmosDbCollectionIncludedPathIndex`. See [this page](https://docs.microsoft.com/en-us/azure/cosmos-db/index-types#index-kind)
+  for more information - fixes [Issue #271](https://github.com/PlagueHO/CosmosDB/issues/271).
 
 ## 3.1.0.289
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Convert module name to be a variable in PSake file to make it more
   easily portable between projects.
 - Fix `Notes` display in Readme Markdown - fixes [Issue #269](https://github.com/PlagueHO/CosmosDB/issues/269).
+- Change `cosmosdb.psdepend.psd1` to install `Az.Accounts` and
+  `Az.Resources` modules instead of the entire `Az` module suite.
 
 ## 3.1.0.289
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Convert module name to be a variable in PSake file to make it more
   easily portable between projects.
+- Fix `Notes` display in Readme Markdown - fixes [Issue #269](https://github.com/PlagueHO/CosmosDB/issues/269).
 
 ## 3.1.0.289
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@
 - Convert module name to be a variable in PSake file to make it more
   easily portable between projects.
 - Fix `Notes` display in Readme Markdown - fixes [Issue #269](https://github.com/PlagueHO/CosmosDB/issues/269).
-- Change `cosmosdb.psdepend.psd1` to install `Az.Accounts` and
-  `Az.Resources` modules instead of the entire `Az` module suite.
+- Change `cosmosdb.psdepend.psd1` to install modules `Az` 1.2.1.
 
 ## 3.1.0.289
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 - Convert module name to be a variable in PSake file to make it more
   easily portable between projects.
 - Fix `Notes` display in Readme Markdown - fixes [Issue #269](https://github.com/PlagueHO/CosmosDB/issues/269).
-- Change `cosmosdb.psdepend.psd1` to install modules `Az` 1.2.1.
+- Update `cosmosdb.psdepend.psd1` to install modules `Az` 1.2.1 and
+  `Pester` 4.7.0.
 
 ## 3.1.0.289
 

--- a/README.md
+++ b/README.md
@@ -78,11 +78,11 @@ This module requires the following:
     are required if using `New-CosmosDbContext -ResourceGroupName $resourceGroup`
     or `*-CosmosDbAccount` functions.
 
-| Note: As of 3.0.0.0 of the CosmosDB module, support for **AzureRm** and
-| **AzureRm.NetCore** PowerShell modules has been deprecated due to being
-| superceeded by the **Az** modules. If it is a requirement that **AzureRm**
-| or **AzureRm.NetCore** modules are used then you will need to remain on
-| CosmosDB module 2.x.
+> Note: As of 3.0.0.0 of the CosmosDB module, support for **AzureRm** and
+> **AzureRm.NetCore** PowerShell modules has been deprecated due to being
+> superceeded by the **Az** modules. If it is a requirement that **AzureRm**
+> or **AzureRm.NetCore** modules are used then you will need to remain on
+> CosmosDB module 2.x.
 
 ## Installation
 
@@ -206,8 +206,8 @@ New-CosmosDbAccountMasterKey -Name 'MyAzureCosmosDB' -ResourceGroupName 'MyCosmo
 Get the connection strings used to connect to an existing Cosmos DB
 account in Azure:
 
-| Note: This function is not currently working due to an issue in the Microsoft/DocumentDB
-| Provider. See [this issue](https://github.com/Azure/azure-powershell/issues/3650) for more information.
+> Note: This function is not currently working due to an issue in the Microsoft/DocumentDB
+> Provider. See [this issue](https://github.com/Azure/azure-powershell/issues/3650) for more information.
 
 ```powershell
 Get-CosmosDbAccountConnectionString -Name 'MyAzureCosmosDB' -ResourceGroupName 'MyCosmosDbResourceGroup'

--- a/README.md
+++ b/README.md
@@ -336,13 +336,33 @@ spatial index on the '/*' path using consistent indexing mode with no
 excluded paths:
 
 ```powershell
-$indexStringRange = New-CosmosDbCollectionIncludedPathIndex -Kind Range -DataType String -Precision -1
-$indexNumberRange = New-CosmosDbCollectionIncludedPathIndex -Kind Range -DataType Number -Precision -1
-$indexNumberSpatial = New-CosmosDbCollectionIncludedPathIndex -Kind Spatial -DataType Point
-$indexIncludedPath = New-CosmosDbCollectionIncludedPath -Path '/*' -Index $indexStringRange, $indexNumberRange, $indexNumberSpatial
+$indexStringRange = New-CosmosDbCollectionIncludedPathIndex -Kind Range -DataType String
+$indexNumberRange = New-CosmosDbCollectionIncludedPathIndex -Kind Range -DataType Number
+$indexPointSpatial = New-CosmosDbCollectionIncludedPathIndex -Kind Spatial -DataType Point
+$indexIncludedPath = New-CosmosDbCollectionIncludedPath -Path '/*' -Index $indexStringRange, $indexNumberRange, $indexPointSpatial
 $indexingPolicy = New-CosmosDbCollectionIndexingPolicy -Automatic $true -IndexingMode Consistent -IncludedPath $indexIncludedPath
 New-CosmosDbCollection -Context $cosmosDbContext -Id 'MyNewCollection' -PartitionKey 'account' -IndexingPolicy $indexingPolicy
 ```
+
+> **Important Index Notes**
+>
+> The _Hash_ index Kind is no longer supported by Cosmos DB. An exception will
+> be thrown if an attempt to create one is made.
+> A warning will be displayed if the Hash index Kind is used.
+> The Hash index Kind will be removed in a future BREAKING release of the Cosmos DB module.
+> See [this page](https://docs.microsoft.com/en-us/azure/cosmos-db/index-types#index-kind)
+> for more information.
+>
+> The _Precision_ parameter is no longer supported by Cosmos DB and will be
+> ignored. The maximum precision of -1 will always be used for Range indexes.
+> A warning will be displayed if the Precision parameter is passed.
+> The Precision parameter will be removed in a future BREAKING release of the Cosmos DB module.
+> See [this page](https://docs.microsoft.com/en-us/azure/cosmos-db/index-types#index-precision)
+> for more information.
+>
+> It is recommended to remove the use of the _Hash_ index Kind and any instances of the
+> _Precision_ parameter and any automation or scripts to avoid being affected by
+> future BREAKING CHANGES.
 
 For more information on how Cosmos DB indexes documents, see [this page](https://docs.microsoft.com/en-us/azure/cosmos-db/indexing-policies).
 
@@ -353,7 +373,7 @@ assembling an Indexing Policy using the method in the previous section
 and then applying it using the `Set-CosmosDbCollection` function:
 
 ```powershell
-$indexStringRange = New-CosmosDbCollectionIncludedPathIndex -Kind Range -DataType String -Precision -1
+$indexStringRange = New-CosmosDbCollectionIncludedPathIndex -Kind Range -DataType String
 $indexIncludedPath = New-CosmosDbCollectionIncludedPath -Path '/*' -Index $indexStringRange
 $indexingPolicy = New-CosmosDbCollectionIndexingPolicy -Automatic $true -IndexingMode Consistent -IncludedPath $indexIncludedPath
 Set-CosmosDbCollection -Context $cosmosDbContext -Id 'MyExistingCollection' -IndexingPolicy $indexingPolicy

--- a/README.md
+++ b/README.md
@@ -346,8 +346,7 @@ New-CosmosDbCollection -Context $cosmosDbContext -Id 'MyNewCollection' -Partitio
 
 > **Important Index Notes**
 >
-> The _Hash_ index Kind is no longer supported by Cosmos DB. An exception will
-> be thrown if an attempt to create one is made.
+> The _Hash_ index Kind is no longer supported by Cosmos DB.
 > A warning will be displayed if the Hash index Kind is used.
 > The Hash index Kind will be removed in a future BREAKING release of the Cosmos DB module.
 > See [this page](https://docs.microsoft.com/en-us/azure/cosmos-db/index-types#index-kind)

--- a/cosmosdb.depend.psd1
+++ b/cosmosdb.depend.psd1
@@ -43,7 +43,7 @@
             SkipPublisherCheck = $true
         }
         Target         = 'CurrentUser'
-        Version        = '2.0.7'
+        Version        = '2.0.0'
         Tags           = 'Init'
     }
 

--- a/cosmosdb.depend.psd1
+++ b/cosmosdb.depend.psd1
@@ -71,8 +71,8 @@
         Tags           = 'Build'
     }
 
-    Az                = @{
-        Name           = 'Az'
+    AzAccounts        = @{
+        Name           = 'Az.Accounts'
         DependencyType = 'PSGalleryModule'
         Parameters     = @{
             Repository         = 'PSGallery'
@@ -80,6 +80,18 @@
         }
         Target         = 'CurrentUser'
         Version        = '1.2.1'
+        Tags           = 'Test','Deploy'
+    }
+
+    AzResources       = @{
+        Name           = 'Az.Resources'
+        DependencyType = 'PSGalleryModule'
+        Parameters     = @{
+            Repository         = 'PSGallery'
+            SkipPublisherCheck = $true
+        }
+        Target         = 'CurrentUser'
+        Version        = '1.1.1'
         Tags           = 'Test','Deploy'
     }
 }

--- a/cosmosdb.depend.psd1
+++ b/cosmosdb.depend.psd1
@@ -71,27 +71,15 @@
         Tags           = 'Build'
     }
 
-    AzAccounts = @{
-        Name           = 'Az.Accounts'
+    Az = @{
+        Name           = 'Az'
         DependencyType = 'PSGalleryModule'
         Parameters     = @{
             Repository         = 'PSGallery'
             SkipPublisherCheck = $true
         }
         Target         = 'CurrentUser'
-        Version        = '1.0.0'
-        Tags           = 'Test','Deploy'
-    }
-
-    AzResources = @{
-        Name           = 'Az.Resources'
-        DependencyType = 'PSGalleryModule'
-        Parameters     = @{
-            Repository         = 'PSGallery'
-            SkipPublisherCheck = $true
-        }
-        Target         = 'CurrentUser'
-        Version        = '1.0.0'
+        Version        = '1.2.1'
         Tags           = 'Test','Deploy'
     }
 }

--- a/cosmosdb.depend.psd1
+++ b/cosmosdb.depend.psd1
@@ -71,7 +71,7 @@
         Tags           = 'Build'
     }
 
-    'Az.Accounts' = @{
+    AzAccounts = @{
         Name           = 'Az.Accounts'
         DependencyType = 'PSGalleryModule'
         Parameters     = @{
@@ -83,7 +83,7 @@
         Tags           = 'Test','Deploy'
     }
 
-    'Az.Resources' = @{
+    AzResources = @{
         Name           = 'Az.Resources'
         DependencyType = 'PSGalleryModule'
         Parameters     = @{

--- a/cosmosdb.depend.psd1
+++ b/cosmosdb.depend.psd1
@@ -19,7 +19,7 @@
             SkipPublisherCheck = $true
         }
         Target         = 'CurrentUser'
-        Version        = '4.4.2'
+        Version        = '4.6.0'
         Tags           = 'Test'
     }
 
@@ -43,7 +43,7 @@
             SkipPublisherCheck = $true
         }
         Target         = 'CurrentUser'
-        Version        = '2.0.0'
+        Version        = '2.0.7'
         Tags           = 'Init'
     }
 
@@ -55,7 +55,7 @@
             SkipPublisherCheck = $true
         }
         Target         = 'CurrentUser'
-        Version        = '1.0'
+        Version        = '1.0.1'
         Tags           = 'Deploy'
     }
 
@@ -71,7 +71,7 @@
         Tags           = 'Build'
     }
 
-    Az = @{
+    Az                = @{
         Name           = 'Az'
         DependencyType = 'PSGalleryModule'
         Parameters     = @{

--- a/cosmosdb.depend.psd1
+++ b/cosmosdb.depend.psd1
@@ -71,15 +71,27 @@
         Tags           = 'Build'
     }
 
-    'Az' = @{
-        Name           = 'Az'
+    'Az.Accounts' = @{
+        Name           = 'Az.Accounts'
         DependencyType = 'PSGalleryModule'
         Parameters     = @{
             Repository         = 'PSGallery'
             SkipPublisherCheck = $true
         }
         Target         = 'CurrentUser'
-        Version        = '1.0.1'
+        Version        = '1.0.0'
+        Tags           = 'Test','Deploy'
+    }
+
+    'Az.Resources' = @{
+        Name           = 'Az.Resources'
+        DependencyType = 'PSGalleryModule'
+        Parameters     = @{
+            Repository         = 'PSGallery'
+            SkipPublisherCheck = $true
+        }
+        Target         = 'CurrentUser'
+        Version        = '1.0.0'
         Tags           = 'Test','Deploy'
     }
 }

--- a/docs/New-CosmosDbCollectionIncludedPathIndex.md
+++ b/docs/New-CosmosDbCollectionIncludedPathIndex.md
@@ -63,10 +63,16 @@ Accept wildcard characters: False
 
 ### -Kind
 
-The type of index.
-Hash indexes are useful for equality
-comparisons while Range indexes are useful for equality, range comparisons and sorting.
+The Kind of the index.
+Range indexes are useful for equality, range comparisons and sorting.
 Spatial indexes are useful for spatial queries.
+
+The Hash index Kind is no longer supported by Cosmos DB.
+A warning will be displayed if the Hash index Kind is used.
+The Hash index Kind will be removed in a future BREAKING release of the
+Cosmos DB module.
+See https://docs.microsoft.com/en-us/azure/cosmos-db/index-types#index-kind
+for more information.
 
 ```yaml
 Type: String
@@ -83,10 +89,13 @@ Accept wildcard characters: False
 
 ### -Precision
 
-The precision of the index.
-Can be either set to -1 for maximum precision or between 1-8 for Number, and
-1-100 for String.
-Not applicable for Point, Polygon, and LineString data types.
+The Precision parameter is no longer supported by Cosmos DB and will be
+ignored. The maximum precision of -1 will always be used for Range indexes.
+A warning will be displayed if the Precision parameter is passed.
+The Precision parameter will be removed in a future BREAKING release of the
+Cosmos DB module.
+See https://docs.microsoft.com/en-us/azure/cosmos-db/index-types#index-precision
+for more information.
 
 ```yaml
 Type: Int32

--- a/src/CosmosDB.psd1
+++ b/src/CosmosDB.psd1
@@ -12,7 +12,7 @@
 RootModule = 'CosmosDB.psm1'
 
 # Version number of this module.
-ModuleVersion = '3.1.0.293'
+ModuleVersion = '3.2.0.293'
 
 # Supported PSEditions
 CompatiblePSEditions = 'Core', 'Desktop'

--- a/src/CosmosDB.psm1
+++ b/src/CosmosDB.psm1
@@ -52,11 +52,11 @@ namespace CosmosDB {
             }
 
             public class IndexRange : CosmosDB.IndexingPolicy.Path.Index {
-                public System.Int32 precision;
+                public readonly System.Int32 precision = -1;
             }
 
             public class IndexHash : CosmosDB.IndexingPolicy.Path.Index {
-                public System.Int32 precision;
+                public readonly System.Int32 precision = -1;
             }
 
             public class IndexSpatial : CosmosDB.IndexingPolicy.Path.Index {

--- a/src/en-US/CosmosDB.strings.psd1
+++ b/src/en-US/CosmosDB.strings.psd1
@@ -27,6 +27,8 @@ ConvertFrom-StringData -StringData @'
     ErrorNewCollectionParitionKeyRequired = A 'PartitionKey' is required when the 'OfferThroughput' is greater than 10000.
     ErrorNewCollectionIncludedPathIndexInvalidDataType = The DataType '{1}' is invalid for the included path index Kind '{0}'. Please use one of: {2}.
     ErrorNewCollectionIncludedPathIndexPrecisionNotSupported = A Precision value should not be provided for the index Kind '{0}'.
+    WarningNewCollectionIncludedPathIndexHashDeprecated = The 'Hash' index Kind has been deprecated. Default String and Number 'Range' index Kinds will be used instead. The 'Hash' index Kind will be removed in a future breaking release. See https://docs.microsoft.com/en-us/azure/cosmos-db/index-types#index-kind.
+    WarningNewCollectionIncludedPathIndexPrecisionDeprecated = The index 'Precision' has been deprecated. The maximum precision of -1 will be used. The 'Precision' parameter will be removed in a future breaking release. See https://docs.microsoft.com/en-us/azure/cosmos-db/index-types#index-precision.
     ErrorNewCollectionIndexingPolicyInvalidMode = Automatic must be set to 'False' if Indexing Mode of 'None' is used.
     ErrorSetCollectionRemoveDefaultTimeToLiveConflict = RemoveDefaultTimeToLive parameter must not be set when DefaultTimeToLive is specified.
     ErrorAccountDoesNotExist = Cosmos DB account '{0}' in resource group '{1}' does not exist.

--- a/src/lib/collections/New-CosmosDbCollection.ps1
+++ b/src/lib/collections/New-CosmosDbCollection.ps1
@@ -139,10 +139,6 @@ function New-CosmosDbCollection
 
     $body = ConvertTo-Json -InputObject $bodyObject -Depth 10
 
-    Write-Verbose -Message $body -Verbose
-
-    $global:lastBody = $body
-
     $result = Invoke-CosmosDbRequest @PSBoundParameters `
         -Method 'Post' `
         -ResourceType 'colls' `
@@ -150,8 +146,6 @@ function New-CosmosDbCollection
         -Body $body
 
     $collection = ConvertFrom-Json -InputObject $result.Content
-
-    Write-Verbose -Message (ConvertTo-Json -InputObject $collection -Depth 10) -Verbose
 
     if ($collection)
     {

--- a/src/lib/collections/New-CosmosDbCollection.ps1
+++ b/src/lib/collections/New-CosmosDbCollection.ps1
@@ -139,6 +139,10 @@ function New-CosmosDbCollection
 
     $body = ConvertTo-Json -InputObject $bodyObject -Depth 10
 
+    Write-Verbose -Message $body -Verbose
+
+    $global:lastBody = $body
+
     $result = Invoke-CosmosDbRequest @PSBoundParameters `
         -Method 'Post' `
         -ResourceType 'colls' `
@@ -146,6 +150,8 @@ function New-CosmosDbCollection
         -Body $body
 
     $collection = ConvertFrom-Json -InputObject $result.Content
+
+    Write-Verbose -Message (ConvertTo-Json -InputObject $collection -Depth 10) -Verbose
 
     if ($collection)
     {

--- a/src/lib/collections/New-CosmosDbCollectionIncludedPathIndex.ps1
+++ b/src/lib/collections/New-CosmosDbCollectionIncludedPathIndex.ps1
@@ -25,6 +25,15 @@ function New-CosmosDbCollectionIncludedPathIndex
     {
         'Hash'
         {
+            <#
+                Index Hask kind has been deprecated and will result in default Range indexes
+                being created instead. Hash indexes will be removed in a future breaking
+                release.
+                See https://docs.microsoft.com/en-us/azure/cosmos-db/index-types#index-kind
+            #>
+            Write-Warning `
+                -Message $($LocalizedData.WarningNewCollectionIncludedPathIndexHashDeprecated)
+
             if ($DataType -notin @('String', 'Number'))
             {
                 New-CosmosDbInvalidArgumentException `
@@ -64,9 +73,16 @@ function New-CosmosDbCollectionIncludedPathIndex
     $index = New-Object -TypeName ('CosmosDB.IndexingPolicy.Path.Index' + $Kind)
     $index.Kind = $Kind
     $index.DataType = $DataType
+
     if ($PSBoundParameters.ContainsKey('Precision'))
     {
-        $index.Precision = $Precision
+        <#
+            Index Precision should always be -1 for Range and must not be passed for Spatial.
+            The Precision parameter will be removed in a future breaking release.
+            See https://docs.microsoft.com/en-us/azure/cosmos-db/index-types#index-precision
+        #>
+        Write-Warning `
+            -Message $($LocalizedData.WarningNewCollectionIncludedPathIndexPrecisionDeprecated)
     }
 
     return $index

--- a/test/Integration/CosmosDB.integration.Tests.ps1
+++ b/test/Integration/CosmosDB.integration.Tests.ps1
@@ -503,11 +503,6 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
             $script:result.Id | Should -Be $script:testCollection
             $script:result.indexingPolicy.indexingMode | Should -Be 'Consistent'
             $script:result.indexingPolicy.automatic | Should -Be $true
-            Write-Verbose -Message ($script:result.indexingPolicy.includedPaths.Indexes | Out-String ) -Verbose
-            Write-Verbose -Message (@($script:indexNumberRange, $script:indexStringRange, $script:indexSpatialPoint) | Out-String ) -Verbose
-            Compare-Object `
-                -ReferenceObject $script:result.indexingPolicy.includedPaths.Indexes `
-                -DifferenceObject @($script:indexNumberRange, $script:indexStringRange, $script:indexSpatialPoint) | Should -Be $null
             $script:result.indexingPolicy.includedPaths.Indexes[0].DataType | Should -Be 'Number'
             $script:result.indexingPolicy.includedPaths.Indexes[0].Kind | Should -Be 'Range'
             $script:result.indexingPolicy.includedPaths.Indexes[0].Precision | Should -Be -1

--- a/test/Integration/CosmosDB.integration.Tests.ps1
+++ b/test/Integration/CosmosDB.integration.Tests.ps1
@@ -145,6 +145,98 @@ $null = New-AzureTestCosmosDbResourceGroup `
 $currentIpAddress = (Invoke-RestMethod -Uri 'http://ipinfo.io/json').ip
 
 Describe 'Cosmos DB Module' -Tag 'Integration' {
+    function Test-GenericResult
+    {
+        [CmdletBinding()]
+        param
+        (
+            [Parameter(Mandatory = $true)]
+            [System.Object]
+            $GenericResult
+        )
+
+        $GenericResult.Timestamp | Should -BeOfType [System.DateTime]
+        $GenericResult.Etag | Should -BeOfType [System.String]
+        $GenericResult.ResourceId | Should -BeOfType [System.String]
+        $GenericResult.Uri | Should -BeOfType [System.String]
+    }
+
+    function Test-CollectionResult
+    {
+        [CmdletBinding()]
+        param
+        (
+            [Parameter(Mandatory = $true)]
+            [System.Object]
+            $CollectionResult
+        )
+
+        Test-GenericResult -GenericResult $CollectionResult
+        $CollectionResult.Conflicts | Should -BeOfType [System.String]
+        $CollectionResult.Documents | Should -BeOfType [System.String]
+        $CollectionResult.StoredProcedures | Should -BeOfType [System.String]
+        $CollectionResult.Triggers | Should -BeOfType [System.String]
+        $CollectionResult.UserDefinedFunctions | Should -BeOfType [System.String]
+    }
+
+    function Test-CollectionDefaultIndexingPolicy
+    {
+        [CmdletBinding()]
+        param
+        (
+            [Parameter(Mandatory = $true)]
+            [System.Object]
+            $CollectionResult
+        )
+
+        Test-CollectionResult -CollectionResult $CollectionResult
+        $CollectionResult.indexingPolicy.indexingMode | Should -Be 'Consistent'
+        $CollectionResult.indexingPolicy.automatic | Should -Be $true
+        $CollectionResult.indexingPolicy.includedPaths[0].path | Should -Be '/*'
+        $CollectionResult.indexingPolicy.includedPaths[0].Indexes.Count | Should -Be 2
+        $CollectionResult.indexingPolicy.includedPaths[0].Indexes[0].DataType | Should -Be 'Number'
+        $CollectionResult.indexingPolicy.includedPaths[0].Indexes[0].Kind | Should -Be 'Range'
+        $CollectionResult.indexingPolicy.includedPaths[0].Indexes[0].Precision | Should -Be -1
+        $CollectionResult.indexingPolicy.includedPaths[0].Indexes[1].DataType | Should -Be 'String'
+        $CollectionResult.indexingPolicy.includedPaths[0].Indexes[1].Kind | Should -Be 'Range'
+        $CollectionResult.indexingPolicy.includedPaths[0].Indexes[1].Precision | Should -Be -1
+    }
+
+    function Test-CollectionResultComplexAutomaticIndexingPolicy
+    {
+        [CmdletBinding()]
+        param
+        (
+            [Parameter(Mandatory = $true)]
+            [System.Object]
+            $CollectionResult
+        )
+
+        Test-CollectionResult -CollectionResult $CollectionResult
+        $CollectionResult.indexingPolicy.indexingMode | Should -Be 'Consistent'
+        $CollectionResult.indexingPolicy.automatic | Should -Be $true
+        $CollectionResult.indexingPolicy.includedPaths[0].path | Should -Be '/*'
+        $CollectionResult.indexingPolicy.includedPaths[0].Indexes.Count | Should -Be 3
+        $CollectionResult.indexingPolicy.includedPaths[0].Indexes[0].DataType | Should -Be 'Number'
+        $CollectionResult.indexingPolicy.includedPaths[0].Indexes[0].Kind | Should -Be 'Range'
+        $CollectionResult.indexingPolicy.includedPaths[0].Indexes[0].Precision | Should -Be -1
+        $CollectionResult.indexingPolicy.includedPaths[0].Indexes[1].DataType | Should -Be 'String'
+        $CollectionResult.indexingPolicy.includedPaths[0].Indexes[1].Kind | Should -Be 'Range'
+        $CollectionResult.indexingPolicy.includedPaths[0].Indexes[1].Precision | Should -Be -1
+        $CollectionResult.indexingPolicy.includedPaths[0].Indexes[2].DataType | Should -Be 'Point'
+        $CollectionResult.indexingPolicy.includedPaths[0].Indexes[2].Kind | Should -Be 'Spatial'
+        $CollectionResult.indexingPolicy.includedPaths[1].path | Should -Be '/Location/*'
+        $CollectionResult.indexingPolicy.includedPaths[1].Indexes.Count | Should -Be 3
+        $CollectionResult.indexingPolicy.includedPaths[1].Indexes[0].DataType | Should -Be 'Point'
+        $CollectionResult.indexingPolicy.includedPaths[1].Indexes[0].Kind | Should -Be 'Spatial'
+        $CollectionResult.indexingPolicy.includedPaths[1].Indexes[1].DataType | Should -Be 'Number'
+        $CollectionResult.indexingPolicy.includedPaths[1].Indexes[1].Kind | Should -Be 'Range'
+        $CollectionResult.indexingPolicy.includedPaths[1].Indexes[1].Precision | Should -Be -1
+        $CollectionResult.indexingPolicy.includedPaths[1].Indexes[2].DataType | Should -Be 'String'
+        $CollectionResult.indexingPolicy.includedPaths[1].Indexes[2].Kind | Should -Be 'Range'
+        $CollectionResult.indexingPolicy.includedPaths[1].Indexes[2].Precision | Should -Be -1
+    }
+
     Context 'When creating a new Azure Cosmos DB Account' {
         It 'Should not throw an exception' {
             New-CosmosDbAccount `
@@ -397,10 +489,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
         }
 
         It 'Should return expected object' {
-            $script:result.Timestamp | Should -BeOfType [System.DateTime]
-            $script:result.Etag | Should -BeOfType [System.String]
-            $script:result.ResourceId | Should -BeOfType [System.String]
-            $script:result.Uri | Should -BeOfType [System.String]
+            Test-GenericResult -GenericResult $script:result
             $script:result.Id | Should -Be $script:testUser
             $script:result.Permissions | Should -Be 'permissions/'
         }
@@ -415,60 +504,69 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
         }
 
         It 'Should return expected object' {
-            $script:result.Timestamp | Should -BeOfType [System.DateTime]
-            $script:result.Etag | Should -BeOfType [System.String]
-            $script:result.ResourceId | Should -BeOfType [System.String]
-            $script:result.Uri | Should -BeOfType [System.String]
+            Test-GenericResult -GenericResult $script:result
             $script:result.Id | Should -Be $script:testUser
             $script:result.Permissions | Should -Be 'permissions/'
         }
     }
 
-    Context 'When creating a new simple indexing policy' {
-        It 'Should not throw an exception' {
-            $script:indexingPolicySimple = New-CosmosDbCollectionIndexingPolicy -Automatic $true -IndexingMode Consistent
-        }
-    }
-
-    Context 'When creating a new collection with a simple IndexingPolicy' {
+    Context 'When creating a new collection with no IndexingPolicy' {
         It 'Should not throw an exception' {
             $script:result = New-CosmosDbCollection `
                 -Context $script:testContext `
                 -Id $script:testCollection `
                 -OfferThroughput 400 `
-                -IndexingPolicy $script:indexingPolicySimple `
                 -Verbose
         }
 
         It 'Should return expected object' {
-            $script:result.Timestamp | Should -BeOfType [System.DateTime]
-            $script:result.Etag | Should -BeOfType [System.String]
-            $script:result.ResourceId | Should -BeOfType [System.String]
-            $script:result.Uri | Should -BeOfType [System.String]
-            $script:result.Conflicts | Should -BeOfType [System.String]
-            $script:result.Documents | Should -BeOfType [System.String]
-            $script:result.StoredProcedures | Should -BeOfType [System.String]
-            $script:result.Triggers | Should -BeOfType [System.String]
-            $script:result.UserDefinedFunctions | Should -BeOfType [System.String]
+            Test-CollectionDefaultIndexingPolicy -CollectionResult $script:result
             $script:result.Id | Should -Be $script:testCollection
-            $script:result.indexingPolicy.indexingMode | Should -Be 'Consistent'
-            $script:result.indexingPolicy.automatic | Should -Be $true
         }
     }
 
-    Context 'When removing existing collection with a simple indexing policy' {
+    Context 'When removing existing collection with no indexing policy' {
         It 'Should not throw an exception' {
             $script:result = Remove-CosmosDbCollection -Context $script:testContext -Id $script:testCollection -Verbose
         }
     }
 
-    Context 'When creating a new indexing policy' {
+    Context 'When creating a new simple automatic indexing policy' {
+        It 'Should not throw an exception' {
+            $script:indexingPolicySimpleAutomatic = New-CosmosDbCollectionIndexingPolicy -Automatic $true -IndexingMode Consistent
+        }
+    }
+
+    Context 'When creating a new collection with a simple automatic IndexingPolicy' {
+        It 'Should not throw an exception' {
+            $script:result = New-CosmosDbCollection `
+                -Context $script:testContext `
+                -Id $script:testCollection `
+                -OfferThroughput 400 `
+                -IndexingPolicy $script:indexingPolicySimpleAutomatic `
+                -Verbose
+        }
+
+        It 'Should return expected object' {
+            Test-CollectionDefaultIndexingPolicy -CollectionResult $script:result
+            $script:result.Id | Should -Be $script:testCollection
+        }
+    }
+
+    Context 'When removing existing collection with a simple automatic indexing policy' {
+        It 'Should not throw an exception' {
+            $script:result = Remove-CosmosDbCollection -Context $script:testContext -Id $script:testCollection -Verbose
+        }
+    }
+
+    Context 'When creating a new complex automatic indexing policy' {
         It 'Should not throw an exception' {
             $script:indexNumberRange = New-CosmosDbCollectionIncludedPathIndex -Kind Range -DataType Number -Precision -1
-            $script:indexStringHash = New-CosmosDbCollectionIncludedPathIndex -Kind Hash -DataType String -Precision 3
+            $script:indexStringRange = New-CosmosDbCollectionIncludedPathIndex -Kind Range -DataType String -Precision -1
             $script:indexSpatialPoint = New-CosmosDbCollectionIncludedPathIndex -Kind Spatial -DataType Point
-            $script:indexIncludedPath = New-CosmosDbCollectionIncludedPath -Path '/*' -Index $script:indexNumberRange, $script:indexStringHash, $script:indexSpatialPoint
-            $script:indexingPolicy = New-CosmosDbCollectionIndexingPolicy -Automatic $true -IndexingMode Consistent -IncludedPath $script:indexIncludedPath
+            $script:indexIncludedPath = New-CosmosDbCollectionIncludedPath -Path '/*' -Index $script:indexNumberRange, $script:indexStringRange, $script:indexSpatialPoint
+            $script:indexIncludedPathLocation = New-CosmosDbCollectionIncludedPath -Path '/Location/*' -Index $script:indexSpatialPoint
+            $script:indexingPolicyComplexAutomatic = New-CosmosDbCollectionIndexingPolicy -Automatic $true -IndexingMode Consistent -IncludedPath $script:indexIncludedPath,$script:indexIncludedPathLocation
         }
     }
 
@@ -479,38 +577,20 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
         }
     }
 
-    Context 'When creating a new collection with an IndexingPolicy and UniqueKeyPolicy' {
+    Context 'When creating a new collection with a complex automatic IndexingPolicy and UniqueKeyPolicy' {
         It 'Should not throw an exception' {
             $script:result = New-CosmosDbCollection `
                 -Context $script:testContext `
                 -Id $script:testCollection `
                 -OfferThroughput 400 `
-                -IndexingPolicy $script:indexingPolicy `
+                -IndexingPolicy $script:indexingPolicyComplexAutomatic `
                 -UniqueKeyPolicy $script:uniqueKeyPolicy `
                 -Verbose
         }
 
         It 'Should return expected object' {
-            $script:result.Timestamp | Should -BeOfType [System.DateTime]
-            $script:result.Etag | Should -BeOfType [System.String]
-            $script:result.ResourceId | Should -BeOfType [System.String]
-            $script:result.Uri | Should -BeOfType [System.String]
-            $script:result.Conflicts | Should -BeOfType [System.String]
-            $script:result.Documents | Should -BeOfType [System.String]
-            $script:result.StoredProcedures | Should -BeOfType [System.String]
-            $script:result.Triggers | Should -BeOfType [System.String]
-            $script:result.UserDefinedFunctions | Should -BeOfType [System.String]
+            Test-CollectionResultComplexAutomaticIndexingPolicy -CollectionResult $script:Result
             $script:result.Id | Should -Be $script:testCollection
-            $script:result.indexingPolicy.indexingMode | Should -Be 'Consistent'
-            $script:result.indexingPolicy.automatic | Should -Be $true
-            $script:result.indexingPolicy.includedPaths.Indexes[0].DataType | Should -Be 'Number'
-            $script:result.indexingPolicy.includedPaths.Indexes[0].Kind | Should -Be 'Range'
-            $script:result.indexingPolicy.includedPaths.Indexes[0].Precision | Should -Be -1
-            $script:result.indexingPolicy.includedPaths.Indexes[1].DataType | Should -Be 'String'
-            $script:result.indexingPolicy.includedPaths.Indexes[1].Kind | Should -Be 'Hash'
-            $script:result.indexingPolicy.includedPaths.Indexes[1].Precision | Should -Be 3
-            $script:result.indexingPolicy.includedPaths.Indexes[2].DataType | Should -Be 'Point'
-            $script:result.indexingPolicy.includedPaths.Indexes[2].Kind | Should -Be 'Spatial'
             $script:result.uniqueKeyPolicy.uniqueKeys[0].paths[0] | Should -Be '/uniquekey'
         }
     }
@@ -524,61 +604,25 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
         }
 
         It 'Should return expected object' {
-            $script:result.Timestamp | Should -BeOfType [System.DateTime]
-            $script:result.Etag | Should -BeOfType [System.String]
-            $script:result.ResourceId | Should -BeOfType [System.String]
-            $script:result.Uri | Should -BeOfType [System.String]
-            $script:result.Conflicts | Should -BeOfType [System.String]
-            $script:result.Documents | Should -BeOfType [System.String]
-            $script:result.StoredProcedures | Should -BeOfType [System.String]
-            $script:result.Triggers | Should -BeOfType [System.String]
-            $script:result.UserDefinedFunctions | Should -BeOfType [System.String]
+            Test-CollectionResultComplexAutomaticIndexingPolicy -CollectionResult $script:Result
             $script:result.Id | Should -Be $script:testCollection
-            $script:result.indexingPolicy.indexingMode | Should -Be 'Consistent'
-            $script:result.indexingPolicy.automatic | Should -Be $true
-            $script:result.indexingPolicy.includedPaths.Indexes[0].DataType | Should -Be 'Number'
-            $script:result.indexingPolicy.includedPaths.Indexes[0].Kind | Should -Be 'Range'
-            $script:result.indexingPolicy.includedPaths.Indexes[0].Precision | Should -Be -1
-            $script:result.indexingPolicy.includedPaths.Indexes[1].DataType | Should -Be 'String'
-            $script:result.indexingPolicy.includedPaths.Indexes[1].Kind | Should -Be 'Hash'
-            $script:result.indexingPolicy.includedPaths.Indexes[1].Precision | Should -Be 3
-            $script:result.indexingPolicy.includedPaths.Indexes[2].DataType | Should -Be 'Point'
-            $script:result.indexingPolicy.includedPaths.Indexes[2].Kind | Should -Be 'Spatial'
             $script:result.uniqueKeyPolicy.uniqueKeys[0].paths[0] | Should -Be '/uniquekey'
         }
     }
 
-    Context 'When updating an existing collection with an IndexingPolicy and UniqueKeyPolicy' {
+    Context 'When updating an existing collection with a complex IndexingPolicy and UniqueKeyPolicy' {
         It 'Should not throw an exception' {
             $script:result = Set-CosmosDbCollection `
                 -Context $script:testContext `
                 -Id $script:testCollection `
-                -IndexingPolicy $script:indexingPolicy `
+                -IndexingPolicy $script:indexingPolicyComplexAutomatic `
                 -UniqueKeyPolicy $script:uniqueKeyPolicy `
                 -Verbose
         }
 
         It 'Should return expected object' {
-            $script:result.Timestamp | Should -BeOfType [System.DateTime]
-            $script:result.Etag | Should -BeOfType [System.String]
-            $script:result.ResourceId | Should -BeOfType [System.String]
-            $script:result.Uri | Should -BeOfType [System.String]
-            $script:result.Conflicts | Should -BeOfType [System.String]
-            $script:result.Documents | Should -BeOfType [System.String]
-            $script:result.StoredProcedures | Should -BeOfType [System.String]
-            $script:result.Triggers | Should -BeOfType [System.String]
-            $script:result.UserDefinedFunctions | Should -BeOfType [System.String]
+            Test-CollectionResultComplexAutomaticIndexingPolicy -CollectionResult $script:Result
             $script:result.Id | Should -Be $script:testCollection
-            $script:result.indexingPolicy.indexingMode | Should -Be 'Consistent'
-            $script:result.indexingPolicy.automatic | Should -Be $true
-            $script:result.indexingPolicy.includedPaths.Indexes[0].DataType | Should -Be 'Number'
-            $script:result.indexingPolicy.includedPaths.Indexes[0].Kind | Should -Be 'Range'
-            $script:result.indexingPolicy.includedPaths.Indexes[0].Precision | Should -Be -1
-            $script:result.indexingPolicy.includedPaths.Indexes[1].DataType | Should -Be 'String'
-            $script:result.indexingPolicy.includedPaths.Indexes[1].Kind | Should -Be 'Hash'
-            $script:result.indexingPolicy.includedPaths.Indexes[1].Precision | Should -Be 3
-            $script:result.indexingPolicy.includedPaths.Indexes[2].DataType | Should -Be 'Point'
-            $script:result.indexingPolicy.includedPaths.Indexes[2].Kind | Should -Be 'Spatial'
             $script:result.uniqueKeyPolicy.uniqueKeys[0].paths[0] | Should -Be '/uniquekey'
         }
     }
@@ -598,10 +642,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
         }
 
         It 'Should return expected object' {
-            $script:result.Timestamp | Should -BeOfType [System.DateTime]
-            $script:result.Etag | Should -BeOfType [System.String]
-            $script:result.ResourceId | Should -BeOfType [System.String]
-            $script:result.Uri | Should -BeOfType [System.String]
+            Test-GenericResult -GenericResult $script:result
             $script:result.Id | Should -Be $script:testCollectionPermission
             $script:result.permissionMode | Should -Be 'Read'
             $script:result.resource | Should -Be $script:collectionResourcePath
@@ -622,10 +663,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
         }
 
         It 'Should return expected object' {
-            $script:result.Timestamp | Should -BeOfType [System.DateTime]
-            $script:result.Etag | Should -BeOfType [System.String]
-            $script:result.ResourceId | Should -BeOfType [System.String]
-            $script:result.Uri | Should -BeOfType [System.String]
+            Test-GenericResult -GenericResult $script:result
             $script:result.Id | Should -Be $script:testCollectionPermission
             $script:result.permissionMode | Should -Be 'Read'
             $script:result.resource | Should -Be $script:collectionResourcePath
@@ -661,26 +699,8 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
         }
 
         It 'Should return expected object' {
-            $script:result.Timestamp | Should -BeOfType [System.DateTime]
-            $script:result.Etag | Should -BeOfType [System.String]
-            $script:result.ResourceId | Should -BeOfType [System.String]
-            $script:result.Uri | Should -BeOfType [System.String]
-            $script:result.Conflicts | Should -BeOfType [System.String]
-            $script:result.Documents | Should -BeOfType [System.String]
-            $script:result.StoredProcedures | Should -BeOfType [System.String]
-            $script:result.Triggers | Should -BeOfType [System.String]
-            $script:result.UserDefinedFunctions | Should -BeOfType [System.String]
+            Test-CollectionResultComplexAutomaticIndexingPolicy -CollectionResult $script:Result
             $script:result.Id | Should -Be $script:testCollection
-            $script:result.indexingPolicy.indexingMode | Should -Be 'Consistent'
-            $script:result.indexingPolicy.automatic | Should -Be $true
-            $script:result.indexingPolicy.includedPaths.Indexes[0].DataType | Should -Be 'Number'
-            $script:result.indexingPolicy.includedPaths.Indexes[0].Kind | Should -Be 'Range'
-            $script:result.indexingPolicy.includedPaths.Indexes[0].Precision | Should -Be -1
-            $script:result.indexingPolicy.includedPaths.Indexes[1].DataType | Should -Be 'String'
-            $script:result.indexingPolicy.includedPaths.Indexes[1].Kind | Should -Be 'Hash'
-            $script:result.indexingPolicy.includedPaths.Indexes[1].Precision | Should -Be 3
-            $script:result.indexingPolicy.includedPaths.Indexes[2].DataType | Should -Be 'Point'
-            $script:result.indexingPolicy.includedPaths.Indexes[2].Kind | Should -Be 'Spatial'
         }
     }
 
@@ -690,10 +710,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
         }
 
         It 'Should return expected object' {
-            $script:result.Timestamp | Should -BeOfType [System.DateTime]
-            $script:result.Etag | Should -BeOfType [System.String]
-            $script:result.ResourceId | Should -BeOfType [System.String]
-            $script:result.Uri | Should -BeOfType [System.String]
+            Test-GenericResult -GenericResult $script:result
             $script:result.OfferVersion | Should -BeOfType [System.String]
             $script:result.OfferType | Should -BeOfType [System.String]
             $script:result.OfferResourceId | Should -BeOfType [System.String]
@@ -711,10 +728,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
         }
 
         It 'Should return expected object' {
-            $script:result.Timestamp | Should -BeOfType [System.DateTime]
-            $script:result.Etag | Should -BeOfType [System.String]
-            $script:result.ResourceId | Should -BeOfType [System.String]
-            $script:result.Uri | Should -BeOfType [System.String]
+            Test-GenericResult -GenericResult $script:result
             $script:result.OfferVersion | Should -BeOfType [System.String]
             $script:result.OfferType | Should -BeOfType [System.String]
             $script:result.OfferResourceId | Should -BeOfType [System.String]
@@ -734,10 +748,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
         }
 
         It 'Should return expected object' {
-            $script:result.Timestamp | Should -BeOfType [System.DateTime]
-            $script:result.Etag | Should -BeOfType [System.String]
-            $script:result.ResourceId | Should -BeOfType [System.String]
-            $script:result.Uri | Should -BeOfType [System.String]
+            Test-GenericResult -GenericResult $script:result
             $script:result.Attachments | Should -BeOfType [System.String]
             $script:result.Id | Should -Be $script:testDocumentId
             $script:result.Content | Should -Be 'Some string'
@@ -758,10 +769,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
         }
 
         It 'Should return expected object' {
-            $script:result.Timestamp | Should -BeOfType [System.DateTime]
-            $script:result.Etag | Should -BeOfType [System.String]
-            $script:result.ResourceId | Should -BeOfType [System.String]
-            $script:result.Uri | Should -BeOfType [System.String]
+            Test-GenericResult -GenericResult $script:result
             $script:result.Id | Should -Be $script:testAttachmentId
             $script:result.ContentType | Should -Be $script:testAttachmentContentType
             $script:result.Media | Should -Be $script:testAttachmentMedia
@@ -779,10 +787,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
         }
 
         It 'Should return expected object' {
-            $script:result.Timestamp | Should -BeOfType [System.DateTime]
-            $script:result.Etag | Should -BeOfType [System.String]
-            $script:result.ResourceId | Should -BeOfType [System.String]
-            $script:result.Uri | Should -BeOfType [System.String]
+            Test-GenericResult -GenericResult $script:result
             $script:result.Id | Should -Be $script:testAttachmentId
             $script:result.ContentType | Should -Be $script:testAttachmentContentType
             $script:result.Media | Should -Be $script:testAttachmentMedia
@@ -805,10 +810,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
         }
 
         It 'Should return expected object' {
-            $script:result.Timestamp | Should -BeOfType [System.DateTime]
-            $script:result.Etag | Should -BeOfType [System.String]
-            $script:result.ResourceId | Should -BeOfType [System.String]
-            $script:result.Uri | Should -BeOfType [System.String]
+            Test-GenericResult -GenericResult $script:result
             $script:result.Id | Should -Be $script:testDocumentPermission
             $script:result.permissionMode | Should -Be 'Read'
             $script:result.resource | Should -Be $script:documentResourcePath
@@ -830,10 +832,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
         }
 
         It 'Should return expected object' {
-            $script:result.Timestamp | Should -BeOfType [System.DateTime]
-            $script:result.Etag | Should -BeOfType [System.String]
-            $script:result.ResourceId | Should -BeOfType [System.String]
-            $script:result.Uri | Should -BeOfType [System.String]
+            Test-GenericResult -GenericResult $script:result
             $script:result.Id | Should -Be $script:testDocumentPermission
             $script:result.permissionMode | Should -Be 'Read'
             $script:result.resource | Should -Be $script:documentResourcePath
@@ -881,10 +880,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
         }
 
         It 'Should return expected object' {
-            $script:result.Timestamp | Should -BeOfType [System.DateTime]
-            $script:result.Etag | Should -BeOfType [System.String]
-            $script:result.ResourceId | Should -BeOfType [System.String]
-            $script:result.Uri | Should -BeOfType [System.String]
+            Test-GenericResult -GenericResult $script:result
             $script:result.Id | Should -Be $script:testStoredProcedureId
         }
     }
@@ -899,10 +895,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
         }
 
         It 'Should return expected object' {
-            $script:result.Timestamp | Should -BeOfType [System.DateTime]
-            $script:result.Etag | Should -BeOfType [System.String]
-            $script:result.ResourceId | Should -BeOfType [System.String]
-            $script:result.Uri | Should -BeOfType [System.String]
+            Test-GenericResult -GenericResult $script:result
             $script:result.Id | Should -Be $script:testStoredProcedureId
         }
     }
@@ -932,10 +925,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
             }
 
             It 'Should return expected object' {
-                $script:result.Timestamp | Should -BeOfType [System.DateTime]
-                $script:result.Etag | Should -BeOfType [System.String]
-                $script:result.ResourceId | Should -BeOfType [System.String]
-                $script:result.Uri | Should -BeOfType [System.String]
+                Test-GenericResult -GenericResult $script:result
                 $script:result.Id | Should -Be $script:testTriggerId
                 $script:result.TriggerOperation | Should -Be $operation
                 $script:result.TriggerType | Should -Be 'Pre'
@@ -952,10 +942,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
             }
 
             It 'Should return expected object' {
-                $script:result.Timestamp | Should -BeOfType [System.DateTime]
-                $script:result.Etag | Should -BeOfType [System.String]
-                $script:result.ResourceId | Should -BeOfType [System.String]
-                $script:result.Uri | Should -BeOfType [System.String]
+                Test-GenericResult -GenericResult $script:result
                 $script:result.Id | Should -Be $script:testTriggerId
                 $script:result.TriggerOperation | Should -Be $operation
                 $script:result.TriggerType | Should -Be 'Pre'
@@ -984,10 +971,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
         }
 
         It 'Should return expected object' {
-            $script:result.Timestamp | Should -BeOfType [System.DateTime]
-            $script:result.Etag | Should -BeOfType [System.String]
-            $script:result.ResourceId | Should -BeOfType [System.String]
-            $script:result.Uri | Should -BeOfType [System.String]
+            Test-GenericResult -GenericResult $script:result
             $script:result.Id | Should -Be $script:testUserDefinedFunctionId
         }
     }
@@ -1002,10 +986,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
         }
 
         It 'Should return expected object' {
-            $script:result.Timestamp | Should -BeOfType [System.DateTime]
-            $script:result.Etag | Should -BeOfType [System.String]
-            $script:result.ResourceId | Should -BeOfType [System.String]
-            $script:result.Uri | Should -BeOfType [System.String]
+            Test-GenericResult -GenericResult $script:result
             $script:result.Id | Should -Be $script:testUserDefinedFunctionId
         }
     }
@@ -1062,10 +1043,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
         }
 
         It 'Should return expected object' {
-            $script:result.Timestamp | Should -BeOfType [System.DateTime]
-            $script:result.Etag | Should -BeOfType [System.String]
-            $script:result.ResourceId | Should -BeOfType [System.String]
-            $script:result.Uri | Should -BeOfType [System.String]
+            Test-GenericResult -GenericResult $script:result
             $script:result.Attachments | Should -BeOfType [System.String]
             $script:result.Id | Should -Be $script:testDocumentUTF8Id
         }
@@ -1081,10 +1059,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
         }
 
         It 'Should return expected object' {
-            $script:result.Timestamp | Should -BeOfType [System.DateTime]
-            $script:result.Etag | Should -BeOfType [System.String]
-            $script:result.ResourceId | Should -BeOfType [System.String]
-            $script:result.Uri | Should -BeOfType [System.String]
+            Test-GenericResult -GenericResult $script:result
             $script:result.Attachments | Should -BeOfType [System.String]
             $script:result.Id | Should -Be $script:testDocumentUTF8Id
         }
@@ -1102,10 +1077,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
         }
 
         It 'Should return expected object' {
-            $script:result.Timestamp | Should -BeOfType [System.DateTime]
-            $script:result.Etag | Should -BeOfType [System.String]
-            $script:result.ResourceId | Should -BeOfType [System.String]
-            $script:result.Uri | Should -BeOfType [System.String]
+            Test-GenericResult -GenericResult $script:result
             $script:result.Attachments | Should -BeOfType [System.String]
             $script:result.Id | Should -Be $script:testDocumentUTF8Id
         }
@@ -1121,10 +1093,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
         }
 
         It 'Should return expected object' {
-            $script:result.Timestamp | Should -BeOfType [System.DateTime]
-            $script:result.Etag | Should -BeOfType [System.String]
-            $script:result.ResourceId | Should -BeOfType [System.String]
-            $script:result.Uri | Should -BeOfType [System.String]
+            Test-GenericResult -GenericResult $script:result
             $script:result.Attachments | Should -BeOfType [System.String]
             $script:result.Id | Should -Be $script:testDocumentUTF8Id
         }
@@ -1156,15 +1125,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
         }
 
         It 'Should return expected object' {
-            $script:result.Timestamp | Should -BeOfType [System.DateTime]
-            $script:result.Etag | Should -BeOfType [System.String]
-            $script:result.ResourceId | Should -BeOfType [System.String]
-            $script:result.Uri | Should -BeOfType [System.String]
-            $script:result.Conflicts | Should -BeOfType [System.String]
-            $script:result.Documents | Should -BeOfType [System.String]
-            $script:result.StoredProcedures | Should -BeOfType [System.String]
-            $script:result.Triggers | Should -BeOfType [System.String]
-            $script:result.UserDefinedFunctions | Should -BeOfType [System.String]
+            Test-CollectionResult -CollectionResult $script:result
             $script:result.Id | Should -Be $script:testCollection
             $script:result.partitionKey.kind | Should -Be 'Hash'
             $script:result.partitionKey.paths[0] | Should -Be ('/{0}' -f $script:testPartitionKey)
@@ -1182,10 +1143,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
         }
 
         It 'Should return expected object' {
-            $script:result.Timestamp | Should -BeOfType [System.DateTime]
-            $script:result.Etag | Should -BeOfType [System.String]
-            $script:result.ResourceId | Should -BeOfType [System.String]
-            $script:result.Uri | Should -BeOfType [System.String]
+            Test-GenericResult -GenericResult $script:result
             $script:result.Attachments | Should -BeOfType [System.String]
             $script:result.Id | Should -Be $script:testDocumentId
             $script:result.Content | Should -Be 'Some string'
@@ -1204,10 +1162,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
         }
 
         It 'Should return expected object' {
-            $script:result.Timestamp | Should -BeOfType [System.DateTime]
-            $script:result.Etag | Should -BeOfType [System.String]
-            $script:result.ResourceId | Should -BeOfType [System.String]
-            $script:result.Uri | Should -BeOfType [System.String]
+            Test-GenericResult -GenericResult $script:result
             $script:result.Attachments | Should -BeOfType [System.String]
             $script:result.Id | Should -Be $script:testDocumentId
             $script:result.Content | Should -Be 'Some string'
@@ -1225,10 +1180,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
         }
 
         It 'Should return expected object' {
-            $script:result.Timestamp | Should -BeOfType [System.DateTime]
-            $script:result.Etag | Should -BeOfType [System.String]
-            $script:result.ResourceId | Should -BeOfType [System.String]
-            $script:result.Uri | Should -BeOfType [System.String]
+            Test-GenericResult -GenericResult $script:result
             $script:result.Attachments | Should -BeOfType [System.String]
             $script:result.Id | Should -Be $script:testDocumentId
             $script:result.Content | Should -Be 'Some string'
@@ -1261,15 +1213,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
         }
 
         It 'Should return expected object' {
-            $script:result.Timestamp | Should -BeOfType [System.DateTime]
-            $script:result.Etag | Should -BeOfType [System.String]
-            $script:result.ResourceId | Should -BeOfType [System.String]
-            $script:result.Uri | Should -BeOfType [System.String]
-            $script:result.Conflicts | Should -BeOfType [System.String]
-            $script:result.Documents | Should -BeOfType [System.String]
-            $script:result.StoredProcedures | Should -BeOfType [System.String]
-            $script:result.Triggers | Should -BeOfType [System.String]
-            $script:result.UserDefinedFunctions | Should -BeOfType [System.String]
+            Test-CollectionResult -CollectionResult $script:result
             $script:result.Id | Should -Be $script:testCollection
             $script:result.indexingPolicy.indexingMode | Should -Be 'None'
             $script:result.indexingPolicy.automatic | Should -Be $false
@@ -1292,15 +1236,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
         }
 
         It 'Should return expected object' {
-            $script:result.Timestamp | Should -BeOfType [System.DateTime]
-            $script:result.Etag | Should -BeOfType [System.String]
-            $script:result.ResourceId | Should -BeOfType [System.String]
-            $script:result.Uri | Should -BeOfType [System.String]
-            $script:result.Conflicts | Should -BeOfType [System.String]
-            $script:result.Documents | Should -BeOfType [System.String]
-            $script:result.StoredProcedures | Should -BeOfType [System.String]
-            $script:result.Triggers | Should -BeOfType [System.String]
-            $script:result.UserDefinedFunctions | Should -BeOfType [System.String]
+            Test-CollectionResult -CollectionResult $script:result
             $script:result.Id | Should -Be $script:testCollection
             $script:result.indexingPolicy.indexingMode | Should -Be 'Consistent'
             $script:result.indexingPolicy.automatic | Should -Be $true
@@ -1318,15 +1254,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
         }
 
         It 'Should return expected object' {
-            $script:result.Timestamp | Should -BeOfType [System.DateTime]
-            $script:result.Etag | Should -BeOfType [System.String]
-            $script:result.ResourceId | Should -BeOfType [System.String]
-            $script:result.Uri | Should -BeOfType [System.String]
-            $script:result.Conflicts | Should -BeOfType [System.String]
-            $script:result.Documents | Should -BeOfType [System.String]
-            $script:result.StoredProcedures | Should -BeOfType [System.String]
-            $script:result.Triggers | Should -BeOfType [System.String]
-            $script:result.UserDefinedFunctions | Should -BeOfType [System.String]
+            Test-CollectionResult -CollectionResult $script:result
             $script:result.Id | Should -Be $script:testCollection
             $script:result.indexingPolicy.indexingMode | Should -Be 'Consistent'
             $script:result.indexingPolicy.automatic | Should -Be $true
@@ -1344,15 +1272,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
         }
 
         It 'Should return expected object' {
-            $script:result.Timestamp | Should -BeOfType [System.DateTime]
-            $script:result.Etag | Should -BeOfType [System.String]
-            $script:result.ResourceId | Should -BeOfType [System.String]
-            $script:result.Uri | Should -BeOfType [System.String]
-            $script:result.Conflicts | Should -BeOfType [System.String]
-            $script:result.Documents | Should -BeOfType [System.String]
-            $script:result.StoredProcedures | Should -BeOfType [System.String]
-            $script:result.Triggers | Should -BeOfType [System.String]
-            $script:result.UserDefinedFunctions | Should -BeOfType [System.String]
+            Test-CollectionResult -CollectionResult $script:result
             $script:result.Id | Should -Be $script:testCollection
             $script:result.indexingPolicy.indexingMode | Should -Be 'Consistent'
             $script:result.indexingPolicy.automatic | Should -Be $true
@@ -1365,32 +1285,14 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
             $script:result = Set-CosmosDbCollection `
                 -Context $script:testContext `
                 -Id $script:testCollection `
-                -IndexingPolicy $script:indexingPolicy `
+                -IndexingPolicy $script:indexingPolicyComplexAutomatic `
                 -DefaultTimeToLive ($script:testDefaultTimeToLive + 2) `
                 -Verbose
         }
 
         It 'Should return expected object' {
-            $script:result.Timestamp | Should -BeOfType [System.DateTime]
-            $script:result.Etag | Should -BeOfType [System.String]
-            $script:result.ResourceId | Should -BeOfType [System.String]
-            $script:result.Uri | Should -BeOfType [System.String]
-            $script:result.Conflicts | Should -BeOfType [System.String]
-            $script:result.Documents | Should -BeOfType [System.String]
-            $script:result.StoredProcedures | Should -BeOfType [System.String]
-            $script:result.Triggers | Should -BeOfType [System.String]
-            $script:result.UserDefinedFunctions | Should -BeOfType [System.String]
+            Test-CollectionResultComplexAutomaticIndexingPolicy -CollectionResult $script:Result
             $script:result.Id | Should -Be $script:testCollection
-            $script:result.indexingPolicy.indexingMode | Should -Be 'Consistent'
-            $script:result.indexingPolicy.automatic | Should -Be $true
-            $script:result.indexingPolicy.includedPaths.Indexes[0].DataType | Should -Be 'Number'
-            $script:result.indexingPolicy.includedPaths.Indexes[0].Kind | Should -Be 'Range'
-            $script:result.indexingPolicy.includedPaths.Indexes[0].Precision | Should -Be -1
-            $script:result.indexingPolicy.includedPaths.Indexes[1].DataType | Should -Be 'String'
-            $script:result.indexingPolicy.includedPaths.Indexes[1].Kind | Should -Be 'Hash'
-            $script:result.indexingPolicy.includedPaths.Indexes[1].Precision | Should -Be 3
-            $script:result.indexingPolicy.includedPaths.Indexes[2].DataType | Should -Be 'Point'
-            $script:result.indexingPolicy.includedPaths.Indexes[2].Kind | Should -Be 'Spatial'
             $script:result.defaultTtl | Should -Be ($script:testDefaultTimeToLive + 2)
         }
     }
@@ -1404,26 +1306,8 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
         }
 
         It 'Should return expected object' {
-            $script:result.Timestamp | Should -BeOfType [System.DateTime]
-            $script:result.Etag | Should -BeOfType [System.String]
-            $script:result.ResourceId | Should -BeOfType [System.String]
-            $script:result.Uri | Should -BeOfType [System.String]
-            $script:result.Conflicts | Should -BeOfType [System.String]
-            $script:result.Documents | Should -BeOfType [System.String]
-            $script:result.StoredProcedures | Should -BeOfType [System.String]
-            $script:result.Triggers | Should -BeOfType [System.String]
-            $script:result.UserDefinedFunctions | Should -BeOfType [System.String]
+            Test-CollectionResultComplexAutomaticIndexingPolicy -CollectionResult $script:Result
             $script:result.Id | Should -Be $script:testCollection
-            $script:result.indexingPolicy.indexingMode | Should -Be 'Consistent'
-            $script:result.indexingPolicy.automatic | Should -Be $true
-            $script:result.indexingPolicy.includedPaths.Indexes[0].DataType | Should -Be 'Number'
-            $script:result.indexingPolicy.includedPaths.Indexes[0].Kind | Should -Be 'Range'
-            $script:result.indexingPolicy.includedPaths.Indexes[0].Precision | Should -Be -1
-            $script:result.indexingPolicy.includedPaths.Indexes[1].DataType | Should -Be 'String'
-            $script:result.indexingPolicy.includedPaths.Indexes[1].Kind | Should -Be 'Hash'
-            $script:result.indexingPolicy.includedPaths.Indexes[1].Precision | Should -Be 3
-            $script:result.indexingPolicy.includedPaths.Indexes[2].DataType | Should -Be 'Point'
-            $script:result.indexingPolicy.includedPaths.Indexes[2].Kind | Should -Be 'Spatial'
             $script:result.defaultTtl | Should -Be ($script:testDefaultTimeToLive + 2)
         }
     }
@@ -1471,7 +1355,6 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
         It 'Should have a continuation token in headers' {
             $script:ResponseHeader.'x-ms-continuation' | Should -Not -BeNullOrEmpty
         }
-
     }
 
     Context 'When getting collections using a maximum item count of 1 and a continuation token' {

--- a/test/Integration/CosmosDB.integration.Tests.ps1
+++ b/test/Integration/CosmosDB.integration.Tests.ps1
@@ -503,6 +503,11 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
             $script:result.Id | Should -Be $script:testCollection
             $script:result.indexingPolicy.indexingMode | Should -Be 'Consistent'
             $script:result.indexingPolicy.automatic | Should -Be $true
+            Write-Verbose -Message ($script:result.indexingPolicy.includedPaths.Indexes | Out-String ) -Verbose
+            Write-Verbose -Message (@($script:indexNumberRange, $script:indexStringRange, $script:indexSpatialPoint) | Out-String ) -Verbose
+            Compare-Object `
+                -ReferenceObject $script:result.indexingPolicy.includedPaths.Indexes `
+                -DifferenceObject @($script:indexNumberRange, $script:indexStringRange, $script:indexSpatialPoint) | Should -Be $null
             $script:result.indexingPolicy.includedPaths.Indexes[0].DataType | Should -Be 'Number'
             $script:result.indexingPolicy.includedPaths.Indexes[0].Kind | Should -Be 'Range'
             $script:result.indexingPolicy.includedPaths.Indexes[0].Precision | Should -Be -1

--- a/test/Integration/CosmosDB.integration.Tests.ps1
+++ b/test/Integration/CosmosDB.integration.Tests.ps1
@@ -465,9 +465,9 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
     Context 'When creating a new indexing policy' {
         It 'Should not throw an exception' {
             $script:indexNumberRange = New-CosmosDbCollectionIncludedPathIndex -Kind Range -DataType Number -Precision -1
-            $script:indexStringRange = New-CosmosDbCollectionIncludedPathIndex -Kind Hash -DataType String -Precision 3
+            $script:indexStringHash = New-CosmosDbCollectionIncludedPathIndex -Kind Hash -DataType String -Precision 3
             $script:indexSpatialPoint = New-CosmosDbCollectionIncludedPathIndex -Kind Spatial -DataType Point
-            $script:indexIncludedPath = New-CosmosDbCollectionIncludedPath -Path '/*' -Index $script:indexNumberRange, $script:indexStringRange, $script:indexSpatialPoint
+            $script:indexIncludedPath = New-CosmosDbCollectionIncludedPath -Path '/*' -Index $script:indexNumberRange, $script:indexStringHash, $script:indexSpatialPoint
             $script:indexingPolicy = New-CosmosDbCollectionIndexingPolicy -Automatic $true -IndexingMode Consistent -IncludedPath $script:indexIncludedPath
         }
     }

--- a/test/Unit/CosmosDB.collections.Tests.ps1
+++ b/test/Unit/CosmosDB.collections.Tests.ps1
@@ -60,7 +60,7 @@ InModuleScope CosmosDB {
         -IndexingMode 'Consistent' `
         -IncludedPath (
         New-CosmosDbCollectionIncludedPath -Path '/*' -Index (
-            New-CosmosDbCollectionIncludedPathIndex -Kind 'Hash' -DataType 'String' -Precision -1
+            New-CosmosDbCollectionIncludedPathIndex -Kind 'Range' -DataType 'String'
         )
     ) `
         -ExcludedPath (
@@ -179,7 +179,7 @@ InModuleScope CosmosDB {
             } | Should -Not -Throw
         }
 
-        Context 'When called with valid Hash parameters' {
+        Context 'When called with valid Hash parameters and Precision' {
             $script:result = $null
 
             It 'Should not throw an exception' {
@@ -187,6 +187,27 @@ InModuleScope CosmosDB {
                     Kind      = 'Hash'
                     DataType  = 'String'
                     Precision = -1
+                    Verbose   = $true
+                }
+
+                $script:result = New-CosmosDbCollectionIncludedPathIndex @newCosmosDbCollectionIncludedPathIndexParameters
+            }
+
+            It 'Should return expected result' {
+                $script:result | Should -BeOfType 'CosmosDB.IndexingPolicy.Path.Index'
+                $script:result.Kind | Should -Be 'Hash'
+                $script:result.DataType | Should -Be 'String'
+                $script:result.Precision | Should -Be -1
+            }
+        }
+
+        Context 'When called with valid Hash parameters and Precision not Specified' {
+            $script:result = $null
+
+            It 'Should not throw an exception' {
+                $newCosmosDbCollectionIncludedPathIndexParameters = @{
+                    Kind      = 'Hash'
+                    DataType  = 'String'
                     Verbose   = $true
                 }
 
@@ -221,7 +242,7 @@ InModuleScope CosmosDB {
             }
         }
 
-        Context 'When called with valid Range parameters' {
+        Context 'When called with valid Range parameters and Precision specified' {
             $script:result = $null
 
             It 'Should not throw an exception' {
@@ -239,7 +260,28 @@ InModuleScope CosmosDB {
                 $script:result | Should -BeOfType 'CosmosDB.IndexingPolicy.Path.Index'
                 $script:result.Kind | Should -Be 'Range'
                 $script:result.DataType | Should -Be 'Number'
-                $script:result.Precision | Should -Be 2
+                $script:result.Precision | Should -Be -1
+            }
+        }
+
+        Context 'When called with valid Range parameters and Precision not Specified' {
+            $script:result = $null
+
+            It 'Should not throw an exception' {
+                $newCosmosDbCollectionIncludedPathIndexParameters = @{
+                    Kind      = 'Range'
+                    DataType  = 'Number'
+                    Verbose   = $true
+                }
+
+                $script:result = New-CosmosDbCollectionIncludedPathIndex @newCosmosDbCollectionIncludedPathIndexParameters
+            }
+
+            It 'Should return expected result' {
+                $script:result | Should -BeOfType 'CosmosDB.IndexingPolicy.Path.Index'
+                $script:result.Kind | Should -Be 'Range'
+                $script:result.DataType | Should -Be 'Number'
+                $script:result.Precision | Should -Be -1
             }
         }
 
@@ -337,7 +379,7 @@ InModuleScope CosmosDB {
             It 'Should not throw an exception' {
                 $newCosmosDbCollectionIncludedPathParameters = @{
                     Path    = '/*'
-                    Index   = (New-CosmosDbCollectionIncludedPathIndex -Kind 'Hash' -DataType 'String' -Precision -1)
+                    Index   = (New-CosmosDbCollectionIncludedPathIndex -Kind 'Range' -DataType 'String' -Precision -1)
                     Verbose = $true
                 }
 
@@ -347,7 +389,7 @@ InModuleScope CosmosDB {
             It 'Should return expected result' {
                 $script:result | Should -BeOfType 'CosmosDB.IndexingPolicy.Path.IncludedPath'
                 $script:result.Path | Should -Be '/*'
-                $script:result.Indexes[0].Kind | Should -Be 'Hash'
+                $script:result.Indexes[0].Kind | Should -Be 'Range'
                 $script:result.Indexes[0].DataType | Should -Be 'String'
                 $script:result.Indexes[0].Precision | Should -Be -1
             }
@@ -394,7 +436,7 @@ InModuleScope CosmosDB {
                 $newCosmosDbCollectionIndexingPolicyParameters = @{
                     Automatic    = $true
                     IndexingMode = 'Consistent'
-                    IncludedPath = (New-CosmosDbCollectionIncludedPath -Path '/*' -Index (New-CosmosDbCollectionIncludedPathIndex -Kind 'Hash' -DataType 'String' -Precision -1))
+                    IncludedPath = (New-CosmosDbCollectionIncludedPath -Path '/*' -Index (New-CosmosDbCollectionIncludedPathIndex -Kind 'Range' -DataType 'String' -Precision -1))
                     ExcludedPath = (New-CosmosDbCollectionExcludedPath -Path '/*')
                     Verbose      = $true
                 }
@@ -619,7 +661,7 @@ InModuleScope CosmosDB {
 
         Context 'When called with context parameter and an Id' {
             $invokecosmosdbrequest_parameterfilter = {
-                $BodyObject = $Body | ConvertFrom-Json;
+                $BodyObject = $Body | ConvertFrom-Json
                 $Method -eq 'Post' -and `
                     $ResourceType -eq 'colls' -and `
                     $BodyObject.id -eq $script:testCollection1
@@ -654,7 +696,7 @@ InModuleScope CosmosDB {
 
         Context 'When called with context parameter and an Id and a DefaultTimeToLive' {
             $invokecosmosdbrequest_parameterfilter = {
-                $BodyObject = $Body | ConvertFrom-Json;
+                $BodyObject = $Body | ConvertFrom-Json
                 $Method -eq 'Post' -and `
                     $ResourceType -eq 'colls' -and `
                     $BodyObject.id -eq $script:testCollection1 -and `
@@ -692,7 +734,7 @@ InModuleScope CosmosDB {
         Context 'When called with context parameter and an Id and OfferThroughput parameter' {
             $script:result = $null
             $invokecosmosdbrequest_parameterfilter = {
-                $BodyObject = $Body | ConvertFrom-Json;
+                $BodyObject = $Body | ConvertFrom-Json
                 $Method -eq 'Post' -and `
                     $ResourceType -eq 'colls' -and `
                     $BodyObject.id -eq $script:testCollection1 -and `
@@ -729,7 +771,7 @@ InModuleScope CosmosDB {
         Context 'When called with context parameter and an Id and OfferType parameter' {
             $script:result = $null
             $invokecosmosdbrequest_parameterfilter = {
-                $BodyObject = $Body | ConvertFrom-Json;
+                $BodyObject = $Body | ConvertFrom-Json
                 $Method -eq 'Post' -and `
                     $ResourceType -eq 'colls' -and `
                     $BodyObject.id -eq $script:testCollection1 -and `
@@ -843,7 +885,7 @@ InModuleScope CosmosDB {
         Context 'When called with context parameter and an Id and PartitionKey parameter' {
             $script:result = $null
             $invokecosmosdbrequest_parameterfilter = {
-                $BodyObject = $Body | ConvertFrom-Json;
+                $BodyObject = $Body | ConvertFrom-Json
                 $Method -eq 'Post' -and `
                     $ResourceType -eq 'colls' -and `
                     $BodyObject.id -eq $script:testCollection1 -and `
@@ -881,7 +923,7 @@ InModuleScope CosmosDB {
         Context 'When called with context parameter and an Id parameter and PartitionKey parameter starting with ''/''' {
             $script:result = $null
             $invokecosmosdbrequest_parameterfilter = {
-                $BodyObject = $Body | ConvertFrom-Json;
+                $BodyObject = $Body | ConvertFrom-Json
                 $Method -eq 'Post' -and `
                     $ResourceType -eq 'colls' -and `
                     $BodyObject.id -eq $script:testCollection1 -and `
@@ -996,7 +1038,7 @@ InModuleScope CosmosDB {
             $script:result = $null
 
             $invokecosmosdbrequest_parameterfilter = {
-                $BodyObject = $Body | ConvertFrom-Json;
+                $BodyObject = $Body | ConvertFrom-Json
                 $Method -eq 'Put' -and `
                     $ResourceType -eq 'colls' -and `
                     $ResourcePath -eq ('colls/{0}' -f $script:testCollection1) -and `
@@ -1047,7 +1089,7 @@ InModuleScope CosmosDB {
             $script:result = $null
 
             $invokecosmosdbrequest_parameterfilter = {
-                $BodyObject = $Body | ConvertFrom-Json;
+                $BodyObject = $Body | ConvertFrom-Json
                 $Method -eq 'Put' -and `
                     $ResourceType -eq 'colls' -and `
                     $ResourcePath -eq ('colls/{0}' -f $script:testCollection1) -and `
@@ -1101,7 +1143,7 @@ InModuleScope CosmosDB {
             $script:result = $null
 
             $invokecosmosdbrequest_parameterfilter = {
-                $BodyObject = $Body | ConvertFrom-Json;
+                $BodyObject = $Body | ConvertFrom-Json
                 $Method -eq 'Put' -and `
                     $ResourceType -eq 'colls' -and `
                     $ResourcePath -eq ('colls/{0}' -f $script:testCollection1) -and `
@@ -1156,7 +1198,7 @@ InModuleScope CosmosDB {
             $script:result = $null
 
             $invokecosmosdbrequest_parameterfilter = {
-                $BodyObject = $Body | ConvertFrom-Json;
+                $BodyObject = $Body | ConvertFrom-Json
                 $Method -eq 'Put' -and `
                     $ResourceType -eq 'colls' -and `
                     $ResourcePath -eq ('colls/{0}' -f $script:testCollection1) -and `
@@ -1212,7 +1254,7 @@ InModuleScope CosmosDB {
             $script:result = $null
 
             $invokecosmosdbrequest_parameterfilter = {
-                $BodyObject = $Body | ConvertFrom-Json;
+                $BodyObject = $Body | ConvertFrom-Json
                 $Method -eq 'Put' -and `
                     $ResourceType -eq 'colls' -and `
                     $ResourcePath -eq ('colls/{0}' -f $script:testCollection1) -and `


### PR DESCRIPTION
Correct Notes display in Markdown README.MD.
Deprecate Hash index policy and precision.

- Fixes #269 
- Fixes #271 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plagueho/cosmosdb/270)
<!-- Reviewable:end -->
