### PR TITLE
Added support for PartitionKey in *-CosmosDBAttachment functions - Fixes #274

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Added support for `PartitionKey` in `*-CosmosDBAttachment`
   functions - fixes [Issue #274](https://github.com/PlagueHO/CosmosDB/issues/274).
+- Update `cosmosdb.psdepend.psd1` to install modules `Az.Resources` 1.1.2 and
+  `Az.Accounts` 1.3.0.
 
 ## 3.2.0.320
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+- Added support for `PartitionId` in `*-CosmosDBAttachment`
+  functions - fixes [Issue #274](https://github.com/PlagueHO/CosmosDB/issues/274).
+
 ## 3.2.0.320
 
 - Convert module name to be a variable in PSake file to make it more

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Added support for `PartitionId` in `*-CosmosDBAttachment`
+- Added support for `PartitionKey` in `*-CosmosDBAttachment`
   functions - fixes [Issue #274](https://github.com/PlagueHO/CosmosDB/issues/274).
 
 ## 3.2.0.320

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -8,6 +8,8 @@ February 22, 2018
   functions - fixes [Issue #274](https://github.com/PlagueHO/CosmosDB/issues/274).
 - Update `cosmosdb.psdepend.psd1` to install modules `Az.Resources` 1.1.2 and
   `Az.Accounts` 1.3.0.
+- Suppress verbose output when loading module during automated
+  testing to reduce output.
 
 ## What is New in CosmosDB 3.2.0.320
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -4,7 +4,7 @@
 
 February 22, 2018
 
-- Added support for `PartitionId` in `*-CosmosDBAttachment`
+- Added support for `PartitionKey` in `*-CosmosDBAttachment`
   functions - fixes [Issue #274](https://github.com/PlagueHO/CosmosDB/issues/274).
 
 ## What is New in CosmosDB 3.2.0.320

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## What is New in CosmosDB Unreleased
+
+February 22, 2018
+
+- Added support for `PartitionId` in `*-CosmosDBAttachment`
+  functions - fixes [Issue #274](https://github.com/PlagueHO/CosmosDB/issues/274).
+
 ## What is New in CosmosDB 3.2.0.320
 
 February 6, 2018

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -6,6 +6,8 @@ February 22, 2018
 
 - Added support for `PartitionKey` in `*-CosmosDBAttachment`
   functions - fixes [Issue #274](https://github.com/PlagueHO/CosmosDB/issues/274).
+- Update `cosmosdb.psdepend.psd1` to install modules `Az.Resources` 1.1.2 and
+  `Az.Accounts` 1.3.0.
 
 ## What is New in CosmosDB 3.2.0.320
 

--- a/cosmosdb.depend.psd1
+++ b/cosmosdb.depend.psd1
@@ -79,7 +79,7 @@
             SkipPublisherCheck = $true
         }
         Target         = 'CurrentUser'
-        Version        = '1.2.1'
+        Version        = '1.3.0'
         Tags           = 'Test','Deploy'
     }
 
@@ -91,7 +91,7 @@
             SkipPublisherCheck = $true
         }
         Target         = 'CurrentUser'
-        Version        = '1.1.1'
+        Version        = '1.1.2'
         Tags           = 'Test','Deploy'
     }
 }

--- a/docs/Get-CosmosDbAttachment.md
+++ b/docs/Get-CosmosDbAttachment.md
@@ -17,14 +17,14 @@ Return the attachments for a Cosmos DB document.
 
 ```powershell
 Get-CosmosDbAttachment -Context <Context> [-Key <SecureString>] [-KeyType <String>] [-Database <String>]
- -CollectionId <String> -DocumentId <String> [-Id <String>] [<CommonParameters>]
+ -CollectionId <String> -DocumentId <String> [-Id <String>] [-PartitionKey <String[]>] [<CommonParameters>]
 ```
 
 ### Account
 
 ```powershell
 Get-CosmosDbAttachment -Account <String> [-Key <SecureString>] [-KeyType <String>] [-Database <String>]
- -CollectionId <String> -DocumentId <String> [-Id <String>] [<CommonParameters>]
+ -CollectionId <String> -DocumentId <String> [-Id <String>] [-PartitionKey <String[]>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -50,6 +50,24 @@ PS C:\> Get-CosmosDbAttachment -Context $cosmosDbContext -CollectionId 'MyNewCol
 ```
 
 Get an attachment by Id for a document in a collection.
+
+### Example 3
+
+```powershell
+PS C:\> Get-CosmosDbAttachment -Context $cosmosDbContext -CollectionId 'MyNewCollection' -DocumentId 'ac12345' -PartitionKey 'Id'
+```
+
+Get all attachments for a document in a collection that contains a
+partition key.
+
+### Example 4
+
+```powershell
+PS C:\> Get-CosmosDbAttachment -Context $cosmosDbContext -CollectionId 'MyNewCollection' -DocumentId 'ac12345' -Id 'image_1' -PartitionKey 'Id'
+```
+
+Get an attachment by Id for a document in a collection that contains a
+partition key.
 
 ## PARAMETERS
 
@@ -179,6 +197,24 @@ Accepted values: master, resource
 Required: False
 Position: Named
 Default value: Master
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PartitionKey
+
+The partition keys for the collection that the attachment is in.
+Must be included if and only if the collection is created with
+a partitionKey definition.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/New-CosmosDbAttachment.md
+++ b/docs/New-CosmosDbAttachment.md
@@ -25,8 +25,8 @@ New-CosmosDbAttachment -Context <Context> [-KeyType <String>] [-Key <SecureStrin
 
 ```powershell
 New-CosmosDbAttachment -Account <String> [-KeyType <String>] [-Key <SecureString>] [-Database <String>]
- -CollectionId <String> -DocumentId <String> [-Id <String>] [-ContentType <String>] [-Media <String>]
- [-Slug <String>] [<CommonParameters>]
+ -CollectionId <String> -DocumentId <String> [-Id <String>] [-PartitionKey <String[]>]
+ [-ContentType <String>] [-Media <String>] [-Slug <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -42,6 +42,15 @@ PS C:\> New-CosmosDbAttachment -Context $cosmosDbContext -CollectionId 'MyNewCol
 ```
 
 Create an attachment on a document in a collection.
+
+### Example 2
+
+```powershell
+PS C:\> New-CosmosDbAttachment -Context $cosmosDbContext -CollectionId 'MyNewCollection' -DocumentId 'ac12345' -Id 'image_1' -ContentType 'image/jpg' -Media 'www.bing.com' -PartitionKey 'id'
+```
+
+Create an attachment on a document in a collection that is in a collection with
+a partition key.
 
 ## PARAMETERS
 
@@ -213,6 +222,32 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
+
+### -PartitionKey
+
+The partition keys for the collection that the attachment should
+be created in.
+Must be included if and only if the collection is created with
+a partitionKey definition.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Upsert
+
+Include adds the document to the index.
+Exclude omits the document from indexing.
+The default for indexing behavior is determined by the automatic
+property's value in the indexing policy for the collection.
 
 ### -Slug
 

--- a/docs/Remove-CosmosDbAttachment.md
+++ b/docs/Remove-CosmosDbAttachment.md
@@ -17,14 +17,14 @@ Delete an attachment from a Cosmos DB document.
 
 ```powershell
 Remove-CosmosDbAttachment -Context <Context> [-Database <String>] [-Key <SecureString>] [-KeyType <String>]
- -CollectionId <String> -DocumentId <String> -Id <String> [<CommonParameters>]
+ -CollectionId <String> -DocumentId <String> -Id <String> [-PartitionKey <String[]>] [<CommonParameters>]
 ```
 
 ### Account
 
 ```powershell
 Remove-CosmosDbAttachment -Account <String> [-Database <String>] [-Key <SecureString>] [-KeyType <String>]
- -CollectionId <String> -DocumentId <String> -Id <String> [<CommonParameters>]
+ -CollectionId <String> -DocumentId <String> -Id <String> [-PartitionKey <String[]>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -40,6 +40,14 @@ PS C:\> Remove-CosmosDbAttachment -Context $cosmosDbContext -CollectionId 'MyNew
 ```
 
 Delete an attachment from a document in collection.
+
+### Example 2
+
+```powershell
+PS C:\> Remove-CosmosDbAttachment -Context $cosmosDbContext -CollectionId 'MyNewCollection' -Id 'ac12345' -Id 'Image_2' -PartitionKey 'Id'
+```
+
+Delete an attachment from a document in collection that has a parttion key.
 
 ## PARAMETERS
 
@@ -169,6 +177,24 @@ Accepted values: master, resource
 Required: False
 Position: Named
 Default value: Master
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PartitionKey
+
+The partition keys for the collection that the attachment is in.
+Must be included if and only if the collection is created with
+a partitionKey definition.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/Set-CosmosDbAttachment.md
+++ b/docs/Set-CosmosDbAttachment.md
@@ -17,16 +17,16 @@ Update am attachment for a Cosmos DB document.
 
 ```powershell
 Set-CosmosDbAttachment -Context <Context> [-Database <String>] [-Key <SecureString>] -CollectionId <String>
- -DocumentId <String> -Id <String> [-NewId <String>] [-ContentType <String>] [-Media <String>] [-Slug <String>]
- [<CommonParameters>]
+ -DocumentId <String> -Id <String> [-NewId <String>] [-PartitionKey <String[]>] [-ContentType <String>]
+ [-Media <String>] [-Slug <String>] [<CommonParameters>]
 ```
 
 ### Account
 
 ```powershell
 Set-CosmosDbAttachment -Account <String> [-Database <String>] [-Key <SecureString>] [-KeyType <String>]
- -CollectionId <String> -DocumentId <String> -Id <String> [-NewId <String>] [-ContentType <String>]
- [-Media <String>] [-Slug <String>] [<CommonParameters>]
+ -CollectionId <String> -DocumentId <String> -Id <String> [-NewId <String>] [-PartitionKey <String[]>]
+ [-ContentType <String>] [-Media <String>] [-Slug <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -43,6 +43,15 @@ PS C:\> Set-CosmosDbAttachment -Context $cosmosDbContext -CollectionId 'MyNewCol
 ```
 
 Rename the Id of an attachment for a document in a collection.
+
+### Example 2
+
+```powershell
+PS C:\> Set-CosmosDbAttachment -Context $cosmosDbContext -CollectionId 'MyNewCollection' -DocumentId 'ac12345' -Id 'image_1' -NewId 'Image_2' -PartitionKey 'Id'
+```
+
+Rename the Id of an attachment for a document in a collection that
+has a partition key.
 
 ## PARAMETERS
 
@@ -217,6 +226,24 @@ This is the new Id of the attachment if renaming the attachment.
 
 ```yaml
 Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PartitionKey
+
+The partition keys for the collection that the attachment is in.
+Must be included if and only if the collection is created with
+a partitionKey definition.
+
+```yaml
+Type: String[]
 Parameter Sets: (All)
 Aliases:
 

--- a/src/CosmosDB.psd1
+++ b/src/CosmosDB.psd1
@@ -165,6 +165,8 @@ PrivateData = @{
     functions - fixes [Issue #274](https://github.com/PlagueHO/CosmosDB/issues/274).
   - Update `cosmosdb.psdepend.psd1` to install modules `Az.Resources` 1.1.2 and
     `Az.Accounts` 1.3.0.
+  - Suppress verbose output when loading module during automated
+    testing to reduce output.
 
   ## What is New in CosmosDB 3.2.0.320
 

--- a/src/CosmosDB.psd1
+++ b/src/CosmosDB.psd1
@@ -12,7 +12,7 @@
 RootModule = 'CosmosDB.psm1'
 
 # Version number of this module.
-ModuleVersion = '3.2.0.320'
+ModuleVersion = '3.2.1.320'
 
 # Supported PSEditions
 CompatiblePSEditions = 'Core', 'Desktop'
@@ -51,7 +51,7 @@ PowerShellVersion = '5.1'
 # ProcessorArchitecture = ''
 
 # Modules that must be imported into the global environment prior to importing this module
-RequiredModules = @(@{ModuleName = 'Az.Accounts'; GUID = '17a2feff-488b-47f9-8729-e2cec094624c'; ModuleVersion = '1.0.0'; }, 
+RequiredModules = @(@{ModuleName = 'Az.Accounts'; GUID = '17a2feff-488b-47f9-8729-e2cec094624c'; ModuleVersion = '1.0.0'; },
                @{ModuleName = 'Az.Resources'; GUID = '48bb344d-4c24-441e-8ea0-589947784700'; ModuleVersion = '1.0.0'; })
 
 # Assemblies that must be loaded prior to importing this module
@@ -61,63 +61,63 @@ RequiredModules = @(@{ModuleName = 'Az.Accounts'; GUID = '17a2feff-488b-47f9-872
 # ScriptsToProcess = @()
 
 # Type files (.ps1xml) to be loaded when importing this module
-TypesToProcess = 'types\attachments.types.ps1xml', 'types\collections.types.ps1xml', 
-               'types\databases.types.ps1xml', 'types\documents.types.ps1xml', 
-               'types\offers.types.ps1xml', 'types\permissions.types.ps1xml', 
-               'types\storedprocedures.types.ps1xml', 
-               'types\triggers.types.ps1xml', 
-               'types\userdefinedfunctions.types.ps1xml', 
+TypesToProcess = 'types\attachments.types.ps1xml', 'types\collections.types.ps1xml',
+               'types\databases.types.ps1xml', 'types\documents.types.ps1xml',
+               'types\offers.types.ps1xml', 'types\permissions.types.ps1xml',
+               'types\storedprocedures.types.ps1xml',
+               'types\triggers.types.ps1xml',
+               'types\userdefinedfunctions.types.ps1xml',
                'types\users.types.ps1xml'
 
 # Format files (.ps1xml) to be loaded when importing this module
-FormatsToProcess = 'formats\attachments.formats.ps1xml', 
-               'formats\collections.formats.ps1xml', 
-               'formats\databases.formats.ps1xml', 
-               'formats\documents.formats.ps1xml', 'formats\offers.formats.ps1xml', 
-               'formats\permissions.formats.ps1xml', 
-               'formats\storedprocedures.formats.ps1xml', 
-               'formats\triggers.formats.ps1xml', 
-               'formats\userdefinedfunctions.formats.ps1xml', 
+FormatsToProcess = 'formats\attachments.formats.ps1xml',
+               'formats\collections.formats.ps1xml',
+               'formats\databases.formats.ps1xml',
+               'formats\documents.formats.ps1xml', 'formats\offers.formats.ps1xml',
+               'formats\permissions.formats.ps1xml',
+               'formats\storedprocedures.formats.ps1xml',
+               'formats\triggers.formats.ps1xml',
+               'formats\userdefinedfunctions.formats.ps1xml',
                'formats\users.formats.ps1xml'
 
 # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
 # NestedModules = @()
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-FunctionsToExport = 'Get-CosmosDbAccount', 'Get-CosmosDbAccountConnectionString', 
-               'Get-CosmosDbAccountMasterKey', 'Get-CosmosDbAttachment', 
-               'Get-CosmosDbAttachmentResourcePath', 'Get-CosmosDbCollection', 
-               'Get-CosmosDbCollectionResourcePath', 'Get-CosmosDbCollectionSize', 
-               'Get-CosmosDBDatabase', 'Get-CosmosDBDatabaseResourcePath', 
-               'Get-CosmosDBDocument', 'Get-CosmosDBDocumentResourcePath', 
-               'Get-CosmosDBOffer', 'Get-CosmosDBOfferResourcePath', 
-               'Get-CosmosDbPermission', 'Get-CosmosDbPermissionResourcePath', 
-               'Get-CosmosDbStoredProcedure', 
-               'Get-CosmosDbStoredProcedureResourcePath', 'Get-CosmosDbTrigger', 
-               'Get-CosmosDbTriggerResourcePath', 'Get-CosmosDbUser', 
-               'Get-CosmosDbUserResourcePath', 'Get-CosmosDbUserDefinedFunction', 
-               'Get-CosmosDbUserDefinedFunctionResourcePath', 
-               'Invoke-CosmosDbStoredProcedure', 'New-CosmosDbAccount', 
-               'New-CosmosDbAccountMasterKey', 'New-CosmosDbAttachment', 
-               'New-CosmosDbBackoffPolicy', 'New-CosmosDbCollection', 
-               'New-CosmosDbCollectionIncludedPathIndex', 
-               'New-CosmosDbCollectionIncludedPath', 
-               'New-CosmosDbCollectionExcludedPath', 
-               'New-CosmosDbCollectionIndexingPolicy', 
-               'New-CosmosDbCollectionUniqueKey', 
-               'New-CosmosDbCollectionUniqueKeyPolicy', 'New-CosmosDbDatabase', 
-               'New-CosmosDbDocument', 'New-CosmosDbContext', 
-               'New-CosmosDbContextToken', 'New-CosmosDbPermission', 
-               'New-CosmosDbStoredProcedure', 'New-CosmosDbTrigger', 
-               'New-CosmosDbUser', 'New-CosmosDbUserDefinedFunction', 
-               'Remove-CosmosDbAccount', 'Remove-CosmosDbAttachment', 
-               'Remove-CosmosDbCollection', 'Remove-CosmosDbDatabase', 
-               'Remove-CosmosDbDocument', 'Remove-CosmosDbPermission', 
-               'Remove-CosmosDbStoredProcedure', 'Remove-CosmosDbTrigger', 
-               'Remove-CosmosDbUser', 'Remove-CosmosDbUserDefinedFunction', 
-               'Set-CosmosDbAccount', 'Set-CosmosDbAttachment', 
-               'Set-CosmosDbCollection', 'Set-CosmosDbDocument', 'Set-CosmosDbOffer', 
-               'Set-CosmosDbStoredProcedure', 'Set-CosmosDbTrigger', 
+FunctionsToExport = 'Get-CosmosDbAccount', 'Get-CosmosDbAccountConnectionString',
+               'Get-CosmosDbAccountMasterKey', 'Get-CosmosDbAttachment',
+               'Get-CosmosDbAttachmentResourcePath', 'Get-CosmosDbCollection',
+               'Get-CosmosDbCollectionResourcePath', 'Get-CosmosDbCollectionSize',
+               'Get-CosmosDBDatabase', 'Get-CosmosDBDatabaseResourcePath',
+               'Get-CosmosDBDocument', 'Get-CosmosDBDocumentResourcePath',
+               'Get-CosmosDBOffer', 'Get-CosmosDBOfferResourcePath',
+               'Get-CosmosDbPermission', 'Get-CosmosDbPermissionResourcePath',
+               'Get-CosmosDbStoredProcedure',
+               'Get-CosmosDbStoredProcedureResourcePath', 'Get-CosmosDbTrigger',
+               'Get-CosmosDbTriggerResourcePath', 'Get-CosmosDbUser',
+               'Get-CosmosDbUserResourcePath', 'Get-CosmosDbUserDefinedFunction',
+               'Get-CosmosDbUserDefinedFunctionResourcePath',
+               'Invoke-CosmosDbStoredProcedure', 'New-CosmosDbAccount',
+               'New-CosmosDbAccountMasterKey', 'New-CosmosDbAttachment',
+               'New-CosmosDbBackoffPolicy', 'New-CosmosDbCollection',
+               'New-CosmosDbCollectionIncludedPathIndex',
+               'New-CosmosDbCollectionIncludedPath',
+               'New-CosmosDbCollectionExcludedPath',
+               'New-CosmosDbCollectionIndexingPolicy',
+               'New-CosmosDbCollectionUniqueKey',
+               'New-CosmosDbCollectionUniqueKeyPolicy', 'New-CosmosDbDatabase',
+               'New-CosmosDbDocument', 'New-CosmosDbContext',
+               'New-CosmosDbContextToken', 'New-CosmosDbPermission',
+               'New-CosmosDbStoredProcedure', 'New-CosmosDbTrigger',
+               'New-CosmosDbUser', 'New-CosmosDbUserDefinedFunction',
+               'Remove-CosmosDbAccount', 'Remove-CosmosDbAttachment',
+               'Remove-CosmosDbCollection', 'Remove-CosmosDbDatabase',
+               'Remove-CosmosDbDocument', 'Remove-CosmosDbPermission',
+               'Remove-CosmosDbStoredProcedure', 'Remove-CosmosDbTrigger',
+               'Remove-CosmosDbUser', 'Remove-CosmosDbUserDefinedFunction',
+               'Set-CosmosDbAccount', 'Set-CosmosDbAttachment',
+               'Set-CosmosDbCollection', 'Set-CosmosDbDocument', 'Set-CosmosDbOffer',
+               'Set-CosmosDbStoredProcedure', 'Set-CosmosDbTrigger',
                'Set-CosmosDbUser', 'Set-CosmosDbUserDefinedFunction'
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
@@ -157,6 +157,13 @@ PrivateData = @{
 
         # ReleaseNotes of this module
         ReleaseNotes = '
+  ## What is New in CosmosDB Unreleased
+
+  February 22, 2018
+
+  - Added support for `PartitionId` in `*-CosmosDBAttachment`
+    functions - fixes [Issue #274](https://github.com/PlagueHO/CosmosDB/issues/274).
+
   ## What is New in CosmosDB 3.2.0.320
 
   February 6, 2018
@@ -295,13 +302,6 @@ PrivateData = @{
   - Improved validation on Collection parameter on `*-CosmosDBAttachment*` functions.
   - Improved validation on Document parameter on `*-CosmosDBAttachment*` functions.
   - Added tests to validate module manifest is valud - fixes [Issue #236](https://github.com/PlagueHO/CosmosDB/issues/236).
-
-  ## What is New in CosmosDB 2.1.12.137
-
-  October 30, 2018
-
-  - Added support for setting Collection uniqueKeyPolicy in
-    `New-CosmosDbCollection` and `Set-CosmosDbCollection` - fixes [Issue #197](https://github.com/PlagueHO/CosmosDB/issues/197).
   '
 
     } # End of PSData hashtable

--- a/src/CosmosDB.psd1
+++ b/src/CosmosDB.psd1
@@ -163,6 +163,8 @@ PrivateData = @{
 
   - Added support for `PartitionKey` in `*-CosmosDBAttachment`
     functions - fixes [Issue #274](https://github.com/PlagueHO/CosmosDB/issues/274).
+  - Update `cosmosdb.psdepend.psd1` to install modules `Az.Resources` 1.1.2 and
+    `Az.Accounts` 1.3.0.
 
   ## What is New in CosmosDB 3.2.0.320
 

--- a/src/CosmosDB.psd1
+++ b/src/CosmosDB.psd1
@@ -161,7 +161,7 @@ PrivateData = @{
 
   February 22, 2018
 
-  - Added support for `PartitionId` in `*-CosmosDBAttachment`
+  - Added support for `PartitionKey` in `*-CosmosDBAttachment`
     functions - fixes [Issue #274](https://github.com/PlagueHO/CosmosDB/issues/274).
 
   ## What is New in CosmosDB 3.2.0.320

--- a/src/lib/attachments/New-CosmosDbAttachment.ps1
+++ b/src/lib/attachments/New-CosmosDbAttachment.ps1
@@ -48,6 +48,11 @@ function New-CosmosDbAttachment
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
+        [System.String[]]
+        $PartitionKey,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ContentType,
 
@@ -90,10 +95,18 @@ function New-CosmosDbAttachment
 
     if ($PSBoundParameters.ContainsKey('Slug'))
     {
+        $null = $PSBoundParameters.Remove('Slug')
         $headers += @{
             'Slug' = $Slug
         }
-        $null = $PSBoundParameters.Remove('Slug')
+    }
+
+    if ($PSBoundParameters.ContainsKey('PartitionKey'))
+    {
+        $null = $PSBoundParameters.Remove('PartitionKey')
+        $headers += @{
+            'x-ms-documentdb-partitionkey' = '["' + ($PartitionKey -join '","') + '"]'
+        }
     }
 
     $body = ConvertTo-Json -InputObject $bodyObject

--- a/src/lib/attachments/Remove-CosmosDbAttachment.ps1
+++ b/src/lib/attachments/Remove-CosmosDbAttachment.ps1
@@ -43,7 +43,12 @@ function Remove-CosmosDbAttachment
         [Parameter(Mandatory = $true)]
         [ValidateScript({ Assert-CosmosDbAttachmentIdValid -Id $_ })]
         [System.String]
-        $Id
+        $Id,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.String[]]
+        $PartitionKey
     )
 
     $null = $PSBoundParameters.Remove('CollectionId')
@@ -52,8 +57,19 @@ function Remove-CosmosDbAttachment
 
     $resourcePath = ('colls/{0}/docs/{1}/attachments/{2}' -f $CollectionId, $DocumentId, $Id)
 
+    $headers = @{}
+
+    if ($PSBoundParameters.ContainsKey('PartitionKey'))
+    {
+        $null = $PSBoundParameters.Remove('PartitionKey')
+        $headers += @{
+            'x-ms-documentdb-partitionkey' = '["' + ($PartitionKey -join '","') + '"]'
+        }
+    }
+
     $null = Invoke-CosmosDbRequest @PSBoundParameters `
         -Method 'Delete' `
         -ResourceType 'attachments' `
-        -ResourcePath $resourcePath
+        -ResourcePath $resourcePath `
+        -Header $headers
 }

--- a/src/lib/attachments/Set-CosmosDbAttachment.ps1
+++ b/src/lib/attachments/Set-CosmosDbAttachment.ps1
@@ -53,6 +53,11 @@ function Set-CosmosDbAttachment
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
+        [System.String[]]
+        $PartitionKey,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $ContentType,
 
@@ -100,10 +105,18 @@ function Set-CosmosDbAttachment
 
     if ($PSBoundParameters.ContainsKey('Slug'))
     {
+        $null = $PSBoundParameters.Remove('Slug')
         $headers += @{
             'Slug' = $Slug
         }
-        $null = $PSBoundParameters.Remove('Slug')
+    }
+
+    if ($PSBoundParameters.ContainsKey('PartitionKey'))
+    {
+        $null = $PSBoundParameters.Remove('PartitionKey')
+        $headers += @{
+            'x-ms-documentdb-partitionkey' = '["' + ($PartitionKey -join '","') + '"]'
+        }
     }
 
     $body = ConvertTo-Json -InputObject $bodyObject

--- a/test/Integration/CosmosDB.integration.Tests.ps1
+++ b/test/Integration/CosmosDB.integration.Tests.ps1
@@ -68,6 +68,7 @@ $script:testDocumentUTF8UpdateBody = @"
 $script:testAttachmentId = 'testAttachment'
 $script:testAttachmentContentType = 'image/jpg'
 $script:testAttachmentMedia = 'www.bing.com'
+$script:testAttachmentMediaUpdated = 'www.contoso.com'
 $script:testStoredProcedureId = 'testStoredProcedure'
 $script:testStoredProcedureBody = @'
 function () {
@@ -794,6 +795,26 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
         }
     }
 
+    Context 'When updating an attachment from the document in a collection' {
+        It 'Should not throw an exception' {
+            $script:result = Set-CosmosDbAttachment `
+                -Context $script:testContext `
+                -CollectionId $script:testCollection `
+                -DocumentId $script:testDocumentId `
+                -Id $script:testAttachmentId `
+                -ContentType $script:testAttachmentContentType `
+                -Media $script:testAttachmentMediaUpdated `
+                -Verbose
+        }
+
+        It 'Should return expected object' {
+            Test-GenericResult -GenericResult $script:result
+            $script:result.Id | Should -Be $script:testAttachmentId
+            $script:result.ContentType | Should -Be $script:testAttachmentContentType
+            $script:result.Media | Should -Be $script:testAttachmentMediaUpdated
+        }
+    }
+
     Context 'When adding a read document permission for a user' {
         It 'Should not throw an exception' {
             $script:documentResourcePath = Get-CosmosDbDocumentResourcePath `
@@ -1185,6 +1206,79 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
             $script:result.Id | Should -Be $script:testDocumentId
             $script:result.Content | Should -Be 'Some string'
             $script:result.More | Should -Be 'Some other string'
+        }
+    }
+
+    Context 'When adding an attachment to the document in a collection with a partition key' {
+        It 'Should not throw an exception' {
+            $script:result = New-CosmosDbAttachment `
+                -Context $script:testContext `
+                -CollectionId $script:testCollection `
+                -DocumentId $script:testDocumentId `
+                -Id $script:testAttachmentId `
+                -PartitionKey $script:testDocumentId `
+                -ContentType $script:testAttachmentContentType `
+                -Media $script:testAttachmentMedia `
+                -Verbose
+        }
+
+        It 'Should return expected object' {
+            Test-GenericResult -GenericResult $script:result
+            $script:result.Id | Should -Be $script:testAttachmentId
+            $script:result.ContentType | Should -Be $script:testAttachmentContentType
+            $script:result.Media | Should -Be $script:testAttachmentMedia
+        }
+    }
+
+    Context 'When getting an attachment from the document in a collection with a partition key' {
+        It 'Should not throw an exception' {
+            $script:result = Get-CosmosDbAttachment `
+                -Context $script:testContext `
+                -CollectionId $script:testCollection `
+                -DocumentId $script:testDocumentId `
+                -Id $script:testAttachmentId `
+                -PartitionKey $script:testDocumentId `
+                -Verbose
+        }
+
+        It 'Should return expected object' {
+            Test-GenericResult -GenericResult $script:result
+            $script:result.Id | Should -Be $script:testAttachmentId
+            $script:result.ContentType | Should -Be $script:testAttachmentContentType
+            $script:result.Media | Should -Be $script:testAttachmentMedia
+        }
+    }
+
+    Context 'When updating an attachment from the document in a collection with a partition key' {
+        It 'Should not throw an exception' {
+            $script:result = Set-CosmosDbAttachment `
+                -Context $script:testContext `
+                -CollectionId $script:testCollection `
+                -DocumentId $script:testDocumentId `
+                -Id $script:testAttachmentId `
+                -PartitionKey $script:testDocumentId `
+                -ContentType $script:testAttachmentContentType `
+                -Media $script:testAttachmentMediaUpdated `
+                -Verbose
+        }
+
+        It 'Should return expected object' {
+            Test-GenericResult -GenericResult $script:result
+            $script:result.Id | Should -Be $script:testAttachmentId
+            $script:result.ContentType | Should -Be $script:testAttachmentContentType
+            $script:result.Media | Should -Be $script:testAttachmentMediaUpdated
+        }
+    }
+
+    Context 'When removing an attachment from the document in a collection with a partition key' {
+        It 'Should not throw an exception' {
+            $script:result = Remove-CosmosDbAttachment `
+                -Context $script:testContext `
+                -CollectionId $script:testCollection `
+                -DocumentId $script:testDocumentId `
+                -Id $script:testAttachmentId `
+                -PartitionKey $script:testDocumentId `
+                -Verbose
         }
     }
 

--- a/test/Integration/CosmosDB.integration.Tests.ps1
+++ b/test/Integration/CosmosDB.integration.Tests.ps1
@@ -8,7 +8,7 @@ $ModuleManifestName = 'CosmosDB.psd1'
 $ModuleManifestPath = "$PSScriptRoot\..\..\src\$ModuleManifestName"
 $TestHelperPath = "$PSScriptRoot\..\TestHelper"
 
-Import-Module -Name $ModuleManifestPath -Force
+Import-Module -Name $ModuleManifestPath -Force -Verbose:$false
 Import-Module -Name $TestHelperPath -Force
 
 Get-AzureServicePrincipal

--- a/test/Unit/CosmosDB.accounts.Tests.ps1
+++ b/test/Unit/CosmosDB.accounts.Tests.ps1
@@ -6,7 +6,7 @@ param (
 $ModuleManifestName = 'CosmosDB.psd1'
 $ModuleManifestPath = "$PSScriptRoot\..\..\src\$ModuleManifestName"
 
-Import-Module -Name $ModuleManifestPath -Force
+Import-Module -Name $ModuleManifestPath -Force -Verbose:$false
 
 InModuleScope CosmosDB {
     $TestHelperPath = "$PSScriptRoot\..\TestHelper"

--- a/test/Unit/CosmosDB.attachments.Tests.ps1
+++ b/test/Unit/CosmosDB.attachments.Tests.ps1
@@ -26,6 +26,7 @@ InModuleScope CosmosDB {
     }
     $script:testCollection = 'testCollection'
     $script:testDocument = 'testDocument'
+    $script:testPartitionKeys = 'testPartitionKey1', 'testPartitionKey2'
     $script:testAttachment1 = 'testAttachment1'
     $script:testAttachment2 = 'testAttachment2'
     $script:testContentType = 'image/jpg'
@@ -207,6 +208,42 @@ InModuleScope CosmosDB {
             }
         }
 
+        Context 'When called with context parameter and no id but with two partition keys' {
+            $script:result = $null
+
+            Mock `
+                -CommandName Invoke-CosmosDbRequest `
+                -MockWith { $script:testGetAttachmentResultMulti }
+
+            It 'Should not throw exception' {
+                $getCosmosDbAttachmentParameters = @{
+                    Context      = $script:testContext
+                    CollectionId = $script:testCollection
+                    DocumentId   = $script:testDocument
+                    PartitionKey = $script:testPartitionKeys
+                }
+
+                { $script:result = Get-CosmosDbAttachment @getCosmosDbAttachmentParameters } | Should -Not -Throw
+            }
+
+            It 'Should return expected result' {
+                $script:result.Count | Should -Be 2
+                $script:result[0].id | Should -Be $script:testAttachment1
+                $script:result[1].id | Should -Be $script:testAttachment2
+            }
+
+            It 'Should call expected mocks' {
+                Assert-MockCalled `
+                    -CommandName Invoke-CosmosDbRequest `
+                    -ParameterFilter {
+                        $Method -eq 'Get' -and `
+                        $ResourceType -eq 'Attachments' -and `
+                        $Headers.'x-ms-documentdb-partitionkey' -eq '["' + ($script:testPartitionKeys -join '","') + '"]'
+                    } `
+                    -Exactly -Times 1
+            }
+        }
+
         Context 'When called with context parameter and an id' {
             $script:result = $null
 
@@ -236,6 +273,42 @@ InModuleScope CosmosDB {
                         $Method -eq 'Get' -and `
                         $ResourceType -eq 'Attachments' -and `
                         $ResourcePath -eq ('colls/{0}/docs/{1}/attachments/{2}' -f $script:testCollection, $script:testDocument, $script:testAttachment1)
+                    } `
+                    -Exactly -Times 1
+            }
+        }
+
+        Context 'When called with context parameter and an id and with two partition keys' {
+            $script:result = $null
+
+            Mock `
+                -CommandName Invoke-CosmosDbRequest `
+                -MockWith { $script:testGetAttachmentResultSingle }
+
+            It 'Should not throw exception' {
+                $getCosmosDbAttachmentParameters = @{
+                    Context      = $script:testContext
+                    CollectionId = $script:testCollection
+                    DocumentId   = $script:testDocument
+                    Id           = $script:testAttachment1
+                    PartitionKey = $script:testPartitionKeys
+                }
+
+                { $script:result = Get-CosmosDbAttachment @getCosmosDbAttachmentParameters } | Should -Not -Throw
+            }
+
+            It 'Should return expected result' {
+                $script:result.id | Should -Be $script:testAttachment1
+            }
+
+            It 'Should call expected mocks' {
+                Assert-MockCalled `
+                    -CommandName Invoke-CosmosDbRequest `
+                    -ParameterFilter {
+                        $Method -eq 'Get' -and `
+                        $ResourceType -eq 'Attachments' -and `
+                        $ResourcePath -eq ('colls/{0}/docs/{1}/attachments/{2}' -f $script:testCollection, $script:testDocument, $script:testAttachment1) -and `
+                        $Headers.'x-ms-documentdb-partitionkey' -eq '["' + ($script:testPartitionKeys -join '","') + '"]'
                     } `
                     -Exactly -Times 1
             }
@@ -281,6 +354,43 @@ InModuleScope CosmosDB {
                     -Exactly -Times 1
             }
         }
+
+        Context 'When called with context parameter and an id and with two partition keys' {
+            $script:result = $null
+
+            Mock `
+                -CommandName Invoke-CosmosDbRequest `
+                -MockWith { $script:testGetAttachmentResultSingle }
+
+            It 'Should not throw exception' {
+                $newCosmosDbAttachmentParameters = @{
+                    Context      = $script:testContext
+                    CollectionId = $script:testCollection
+                    DocumentId   = $script:testDocument
+                    Id           = $script:testAttachment1
+                    ContentType  = $script:testContentType
+                    Media        = $script:testMedia
+                    PartitionKey = $script:testPartitionKeys
+                }
+
+                { $script:result = New-CosmosDbAttachment @newCosmosDbAttachmentParameters } | Should -Not -Throw
+            }
+
+            It 'Should return expected result' {
+                $script:result.id | Should -Be $script:testAttachment1
+            }
+
+            It 'Should call expected mocks' {
+                Assert-MockCalled `
+                    -CommandName Invoke-CosmosDbRequest `
+                    -ParameterFilter {
+                        $Method -eq 'Post' -and `
+                        $ResourceType -eq 'Attachments' -and `
+                        $Headers.'x-ms-documentdb-partitionkey' -eq '["' + ($script:testPartitionKeys -join '","') + '"]'
+                    } `
+                    -Exactly -Times 1
+            }
+        }
     }
 
     Describe 'Remove-CosmosDbAttachment' -Tag 'Unit' {
@@ -309,10 +419,41 @@ InModuleScope CosmosDB {
                 Assert-MockCalled `
                     -CommandName Invoke-CosmosDbRequest `
                     -ParameterFilter {
-                    $Method -eq 'Delete' -and `
+                        $Method -eq 'Delete' -and `
                         $ResourceType -eq 'Attachments' -and `
                         $ResourcePath -eq ('colls/{0}/docs/{1}/attachments/{2}' -f $script:testCollection, $script:testDocument, $script:testAttachment1)
-                } `
+                    } `
+                    -Exactly -Times 1
+            }
+        }
+
+        Context 'When called with context parameter and an id and with two partition keys' {
+            $script:result = $null
+
+            Mock `
+                -CommandName Invoke-CosmosDbRequest
+
+            It 'Should not throw exception' {
+                $removeCosmosDbAttachmentParameters = @{
+                    Context      = $script:testContext
+                    CollectionId = $script:testCollection
+                    DocumentId   = $script:testDocument
+                    Id           = $script:testAttachment1
+                    PartitionKey = $script:testPartitionKeys
+                }
+
+                { $script:result = Remove-CosmosDbAttachment @removeCosmosDbAttachmentParameters } | Should -Not -Throw
+            }
+
+            It 'Should call expected mocks' {
+                Assert-MockCalled `
+                    -CommandName Invoke-CosmosDbRequest `
+                    -ParameterFilter {
+                        $Method -eq 'Delete' -and `
+                        $ResourceType -eq 'Attachments' -and `
+                        $ResourcePath -eq ('colls/{0}/docs/{1}/attachments/{2}' -f $script:testCollection, $script:testDocument, $script:testAttachment1) -and `
+                        $Headers.'x-ms-documentdb-partitionkey' -eq '["' + ($script:testPartitionKeys -join '","') + '"]'
+                    } `
                     -Exactly -Times 1
             }
         }
@@ -351,6 +492,43 @@ InModuleScope CosmosDB {
                 Assert-MockCalled `
                     -CommandName Invoke-CosmosDbRequest `
                     -ParameterFilter { $Method -eq 'Put' -and $ResourceType -eq 'attachments' } `
+                    -Exactly -Times 1
+            }
+        }
+
+        Context 'When called with context parameter and an Id and with two partition keys' {
+            $script:result = $null
+
+            Mock `
+                -CommandName Invoke-CosmosDbRequest `
+                -MockWith { $script:testGetAttachmentResultSingle }
+
+            It 'Should not throw exception' {
+                $setCosmosDbAttachmentParameters = @{
+                    Context      = $script:testContext
+                    CollectionId = $script:testCollection
+                    DocumentId   = $script:testDocument
+                    Id           = $script:testAttachment1
+                    ContentType  = $script:testContentType
+                    Media        = $script:testMedia
+                    PartitionKey = $script:testPartitionKeys
+                }
+
+                { $script:result = Set-CosmosDbAttachment @setCosmosDbAttachmentParameters } | Should -Not -Throw
+            }
+
+            It 'Should return expected result' {
+                $script:result.id | Should -Be $script:testAttachment1
+            }
+
+            It 'Should call expected mocks' {
+                Assert-MockCalled `
+                    -CommandName Invoke-CosmosDbRequest `
+                    -ParameterFilter {
+                        $Method -eq 'Put' -and `
+                        $ResourceType -eq 'attachments' -and `
+                        $Headers.'x-ms-documentdb-partitionkey' -eq '["' + ($script:testPartitionKeys -join '","') + '"]'
+                    } `
                     -Exactly -Times 1
             }
         }

--- a/test/Unit/CosmosDB.attachments.Tests.ps1
+++ b/test/Unit/CosmosDB.attachments.Tests.ps1
@@ -6,7 +6,7 @@ param (
 $ModuleManifestName = 'CosmosDB.psd1'
 $ModuleManifestPath = "$PSScriptRoot\..\..\src\$ModuleManifestName"
 
-Import-Module -Name $ModuleManifestPath -Force
+Import-Module -Name $ModuleManifestPath -Force -Verbose:$false
 
 InModuleScope CosmosDB {
     $TestHelperPath = "$PSScriptRoot\..\TestHelper"

--- a/test/Unit/CosmosDB.collections.Tests.ps1
+++ b/test/Unit/CosmosDB.collections.Tests.ps1
@@ -6,7 +6,7 @@ param (
 $ModuleManifestName = 'CosmosDB.psd1'
 $ModuleManifestPath = "$PSScriptRoot\..\..\src\$ModuleManifestName"
 
-Import-Module -Name $ModuleManifestPath -Force
+Import-Module -Name $ModuleManifestPath -Force -Verbose:$false
 
 InModuleScope CosmosDB {
     $TestHelperPath = "$PSScriptRoot\..\TestHelper"

--- a/test/Unit/CosmosDB.databases.Tests.ps1
+++ b/test/Unit/CosmosDB.databases.Tests.ps1
@@ -6,7 +6,7 @@ param (
 $ModuleManifestName = 'CosmosDB.psd1'
 $ModuleManifestPath = "$PSScriptRoot\..\..\src\$ModuleManifestName"
 
-Import-Module -Name $ModuleManifestPath -Force
+Import-Module -Name $ModuleManifestPath -Force -Verbose:$false
 
 InModuleScope CosmosDB {
     $TestHelperPath = "$PSScriptRoot\..\TestHelper"

--- a/test/Unit/CosmosDB.documents.Tests.ps1
+++ b/test/Unit/CosmosDB.documents.Tests.ps1
@@ -6,7 +6,7 @@ param (
 $ModuleManifestName = 'CosmosDB.psd1'
 $ModuleManifestPath = "$PSScriptRoot\..\..\src\$ModuleManifestName"
 
-Import-Module -Name $ModuleManifestPath -Force
+Import-Module -Name $ModuleManifestPath -Force -Verbose:$false
 
 InModuleScope CosmosDB {
     $TestHelperPath = "$PSScriptRoot\..\TestHelper"

--- a/test/Unit/CosmosDB.offers.Tests.ps1
+++ b/test/Unit/CosmosDB.offers.Tests.ps1
@@ -6,7 +6,7 @@ param (
 $ModuleManifestName = 'CosmosDB.psd1'
 $ModuleManifestPath = "$PSScriptRoot\..\..\src\$ModuleManifestName"
 
-Import-Module -Name $ModuleManifestPath -Force
+Import-Module -Name $ModuleManifestPath -Force -Verbose:$false
 
 InModuleScope CosmosDB {
     $TestHelperPath = "$PSScriptRoot\..\TestHelper"

--- a/test/Unit/CosmosDB.permissions.Tests.ps1
+++ b/test/Unit/CosmosDB.permissions.Tests.ps1
@@ -6,7 +6,7 @@ param (
 $ModuleManifestName = 'CosmosDB.psd1'
 $ModuleManifestPath = "$PSScriptRoot\..\..\src\$ModuleManifestName"
 
-Import-Module -Name $ModuleManifestPath -Force
+Import-Module -Name $ModuleManifestPath -Force -Verbose:$false
 
 InModuleScope CosmosDB {
     $TestHelperPath = "$PSScriptRoot\..\TestHelper"

--- a/test/Unit/CosmosDB.storedprocedures.Tests.ps1
+++ b/test/Unit/CosmosDB.storedprocedures.Tests.ps1
@@ -6,7 +6,7 @@ param (
 $ModuleManifestName = 'CosmosDB.psd1'
 $ModuleManifestPath = "$PSScriptRoot\..\..\src\$ModuleManifestName"
 
-Import-Module -Name $ModuleManifestPath -Force
+Import-Module -Name $ModuleManifestPath -Force -Verbose:$false
 
 
 InModuleScope CosmosDB {

--- a/test/Unit/CosmosDB.triggers.Tests.ps1
+++ b/test/Unit/CosmosDB.triggers.Tests.ps1
@@ -6,7 +6,7 @@ param (
 $ModuleManifestName = 'CosmosDB.psd1'
 $ModuleManifestPath = "$PSScriptRoot\..\..\src\$ModuleManifestName"
 
-Import-Module -Name $ModuleManifestPath -Force
+Import-Module -Name $ModuleManifestPath -Force -Verbose:$false
 
 InModuleScope CosmosDB {
     $TestHelperPath = "$PSScriptRoot\..\TestHelper"

--- a/test/Unit/CosmosDB.userdefinedfunctions.Tests.ps1
+++ b/test/Unit/CosmosDB.userdefinedfunctions.Tests.ps1
@@ -6,7 +6,7 @@ param (
 $ModuleManifestName = 'CosmosDB.psd1'
 $ModuleManifestPath = "$PSScriptRoot\..\..\src\$ModuleManifestName"
 
-Import-Module -Name $ModuleManifestPath -Force
+Import-Module -Name $ModuleManifestPath -Force -Verbose:$false
 
 InModuleScope CosmosDB {
     $TestHelperPath = "$PSScriptRoot\..\TestHelper"

--- a/test/Unit/CosmosDB.users.Tests.ps1
+++ b/test/Unit/CosmosDB.users.Tests.ps1
@@ -6,7 +6,7 @@ param (
 $ModuleManifestName = 'CosmosDB.psd1'
 $ModuleManifestPath = "$PSScriptRoot\..\..\src\$ModuleManifestName"
 
-Import-Module -Name $ModuleManifestPath -Force
+Import-Module -Name $ModuleManifestPath -Force -Verbose:$false
 
 InModuleScope CosmosDB {
     $TestHelperPath = "$PSScriptRoot\..\TestHelper"

--- a/test/Unit/CosmosDB.utils.Tests.ps1
+++ b/test/Unit/CosmosDB.utils.Tests.ps1
@@ -6,7 +6,7 @@ param (
 $ModuleManifestName = 'CosmosDB.psd1'
 $ModuleManifestPath = "$PSScriptRoot\..\..\src\$ModuleManifestName"
 
-Import-Module -Name $ModuleManifestPath -Force
+Import-Module -Name $ModuleManifestPath -Force -Verbose:$false
 
 InModuleScope CosmosDB {
     $TestHelperPath = "$PSScriptRoot\..\TestHelper"


### PR DESCRIPTION
# Pull Request

This PR adds support for setting PartitionKey in *-CosmosDBAttachment functions. This prevents http 400 errors when working with attachments in collections with partition keys.

## Bug Fixes

- Fixes #274

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plagueho/cosmosdb/276)
<!-- Reviewable:end -->
