### PR TITLE
Pre-compile Custom Types to enable Functions 2.0 Support - Fixes #290

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,12 @@ matrix:
   include:
     - os: osx
       osx_image: xcode9.1
-      language: csharp
-      mono: none
-      dotnet: 2.1.700
       before_install:
         - brew update
         - brew tap caskroom/cask
         - brew cask install powershell
     - os: linux
       dist: trusty
-      language: csharp
-      mono: none
-      dotnet: 2.1.700
       sudo: required
       addons:
         apt:
@@ -26,4 +20,4 @@ matrix:
             - powershell
 
 script:
-- pwsh -c '.\psake.ps1 -TaskList Test -Verbose'
+- pwsh -c '.\psake.ps1 -TaskList Test'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,18 @@ matrix:
   include:
     - os: osx
       osx_image: xcode9.1
+      language: csharp
+      mono: none
+      dotnet: 2.1.700
       before_install:
         - brew update
         - brew tap caskroom/cask
         - brew cask install powershell
     - os: linux
       dist: trusty
+      language: csharp
+      mono: none
+      dotnet: 2.1.700
       sudo: required
       addons:
         apt:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## Unreleased
+
+- Moved CosmosDB namespace class definitions into C# project to be built
+  into a .NET Standard 2.0 DLL that can be loaded instead of a CS file.
+  This is to work around a problem with Azure Functions 2.0 where
+  types can not be compiled in the runtime (see [this issue](https://github.com/Azure/azure-functions-powershell-worker/issues/220)) -
+  fixes [Issue #290](https://github.com/PlagueHO/CosmosDB/issues/290).
+
 ## 3.2.4.375
 
 - Update `requirements.psd1` to install modules `Az.Resources` 1.3.1 and

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## What is New in CosmosDB Unreleased
+
+June 19, 2019
+
+- Moved CosmosDB namespace class definitions into C# project to be built
+  into a .NET Standard 2.0 DLL that can be loaded instead of a CS file.
+  This is to work around a problem with Azure Functions 2.0 where
+  types can not be compiled in the runtime (see [this issue](https://github.com/Azure/azure-functions-powershell-worker/issues/220)) -
+  fixes [Issue #290](https://github.com/PlagueHO/CosmosDB/issues/290).
+
 ## What is New in CosmosDB 3.2.4.375
 
 May 30, 2019

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,8 @@ image:
 - Visual Studio 2017
 - Visual Studio 2015
 
-build: false
+build_script:
+  - ps: . .\psake.ps1 -TaskList Build -Verbose
 
 test_script:
   - ps: . .\psake.ps1 -TaskList Test -Verbose

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,5 +7,7 @@ image:
 - Visual Studio 2017
 - Visual Studio 2015
 
+build: false
+
 test_script:
   - ps: . .\psake.ps1 -TaskList Test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-﻿#---------------------------------#
+#---------------------------------#
 #      environment configuration  #
 #---------------------------------#
 version: 1.0.0.{build}
@@ -7,8 +7,5 @@ image:
 - Visual Studio 2017
 - Visual Studio 2015
 
-build_script:
-  - ps: . .\psake.ps1 -TaskList Build -Verbose
-
 test_script:
-  - ps: . .\psake.ps1 -TaskList Test -Verbose
+  - ps: . .\psake.ps1 -TaskList Test

--- a/azure-pipelines.daily.yml
+++ b/azure-pipelines.daily.yml
@@ -11,8 +11,18 @@ jobs:
       persistCredentials: true
 
     - powershell: |
-        .\psake.ps1 -TaskList Test -Verbose
-      displayName: 'Execute Tests'
+        .\psake.ps1 -TaskList Build -Verbose
+      displayName: 'Build and Stage Module'
+      env:
+        azureApplicationId: $(azureApplicationId)
+        azureApplicationPassword: $(azureApplicationPassword)
+        azureSubscriptionId: $(azureSubscriptionId)
+        azureTenantId: $(azureTenantId)
+        githubRepoToken: $(githubRepoToken)
+
+    - powershell: |
+        .\psake.ps1 -TaskList UnitTest -Verbose
+      displayName: 'Execute Unit Tests'
       env:
         azureApplicationId: $(azureApplicationId)
         azureApplicationPassword: $(azureApplicationPassword)
@@ -21,26 +31,36 @@ jobs:
         githubRepoToken: $(githubRepoToken)
 
     - task: PublishTestResults@2
+      displayName: 'Publish Unit Test Results'
       inputs:
         testRunner: 'NUnit'
         testResultsFiles: '**/Unit/TestResults.unit.xml'
         testRunTitle: 'PS_Win2016_Unit'
-      displayName: 'Publish Unit Test Results'
       condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues', 'Failed')
 
     - task: PublishCodeCoverageResults@1
+      displayName: 'Publish Unit Test Code Coverage'
       inputs:
         summaryFileLocation: '**/Unit/CodeCoverage.xml'
         failIfCoverageEmpty: true
-      displayName: 'Publish Unit Test Code Coverage'
       condition: and(in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues', 'Failed'), eq(variables['System.PullRequest.IsFork'], false))
 
+    - powershell: |
+        .\psake.ps1 -TaskList IntegrationTest -Parameters @{ TestStagedModule = $true } -Verbose
+      displayName: 'Execute Integration Tests'
+      env:
+        azureApplicationId: $(azureApplicationId)
+        azureApplicationPassword: $(azureApplicationPassword)
+        azureSubscriptionId: $(azureSubscriptionId)
+        azureTenantId: $(azureTenantId)
+        githubRepoToken: $(githubRepoToken)
+
     - task: PublishTestResults@2
+      displayName: 'Publish Integration Test Results'
       inputs:
         testRunner: 'NUnit'
         testResultsFiles: '**/Integration/TestResults.integration.xml'
         testRunTitle: 'PS_Win2016_Integration'
-      displayName: 'Publish Integration Test Results'
       condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues', 'Failed')
 
   - job: Build_PSCore_Ubuntu1604
@@ -56,8 +76,8 @@ jobs:
       displayName: 'Install PowerShell Core'
 
     - script: |
-        pwsh -c '.\psake.ps1 -TaskList Test -Verbose'
-      displayName: 'Execute Tests'
+        pwsh -c '.\psake.ps1 -TaskList UnitTest -Verbose'
+      displayName: 'Execute Unit Tests'
       env:
         azureApplicationId: $(azureApplicationId)
         azureApplicationPassword: $(azureApplicationPassword)
@@ -65,19 +85,28 @@ jobs:
         azureTenantId: $(azureTenantId)
 
     - task: PublishTestResults@2
+      displayName: 'Publish Unit Test Results'
       inputs:
         testRunner: 'NUnit'
-        testResultsFiles: '**/Unit/TestResults.unit.xml'
-        testRunTitle: 'PSCore_Ubuntu1604_Unit'
-      displayName: 'Publish Unit Test Results'
+        testResultsFiles: '**/TestResults.unit.xml'
+        testRunTitle: 'PSCore_MacOS1013_Unit'
       condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues', 'Failed')
 
+    - script: |
+        pwsh -c '.\psake.ps1 -TaskList IntegrationTest -Verbose'
+      displayName: 'Execute Integration Tests'
+      env:
+        azureApplicationId: $(azureApplicationId)
+        azureApplicationPassword: $(azureApplicationPassword)
+        azureSubscriptionId: $(azureSubscriptionId)
+        azureTenantId: $(azureTenantId)
+
     - task: PublishTestResults@2
+      displayName: 'Publish Integration Test Results'
       inputs:
         testRunner: 'NUnit'
-        testResultsFiles: '**/Integration/TestResults.integration.xml'
-        testRunTitle: 'PSCore_Ubuntu1604_Integration'
-      displayName: 'Publish Integration Test Results'
+        testResultsFiles: '**/TestResults.integration.xml'
+        testRunTitle: 'PSCore_MacOS1013_Integration'
       condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues', 'Failed')
 
   - job: Build_PSCore_MacOS1013
@@ -93,8 +122,8 @@ jobs:
       displayName: 'Install PowerShell Core'
 
     - script: |
-        pwsh -c '.\psake.ps1 -TaskList Test -Verbose'
-      displayName: 'Execute Tests'
+        pwsh -c '.\psake.ps1 -TaskList UnitTest -Verbose'
+      displayName: 'Execute Unit Tests'
       env:
         azureApplicationId: $(azureApplicationId)
         azureApplicationPassword: $(azureApplicationPassword)
@@ -102,17 +131,26 @@ jobs:
         azureTenantId: $(azureTenantId)
 
     - task: PublishTestResults@2
+      displayName: 'Publish Unit Test Results'
       inputs:
         testRunner: 'NUnit'
         testResultsFiles: '**/TestResults.unit.xml'
         testRunTitle: 'PSCore_MacOS1013_Unit'
-      displayName: 'Publish Unit Test Results'
       condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues', 'Failed')
 
+    - script: |
+        pwsh -c '.\psake.ps1 -TaskList IntegrationTest -Parameters @{ TestStagedModule = $true } -Verbose'
+      displayName: 'Execute Integration Tests on Staged Module'
+      env:
+        azureApplicationId: $(azureApplicationId)
+        azureApplicationPassword: $(azureApplicationPassword)
+        azureSubscriptionId: $(azureSubscriptionId)
+        azureTenantId: $(azureTenantId)
+
     - task: PublishTestResults@2
+      displayName: 'Publish Integration Test Results'
       inputs:
         testRunner: 'NUnit'
         testResultsFiles: '**/TestResults.integration.xml'
         testRunTitle: 'PSCore_MacOS1013_Integration'
-      displayName: 'Publish Integration Test Results'
       condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues', 'Failed')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,39 +17,6 @@ jobs:
       persistCredentials: true
 
     - powershell: |
-        .\psake.ps1 -TaskList Test -Verbose
-      displayName: 'Execute Tests'
-      env:
-        azureApplicationId: $(azureApplicationId)
-        azureApplicationPassword: $(azureApplicationPassword)
-        azureSubscriptionId: $(azureSubscriptionId)
-        azureTenantId: $(azureTenantId)
-        githubRepoToken: $(githubRepoToken)
-
-    - task: PublishTestResults@2
-      inputs:
-        testRunner: 'NUnit'
-        testResultsFiles: '**/Unit/TestResults.unit.xml'
-        testRunTitle: 'PS_Win2016_Unit'
-      displayName: 'Publish Unit Test Results'
-      condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues', 'Failed')
-
-    - task: PublishCodeCoverageResults@1
-      inputs:
-        summaryFileLocation: '**/Unit/CodeCoverage.xml'
-        failIfCoverageEmpty: true
-      displayName: 'Publish Unit Test Code Coverage'
-      condition: and(in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues', 'Failed'), eq(variables['System.PullRequest.IsFork'], false))
-
-    - task: PublishTestResults@2
-      inputs:
-        testRunner: 'NUnit'
-        testResultsFiles: '**/Integration/TestResults.integration.xml'
-        testRunTitle: 'PS_Win2016_Integration'
-      displayName: 'Publish Integration Test Results'
-      condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues', 'Failed')
-
-    - powershell: |
         .\psake.ps1 -TaskList Build -Verbose
       displayName: 'Build and Stage Module'
       env:
@@ -59,35 +26,78 @@ jobs:
         azureTenantId: $(azureTenantId)
         githubRepoToken: $(githubRepoToken)
 
+    - powershell: |
+        .\psake.ps1 -TaskList UnitTest -Verbose
+      displayName: 'Execute Unit Tests'
+      env:
+        azureApplicationId: $(azureApplicationId)
+        azureApplicationPassword: $(azureApplicationPassword)
+        azureSubscriptionId: $(azureSubscriptionId)
+        azureTenantId: $(azureTenantId)
+        githubRepoToken: $(githubRepoToken)
+
+    - task: PublishTestResults@2
+      displayName: 'Publish Unit Test Results'
+      inputs:
+        testRunner: 'NUnit'
+        testResultsFiles: '**/Unit/TestResults.unit.xml'
+        testRunTitle: 'PS_Win2016_Unit'
+      condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues', 'Failed')
+
+    - task: PublishCodeCoverageResults@1
+      displayName: 'Publish Unit Test Code Coverage'
+      inputs:
+        summaryFileLocation: '**/Unit/CodeCoverage.xml'
+        failIfCoverageEmpty: true
+      condition: and(in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues', 'Failed'), eq(variables['System.PullRequest.IsFork'], false))
+
+    - powershell: |
+        .\psake.ps1 -TaskList IntegrationTest -Parameters @{ TestStagedModule = $true } -Verbose
+      displayName: 'Execute Integration Tests on Staged Module'
+      env:
+        azureApplicationId: $(azureApplicationId)
+        azureApplicationPassword: $(azureApplicationPassword)
+        azureSubscriptionId: $(azureSubscriptionId)
+        azureTenantId: $(azureTenantId)
+        githubRepoToken: $(githubRepoToken)
+
+    - task: PublishTestResults@2
+      displayName: 'Publish Integration Test Results'
+      inputs:
+        testRunner: 'NUnit'
+        testResultsFiles: '**/Integration/TestResults.integration.xml'
+        testRunTitle: 'PS_Win2016_Integration'
+      condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues', 'Failed')
+
     - task: PublishBuildArtifacts@1
+      displayName: 'Publish Module'
       inputs:
         pathtoPublish: 'staging/CosmosDB'
         artifactName: 'CosmosDB'
-      displayName: 'Publish Module'
 
     - task: PublishBuildArtifacts@1
+      displayName: 'Publish Module Zip'
       inputs:
         pathtoPublish: 'staging/zip'
         artifactName: 'zip'
-      displayName: 'Publish Module Zip'
 
     - task: PublishBuildArtifacts@1
+      displayName: 'Publish PSake File'
       inputs:
         pathtoPublish: 'psakefile.ps1'
         artifactName: 'scripts'
-      displayName: 'Publish PSake File'
 
     - task: PublishBuildArtifacts@1
+      displayName: 'Publish PSDepend File'
       inputs:
         pathtoPublish: 'requirements.psd1'
         artifactName: 'scripts'
-      displayName: 'Publish PSDepend File'
 
     - task: PublishBuildArtifacts@1
+      displayName: 'Publish Build File'
       inputs:
         pathtoPublish: 'psake.ps1'
         artifactName: 'scripts'
-      displayName: 'Publish Build File'
 
   - job: Build_PSCore_Ubuntu1604
     pool:
@@ -102,8 +112,8 @@ jobs:
       displayName: 'Install PowerShell Core'
 
     - script: |
-        pwsh -c '.\psake.ps1 -TaskList Test -Verbose'
-      displayName: 'Execute Tests'
+        pwsh -c '.\psake.ps1 -TaskList UnitTest -Verbose'
+      displayName: 'Execute Unit Tests'
       env:
         azureApplicationId: $(azureApplicationId)
         azureApplicationPassword: $(azureApplicationPassword)
@@ -111,19 +121,28 @@ jobs:
         azureTenantId: $(azureTenantId)
 
     - task: PublishTestResults@2
+      displayName: 'Publish Unit Test Results'
       inputs:
         testRunner: 'NUnit'
         testResultsFiles: '**/Unit/TestResults.unit.xml'
         testRunTitle: 'PSCore_Ubuntu1604_Unit'
-      displayName: 'Publish Unit Test Results'
       condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues', 'Failed')
 
+    - script: |
+        pwsh -c '.\psake.ps1 -TaskList IntegrationTest -Verbose'
+      displayName: 'Execute Integration Tests'
+      env:
+        azureApplicationId: $(azureApplicationId)
+        azureApplicationPassword: $(azureApplicationPassword)
+        azureSubscriptionId: $(azureSubscriptionId)
+        azureTenantId: $(azureTenantId)
+
     - task: PublishTestResults@2
+      displayName: 'Publish Integration Test Results'
       inputs:
         testRunner: 'NUnit'
         testResultsFiles: '**/Integration/TestResults.integration.xml'
         testRunTitle: 'PSCore_Ubuntu1604_Integration'
-      displayName: 'Publish Integration Test Results'
       condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues', 'Failed')
 
   - job: Build_PSCore_MacOS1013
@@ -139,8 +158,8 @@ jobs:
       displayName: 'Install PowerShell Core'
 
     - script: |
-        pwsh -c '.\psake.ps1 -TaskList Test -Verbose'
-      displayName: 'Execute Tests'
+        pwsh -c '.\psake.ps1 -TaskList UnitTest -Verbose'
+      displayName: 'Execute Unit Tests'
       env:
         azureApplicationId: $(azureApplicationId)
         azureApplicationPassword: $(azureApplicationPassword)
@@ -148,17 +167,26 @@ jobs:
         azureTenantId: $(azureTenantId)
 
     - task: PublishTestResults@2
+      displayName: 'Publish Unit Test Results'
       inputs:
         testRunner: 'NUnit'
         testResultsFiles: '**/TestResults.unit.xml'
         testRunTitle: 'PSCore_MacOS1013_Unit'
-      displayName: 'Publish Unit Test Results'
       condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues', 'Failed')
 
+    - script: |
+        pwsh -c '.\psake.ps1 -TaskList IntegrationTest -Verbose'
+      displayName: 'Execute Integration Tests'
+      env:
+        azureApplicationId: $(azureApplicationId)
+        azureApplicationPassword: $(azureApplicationPassword)
+        azureSubscriptionId: $(azureSubscriptionId)
+        azureTenantId: $(azureTenantId)
+
     - task: PublishTestResults@2
+      displayName: 'Publish Integration Test Results'
       inputs:
         testRunner: 'NUnit'
         testResultsFiles: '**/TestResults.integration.xml'
         testRunTitle: 'PSCore_MacOS1013_Integration'
-      displayName: 'Publish Integration Test Results'
       condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues', 'Failed')

--- a/psake.ps1
+++ b/psake.ps1
@@ -31,8 +31,7 @@ Invoke-PSDepend `
     -Force `
     -Import `
     -Install `
-    -Tags 'Bootstrap' `
-    -Verbose:$false
+    -Tags 'Bootstrap'
 
 # Execute the PSake tasts from the psakefile.ps1
 Invoke-Psake `

--- a/psake.ps1
+++ b/psake.ps1
@@ -31,7 +31,8 @@ Invoke-PSDepend `
     -Force `
     -Import `
     -Install `
-    -Tags 'Bootstrap'
+    -Tags 'Bootstrap' `
+    -Verbose:$false
 
 # Execute the PSake tasts from the psakefile.ps1
 Invoke-Psake `

--- a/psakefile.ps1
+++ b/psakefile.ps1
@@ -185,6 +185,11 @@ Task Build -Depends Init {
         -Install `
         -Tags 'Build'
 
+    # Build the Classes
+    $classesProjectFolder = Join-Path -Path $ProjectRoot -ChildPath 'src/classes/CosmosDB'
+    $classesProjectPath = Join-Path -Path $classesProjectFolder -ChildPath 'CosmosDB.csproj'
+    & dotnet @('build',$classesProjectPath,'/p:Configuration=Release')
+
     # Generate the next version by adding the build system build number to the manifest version
     $manifestPath = Join-Path -Path $ProjectRoot -ChildPath "src/$ModuleName.psd1"
     $newVersion = Get-VersionNumber `
@@ -219,6 +224,7 @@ Task Build -Depends Init {
     $null = Copy-Item -Path (Join-Path -Path $ProjectRoot -ChildPath 'README.md') -Destination $versionFolder
     $null = Copy-Item -Path (Join-Path -Path $ProjectRoot -ChildPath 'CHANGELOG.md') -Destination $versionFolder
     $null = Copy-Item -Path (Join-Path -Path $ProjectRoot -ChildPath 'RELEASENOTES.md') -Destination $versionFolder
+    $null = Copy-Item -Path (Join-Path -Path $classesProjectFolder -ChildPath 'bin/release/netstandard2.0/CosmosDB.dll') -Destination $versionFolder
 
     # Load the Libs files into the PSM1
     $libFiles = Get-ChildItem `

--- a/psakefile.ps1
+++ b/psakefile.ps1
@@ -234,6 +234,7 @@ Task Build -Depends Init {
 
     # Assemble all the libs content into a single string
     $libFilesStringBuilder = [System.Text.StringBuilder]::new()
+
     foreach ($libFile in $libFiles)
     {
         $libContent = Get-Content -Path $libFile -Raw
@@ -250,6 +251,7 @@ Task Build -Depends Init {
     $moduleContent = Get-Content -Path $modulePath
     $moduleStringBuilder = [System.Text.StringBuilder]::new()
     $importFunctionsRegionFound = $false
+
     foreach ($moduleLine in $moduleContent)
     {
         if ($importFunctionsRegionFound)
@@ -274,6 +276,7 @@ Task Build -Depends Init {
             }
         }
     }
+
     Set-Content -Path $modulePath -Value $moduleStringBuilder -Force
 
     # Prepare external help
@@ -351,6 +354,7 @@ Task Build -Depends Init {
     $zipFilePath = Join-Path `
         -Path $zipFileFolder `
         -ChildPath "${ENV:BHProjectName}_$newVersion.zip"
+
     if (Test-Path -Path $zipFilePath)
     {
         $null = Remove-Item -Path $zipFilePath

--- a/psakefile.ps1
+++ b/psakefile.ps1
@@ -3,6 +3,7 @@
 Properties {
     # Prepare the folder variables
     $ProjectRoot = $ENV:BHProjectPath
+
     if (-not $ProjectRoot)
     {
         $ProjectRoot = $PSScriptRoot
@@ -139,9 +140,30 @@ Task IntegrationTest -Depends Init, PrepareTest {
 
     # Execute tests
     $testScriptsPath = Join-Path -Path $ProjectRoot -ChildPath 'test\Integration'
+
+    if ($TestStagedModule)
+    {
+        # Get the path to the staged module
+        $stagingFolder = Join-Path -Path $ProjectRoot -ChildPath 'staging'
+        $stagedModulesFolder = Join-Path -Path $stagingFolder -ChildPath $ModuleName
+        $mostRecentStagedModulePath = Get-MostRecentStagedModulePath -StagedModulesFolder $stagedModulesFolder
+        $testScript = @{
+            Path = $testScriptsPath
+            Parameters = @{
+                ModuleRootPath = $mostRecentStagedModulePath
+            }
+        }
+        "Executing integration tests on Staged Module in $mostRecentStagedModulePath"
+    }
+    else
+    {
+        "Executing integration tests on src folder"
+        $testScript = $testScriptsPath
+    }
+
     $testResultsFile = Join-Path -Path $testScriptsPath -ChildPath 'TestResults.integration.xml'
     $testResults = Invoke-Pester `
-        -Script $testScriptsPath `
+        -Script $testScript `
         -OutputFormat NUnitXml `
         -OutputFile $testResultsFile `
         -PassThru `
@@ -203,15 +225,15 @@ Task Build -Depends Init {
     }
 
     # Determine the folder names for staging the module
-    $StagingFolder = Join-Path -Path $ProjectRoot -ChildPath 'staging'
-    $ModuleFolder = Join-Path -Path $StagingFolder -ChildPath $ModuleName
+    $stagingFolder = Join-Path -Path $ProjectRoot -ChildPath 'staging'
+    $moduleFolder = Join-Path -Path $stagingFolder -ChildPath $ModuleName
 
     # Determine the folder names for staging the module
-    $versionFolder = Join-Path -Path $ModuleFolder -ChildPath $newVersion
+    $versionFolder = Join-Path -Path $moduleFolder -ChildPath $newVersion
 
     # Stage the module
-    $null = New-Item -Path $StagingFolder -Type directory -ErrorAction SilentlyContinue
-    $null = New-Item -Path $ModuleFolder -Type directory -ErrorAction SilentlyContinue
+    $null = New-Item -Path $stagingFolder -Type directory -ErrorAction SilentlyContinue
+    $null = New-Item -Path $moduleFolder -Type directory -ErrorAction SilentlyContinue
     Remove-Item -Path $versionFolder -Recurse -Force -ErrorAction SilentlyContinue
     $null = New-Item -Path $versionFolder -Type directory
 
@@ -346,7 +368,7 @@ Task Build -Depends Init {
 
     # Create zip artifact
     $zipFileFolder = Join-Path `
-        -Path $StagingFolder `
+        -Path $stagingFolder `
         -ChildPath 'zip'
 
     $null = New-Item -Path $zipFileFolder -Type directory -ErrorAction SilentlyContinue
@@ -360,7 +382,7 @@ Task Build -Depends Init {
         $null = Remove-Item -Path $zipFilePath
     }
     $null = Add-Type -assemblyname System.IO.Compression.FileSystem
-    [System.IO.Compression.ZipFile]::CreateFromDirectory($ModuleFolder, $zipFilePath)
+    [System.IO.Compression.ZipFile]::CreateFromDirectory($moduleFolder, $zipFilePath)
 
     # Update the Git Repo if this is the master branch build in VSTS
     if ($ENV:BHBuildSystem -eq 'VSTS')
@@ -449,7 +471,7 @@ Task Deploy {
     $separator
 
     # Determine the folder name for the Module
-    $ModuleFolder = Join-Path -Path $ProjectRoot -ChildPath $ModuleName
+    $moduleFolder = Join-Path -Path $ProjectRoot -ChildPath $ModuleName
 
     # Install any dependencies required for the Deploy stage
     Invoke-PSDepend `
@@ -463,9 +485,9 @@ Task Deploy {
     $PSModulePath = ($ENV:PSModulePath -split ';')[0]
     $destinationPath = Join-Path -Path $PSModulePath -ChildPath $ModuleName
 
-    "Copying Module from $ModuleFolder to $destinationPath"
+    "Copying Module from $moduleFolder to $destinationPath"
     Copy-Item `
-        -Path $ModuleFolder `
+        -Path $moduleFolder `
         -Destination $destinationPath `
         -Container `
         -Recurse `
@@ -569,4 +591,32 @@ function Invoke-Git
     {
         Write-Warning -Message $_
     }
+}
+
+<#
+    .SYNOPSIS
+        Get path to most recent staged module.
+
+    .PARAMETER StagedModulesFolder
+        Path to folder containing staged modules.
+#>
+function Get-MostRecentStagedModulePath
+{
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $StagedModulesFolder
+    )
+
+    $stagedModules = Get-ChildItem -Path $StagedModulesFolder
+
+    if ($null -eq $stagedModules)
+    {
+        throw 'There are no currently staged modules in {0}' -f $StagedModulesFolder
+    }
+
+    return ($stagedModules | Sort-Object -Property Name -Descending | Select-Object -First 1).Fullname
 }

--- a/requirements.psd1
+++ b/requirements.psd1
@@ -80,7 +80,7 @@
         }
         Target         = 'CurrentUser'
         MinimumVersion = '1.5.1'
-        Tags           = 'Test','Deploy'
+        Tags           = 'Build','Test','Deploy'
     }
 
     AzResources       = @{
@@ -92,6 +92,6 @@
         }
         Target         = 'CurrentUser'
         MinimumVersion = '1.3.1'
-        Tags           = 'Test','Deploy'
+        Tags           = 'Build','Test','Deploy'
     }
 }

--- a/src/CosmosDB.psd1
+++ b/src/CosmosDB.psd1
@@ -12,7 +12,7 @@
 RootModule = 'CosmosDB.psm1'
 
 # Version number of this module.
-ModuleVersion = '3.2.4.375'
+ModuleVersion = '3.3.0.375'
 
 # Supported PSEditions
 CompatiblePSEditions = 'Core', 'Desktop'
@@ -157,6 +157,16 @@ PrivateData = @{
 
         # ReleaseNotes of this module
         ReleaseNotes = '
+  ## What is New in CosmosDB Unreleased
+
+  June 19, 2019
+
+  - Moved CosmosDB namespace class definitions into C# project to be built
+    into a .NET Standard 2.0 DLL that can be loaded instead of a CS file.
+    This is to work around a problem with Azure Functions 2.0 where
+    types can not be compiled in the runtime (see [this issue](https://github.com/Azure/azure-functions-powershell-worker/issues/220)) -
+    fixes [Issue #290](https://github.com/PlagueHO/CosmosDB/issues/290).
+
   ## What is New in CosmosDB 3.2.4.375
 
   May 30, 2019
@@ -276,13 +286,6 @@ PrivateData = @{
   - Renamed `ResultHeaders` parameter to `ResponseHeader` in
     `Get-CosmosDbDocuments` function to adhere to PowerShell standards,
     but included alias for `ResultHeaders` to prevent breaking change.
-
-  ## What is New in CosmosDB 2.1.14.220
-
-  November 15, 2018
-
-  - Extended maximum length of Account Name parameter to be 50 characters - fixes
-    [Issue #201](https://github.com/PlagueHO/CosmosDB/issues/201).
   '
 
     } # End of PSData hashtable
@@ -296,5 +299,3 @@ PrivateData = @{
 # DefaultCommandPrefix = ''
 
 }
-
-

--- a/src/CosmosDB.psd1
+++ b/src/CosmosDB.psd1
@@ -51,8 +51,7 @@ PowerShellVersion = '5.1'
 # ProcessorArchitecture = ''
 
 # Modules that must be imported into the global environment prior to importing this module
-RequiredModules = @(@{ModuleName = 'Az.Accounts'; GUID = '17a2feff-488b-47f9-8729-e2cec094624c'; ModuleVersion = '1.0.0'; }, 
-               @{ModuleName = 'Az.Resources'; GUID = '48bb344d-4c24-441e-8ea0-589947784700'; ModuleVersion = '1.0.0'; })
+RequiredModules = @(@{ModuleName = 'Az.Accounts'; GUID = '17a2feff-488b-47f9-8729-e2cec094624c'; ModuleVersion = '1.0.0'; }, @{ModuleName = 'Az.Resources'; GUID = '48bb344d-4c24-441e-8ea0-589947784700'; ModuleVersion = '1.0.0'; })
 
 # Assemblies that must be loaded prior to importing this module
 # RequiredAssemblies = @()
@@ -61,63 +60,63 @@ RequiredModules = @(@{ModuleName = 'Az.Accounts'; GUID = '17a2feff-488b-47f9-872
 # ScriptsToProcess = @()
 
 # Type files (.ps1xml) to be loaded when importing this module
-TypesToProcess = 'types\attachments.types.ps1xml', 'types\collections.types.ps1xml', 
-               'types\databases.types.ps1xml', 'types\documents.types.ps1xml', 
-               'types\offers.types.ps1xml', 'types\permissions.types.ps1xml', 
-               'types\storedprocedures.types.ps1xml', 
-               'types\triggers.types.ps1xml', 
-               'types\userdefinedfunctions.types.ps1xml', 
+TypesToProcess = 'types\attachments.types.ps1xml', 'types\collections.types.ps1xml',
+               'types\databases.types.ps1xml', 'types\documents.types.ps1xml',
+               'types\offers.types.ps1xml', 'types\permissions.types.ps1xml',
+               'types\storedprocedures.types.ps1xml',
+               'types\triggers.types.ps1xml',
+               'types\userdefinedfunctions.types.ps1xml',
                'types\users.types.ps1xml'
 
 # Format files (.ps1xml) to be loaded when importing this module
-FormatsToProcess = 'formats\attachments.formats.ps1xml', 
-               'formats\collections.formats.ps1xml', 
-               'formats\databases.formats.ps1xml', 
-               'formats\documents.formats.ps1xml', 'formats\offers.formats.ps1xml', 
-               'formats\permissions.formats.ps1xml', 
-               'formats\storedprocedures.formats.ps1xml', 
-               'formats\triggers.formats.ps1xml', 
-               'formats\userdefinedfunctions.formats.ps1xml', 
+FormatsToProcess = 'formats\attachments.formats.ps1xml',
+               'formats\collections.formats.ps1xml',
+               'formats\databases.formats.ps1xml',
+               'formats\documents.formats.ps1xml', 'formats\offers.formats.ps1xml',
+               'formats\permissions.formats.ps1xml',
+               'formats\storedprocedures.formats.ps1xml',
+               'formats\triggers.formats.ps1xml',
+               'formats\userdefinedfunctions.formats.ps1xml',
                'formats\users.formats.ps1xml'
 
 # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
 # NestedModules = @()
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-FunctionsToExport = 'Get-CosmosDbAccount', 'Get-CosmosDbAccountConnectionString', 
-               'Get-CosmosDbAccountMasterKey', 'Get-CosmosDbAttachment', 
-               'Get-CosmosDbAttachmentResourcePath', 'Get-CosmosDbCollection', 
-               'Get-CosmosDbCollectionResourcePath', 'Get-CosmosDbCollectionSize', 
-               'Get-CosmosDBDatabase', 'Get-CosmosDBDatabaseResourcePath', 
-               'Get-CosmosDBDocument', 'Get-CosmosDBDocumentResourcePath', 
-               'Get-CosmosDBOffer', 'Get-CosmosDBOfferResourcePath', 
-               'Get-CosmosDbPermission', 'Get-CosmosDbPermissionResourcePath', 
-               'Get-CosmosDbStoredProcedure', 
-               'Get-CosmosDbStoredProcedureResourcePath', 'Get-CosmosDbTrigger', 
-               'Get-CosmosDbTriggerResourcePath', 'Get-CosmosDbUser', 
-               'Get-CosmosDbUserResourcePath', 'Get-CosmosDbUserDefinedFunction', 
-               'Get-CosmosDbUserDefinedFunctionResourcePath', 
-               'Invoke-CosmosDbStoredProcedure', 'New-CosmosDbAccount', 
-               'New-CosmosDbAccountMasterKey', 'New-CosmosDbAttachment', 
-               'New-CosmosDbBackoffPolicy', 'New-CosmosDbCollection', 
-               'New-CosmosDbCollectionIncludedPathIndex', 
-               'New-CosmosDbCollectionIncludedPath', 
-               'New-CosmosDbCollectionExcludedPath', 
-               'New-CosmosDbCollectionIndexingPolicy', 
-               'New-CosmosDbCollectionUniqueKey', 
-               'New-CosmosDbCollectionUniqueKeyPolicy', 'New-CosmosDbDatabase', 
-               'New-CosmosDbDocument', 'New-CosmosDbContext', 
-               'New-CosmosDbContextToken', 'New-CosmosDbPermission', 
-               'New-CosmosDbStoredProcedure', 'New-CosmosDbTrigger', 
-               'New-CosmosDbUser', 'New-CosmosDbUserDefinedFunction', 
-               'Remove-CosmosDbAccount', 'Remove-CosmosDbAttachment', 
-               'Remove-CosmosDbCollection', 'Remove-CosmosDbDatabase', 
-               'Remove-CosmosDbDocument', 'Remove-CosmosDbPermission', 
-               'Remove-CosmosDbStoredProcedure', 'Remove-CosmosDbTrigger', 
-               'Remove-CosmosDbUser', 'Remove-CosmosDbUserDefinedFunction', 
-               'Set-CosmosDbAccount', 'Set-CosmosDbAttachment', 
-               'Set-CosmosDbCollection', 'Set-CosmosDbDocument', 'Set-CosmosDbOffer', 
-               'Set-CosmosDbStoredProcedure', 'Set-CosmosDbTrigger', 
+FunctionsToExport = 'Get-CosmosDbAccount', 'Get-CosmosDbAccountConnectionString',
+               'Get-CosmosDbAccountMasterKey', 'Get-CosmosDbAttachment',
+               'Get-CosmosDbAttachmentResourcePath', 'Get-CosmosDbCollection',
+               'Get-CosmosDbCollectionResourcePath', 'Get-CosmosDbCollectionSize',
+               'Get-CosmosDBDatabase', 'Get-CosmosDBDatabaseResourcePath',
+               'Get-CosmosDBDocument', 'Get-CosmosDBDocumentResourcePath',
+               'Get-CosmosDBOffer', 'Get-CosmosDBOfferResourcePath',
+               'Get-CosmosDbPermission', 'Get-CosmosDbPermissionResourcePath',
+               'Get-CosmosDbStoredProcedure',
+               'Get-CosmosDbStoredProcedureResourcePath', 'Get-CosmosDbTrigger',
+               'Get-CosmosDbTriggerResourcePath', 'Get-CosmosDbUser',
+               'Get-CosmosDbUserResourcePath', 'Get-CosmosDbUserDefinedFunction',
+               'Get-CosmosDbUserDefinedFunctionResourcePath',
+               'Invoke-CosmosDbStoredProcedure', 'New-CosmosDbAccount',
+               'New-CosmosDbAccountMasterKey', 'New-CosmosDbAttachment',
+               'New-CosmosDbBackoffPolicy', 'New-CosmosDbCollection',
+               'New-CosmosDbCollectionIncludedPathIndex',
+               'New-CosmosDbCollectionIncludedPath',
+               'New-CosmosDbCollectionExcludedPath',
+               'New-CosmosDbCollectionIndexingPolicy',
+               'New-CosmosDbCollectionUniqueKey',
+               'New-CosmosDbCollectionUniqueKeyPolicy', 'New-CosmosDbDatabase',
+               'New-CosmosDbDocument', 'New-CosmosDbContext',
+               'New-CosmosDbContextToken', 'New-CosmosDbPermission',
+               'New-CosmosDbStoredProcedure', 'New-CosmosDbTrigger',
+               'New-CosmosDbUser', 'New-CosmosDbUserDefinedFunction',
+               'Remove-CosmosDbAccount', 'Remove-CosmosDbAttachment',
+               'Remove-CosmosDbCollection', 'Remove-CosmosDbDatabase',
+               'Remove-CosmosDbDocument', 'Remove-CosmosDbPermission',
+               'Remove-CosmosDbStoredProcedure', 'Remove-CosmosDbTrigger',
+               'Remove-CosmosDbUser', 'Remove-CosmosDbUserDefinedFunction',
+               'Set-CosmosDbAccount', 'Set-CosmosDbAttachment',
+               'Set-CosmosDbCollection', 'Set-CosmosDbDocument', 'Set-CosmosDbOffer',
+               'Set-CosmosDbStoredProcedure', 'Set-CosmosDbTrigger',
                'Set-CosmosDbUser', 'Set-CosmosDbUserDefinedFunction'
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
@@ -144,7 +143,7 @@ PrivateData = @{
     PSData = @{
 
         # Tags applied to this module. These help with module discovery in online galleries.
-        Tags = 'CosmosDB', 'DocumentDb', 'Azure', 'PSEdition_Core', 'PSEdition_Desktop', 
+        Tags = 'CosmosDB', 'DocumentDb', 'Azure', 'PSEdition_Core', 'PSEdition_Desktop',
                'Windows', 'Linux', 'MacOS'
 
         # A URL to the license for this module.

--- a/src/CosmosDB.psm1
+++ b/src/CosmosDB.psm1
@@ -50,9 +50,8 @@ if (-not ([System.Management.Automation.PSTypeName]'CosmosDB.Context').Type)
     }
     else
     {
-        $typeDefinitionPath = Join-Path -Path $moduleRoot -ChildPath 'classes\CosmosDB\CosmsosDB.cs'
+        $typeDefinitionPath = Join-Path -Path $moduleRoot -ChildPath 'classes\CosmosDB\CosmosDB.cs'
         Write-Verbose -Message $($LocalizedData.LoadingTypesFromCS -f $typeDefinitionPath)
-        Write-Verbose -Message (Get-ChildItem -Path (Split-Path -Path $typeDefinitionPath -Parent) | Out-String ) -Verbose
         $typeDefinition = Get-Content -Path $typeDefinitionPath -Raw
         Add-Type -TypeDefinition $typeDefinition
     }

--- a/src/CosmosDB.psm1
+++ b/src/CosmosDB.psm1
@@ -13,89 +13,48 @@ $moduleRoot = Split-Path `
 Import-Module -Name Az.Accounts -MinimumVersion 1.0.0 -Scope Global
 Import-Module -Name Az.Resources -MinimumVersion 1.0.0 -Scope Global
 
+#region LocalizedData
+$culture = 'en-us'
+
+if (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath $PSUICulture))
+{
+    $culture = $PSUICulture
+}
+
+Import-LocalizedData `
+    -BindingVariable LocalizedData `
+    -Filename 'CosmosDB.strings.psd1' `
+    -BaseDirectory $moduleRoot `
+    -UICulture $culture
+#endregion
+
 #region Types
 if (-not ([System.Management.Automation.PSTypeName]'CosmosDB.Context').Type)
 {
-    $typeDefinition = @'
-namespace CosmosDB {
-    public class ContextToken
+    <#
+        Attempt to load the classes from within the CosmosDB.dll in the
+        same folder as the module. If the file doesn't exist then load
+        them from the CosmosDB.cs file.
+
+        Loading the classes from the CosmosDB.cs file requires compilation
+        which currently fails in PowerShell on Azure Functions 2.0.
+
+        See https://github.com/Azure/azure-functions-powershell-worker/issues/220
+    #>
+    $classDllPath = Join-Path -Path $moduleRoot -ChildPath 'CosmosDB.dll'
+
+    if (Test-Path -Path $classDllPath)
     {
-        public System.String Resource;
-        public System.DateTime TimeStamp;
-        public System.DateTime Expires;
-        public System.Security.SecureString Token;
+        Write-Verbose -Message $($LocalizedData.LoadingTypesFromDll -f $classDllPath)
+        Add-Type -Path $classDllPath
     }
-
-    public class BackoffPolicy
+    else
     {
-        public System.Int32 MaxRetries;
-        public System.String Method;
-        public System.Int32 Delay;
+        $typeDefinitionPath = Join-Path -Path $moduleRoot -ChildPath 'classes\CosmosDB\CosmsosDB.cs'
+        $typeDefinition = Get-Content -Path $typeDefinitionPath -Raw
+        Write-Verbose -Message $($LocalizedData.LoadingTypesFromCS -f $typeDefinitionPath)
+        Add-Type -TypeDefinition $typeDefinition
     }
-
-    public class Context
-    {
-        public System.String Account;
-        public System.String Database;
-        public System.Security.SecureString Key;
-        public System.String KeyType;
-        public System.String BaseUri;
-        public CosmosDB.ContextToken[] Token;
-        public CosmosDB.BackoffPolicy BackoffPolicy;
-    }
-
-    namespace IndexingPolicy {
-        namespace Path {
-            public class Index {
-                public System.String dataType;
-                public System.String kind;
-            }
-
-            public class IndexRange : CosmosDB.IndexingPolicy.Path.Index {
-                public readonly System.Int32 precision = -1;
-            }
-
-            public class IndexHash : CosmosDB.IndexingPolicy.Path.Index {
-                public readonly System.Int32 precision = -1;
-            }
-
-            public class IndexSpatial : CosmosDB.IndexingPolicy.Path.Index {
-            }
-
-            public class IncludedPath
-            {
-                public System.String path;
-                public CosmosDB.IndexingPolicy.Path.Index[] indexes;
-            }
-
-            public class ExcludedPath
-            {
-                public System.String path;
-            }
-        }
-
-        public class Policy
-        {
-            public System.Boolean automatic;
-            public System.String indexingMode;
-            public CosmosDB.IndexingPolicy.Path.IncludedPath[] includedPaths;
-            public CosmosDB.IndexingPolicy.Path.ExcludedPath[] excludedPaths;
-        }
-    }
-
-    namespace UniqueKeyPolicy {
-        public class UniqueKey {
-            public System.String[] paths;
-        }
-
-        public class Policy
-        {
-            public CosmosDB.UniqueKeyPolicy.UniqueKey[] uniqueKeys;
-        }
-    }
-}
-'@
-    Add-Type -TypeDefinition $typeDefinition
 }
 
 <#
@@ -117,20 +76,6 @@ namespace Microsoft.PowerShell.Commands
 
     Add-Type -TypeDefinition $httpResponseExceptionClassDefinition
 }
-#endregion
-
-#region LocalizedData
-$culture = 'en-us'
-if (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath $PSUICulture))
-{
-    $culture = $PSUICulture
-}
-
-Import-LocalizedData `
-    -BindingVariable LocalizedData `
-    -Filename 'CosmosDB.strings.psd1' `
-    -BaseDirectory $moduleRoot `
-    -UICulture $culture
 #endregion
 
 #region ImportFunctions

--- a/src/CosmosDB.psm1
+++ b/src/CosmosDB.psm1
@@ -51,8 +51,9 @@ if (-not ([System.Management.Automation.PSTypeName]'CosmosDB.Context').Type)
     else
     {
         $typeDefinitionPath = Join-Path -Path $moduleRoot -ChildPath 'classes\CosmosDB\CosmsosDB.cs'
-        $typeDefinition = Get-Content -Path $typeDefinitionPath -Raw
         Write-Verbose -Message $($LocalizedData.LoadingTypesFromCS -f $typeDefinitionPath)
+        Write-Verbose -Message (Get-ChildItem -Path (Split-Path -Path $typeDefinitionPath -Parent) | Out-String ) -Verbose
+        $typeDefinition = Get-Content -Path $typeDefinitionPath -Raw
         Add-Type -TypeDefinition $typeDefinition
     }
 }

--- a/src/classes/CosmosDB/CosmosDB.cs
+++ b/src/classes/CosmosDB/CosmosDB.cs
@@ -1,0 +1,79 @@
+﻿using System;
+
+namespace CosmosDB {
+    public class ContextToken
+    {
+        public System.String Resource;
+        public System.DateTime TimeStamp;
+        public System.DateTime Expires;
+        public System.Security.SecureString Token;
+    }
+
+    public class BackoffPolicy
+    {
+        public System.Int32 MaxRetries;
+        public System.String Method;
+        public System.Int32 Delay;
+    }
+
+    public class Context
+    {
+        public System.String Account;
+        public System.String Database;
+        public System.Security.SecureString Key;
+        public System.String KeyType;
+        public System.String BaseUri;
+        public CosmosDB.ContextToken[] Token;
+        public CosmosDB.BackoffPolicy BackoffPolicy;
+    }
+
+    namespace IndexingPolicy {
+        namespace Path {
+            public class Index {
+                public System.String dataType;
+                public System.String kind;
+            }
+
+            public class IndexRange : CosmosDB.IndexingPolicy.Path.Index {
+                public readonly System.Int32 precision = -1;
+            }
+
+            public class IndexHash : CosmosDB.IndexingPolicy.Path.Index {
+                public readonly System.Int32 precision = -1;
+            }
+
+            public class IndexSpatial : CosmosDB.IndexingPolicy.Path.Index {
+            }
+
+            public class IncludedPath
+            {
+                public System.String path;
+                public CosmosDB.IndexingPolicy.Path.Index[] indexes;
+            }
+
+            public class ExcludedPath
+            {
+                public System.String path;
+            }
+        }
+
+        public class Policy
+        {
+            public System.Boolean automatic;
+            public System.String indexingMode;
+            public CosmosDB.IndexingPolicy.Path.IncludedPath[] includedPaths;
+            public CosmosDB.IndexingPolicy.Path.ExcludedPath[] excludedPaths;
+        }
+    }
+
+    namespace UniqueKeyPolicy {
+        public class UniqueKey {
+            public System.String[] paths;
+        }
+
+        public class Policy
+        {
+            public CosmosDB.UniqueKeyPolicy.UniqueKey[] uniqueKeys;
+        }
+    }
+}

--- a/src/classes/CosmosDB/CosmosDB.csproj
+++ b/src/classes/CosmosDB/CosmosDB.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/en-US/CosmosDB.strings.psd1
+++ b/src/en-US/CosmosDB.strings.psd1
@@ -1,5 +1,7 @@
 # culture="en-US"
 ConvertFrom-StringData -StringData @'
+    LoadingTypesFromDll = Loading Types from DLL '{0}'.
+    LoadingTypesFromCS = Loading Types from CS file '{0}'.
     ImportingLibFileMessage = Importing function library '{0}'.
     FindResourceTokenInContext = Searching context tokens for resource matching '{0}'.
     FoundResourceTokenInContext = {0} context token(s) with resource '{1}' found.

--- a/test/Integration/CosmosDB.integration.Tests.ps1
+++ b/test/Integration/CosmosDB.integration.Tests.ps1
@@ -1,11 +1,14 @@
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
-[System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
 [CmdletBinding()]
-param ()
+param
+(
+    [Parameter()]
+    [System.String]
+    $ModuleRootPath = ($PSScriptRoot | Split-Path -Parent | Split-Path -Parent | Join-Path -ChildPath 'src')
+)
 
 $moduleManifestName = 'CosmosDB.psd1'
-$moduleRootPath = $PSScriptRoot | Split-Path -Parent | Split-Path -Parent | Join-Path -ChildPath 'src'
-$moduleManifestPath = Join-Path -Path $moduleRootPath -ChildPath $moduleManifestName
+$moduleManifestPath = Join-Path -Path $ModuleRootPath -ChildPath $moduleManifestName
 
 Import-Module -Name $moduleManifestPath -Force -Verbose:$false
 

--- a/test/Integration/CosmosDB.integration.Tests.ps1
+++ b/test/Integration/CosmosDB.integration.Tests.ps1
@@ -1,15 +1,16 @@
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
 [CmdletBinding()]
-param (
-)
+param ()
 
-$ModuleManifestName = 'CosmosDB.psd1'
-$ModuleManifestPath = "$PSScriptRoot\..\..\src\$ModuleManifestName"
-$TestHelperPath = "$PSScriptRoot\..\TestHelper"
+$moduleManifestName = 'CosmosDB.psd1'
+$moduleRootPath = $PSScriptRoot | Split-Path -Parent | Split-Path -Parent | Join-Path -ChildPath 'src'
+$moduleManifestPath = Join-Path -Path $moduleRootPath -ChildPath $moduleManifestName
 
-Import-Module -Name $ModuleManifestPath -Force -Verbose:$false
-Import-Module -Name $TestHelperPath -Force
+Import-Module -Name $moduleManifestPath -Force -Verbose:$false
+
+$testHelperPath = $PSScriptRoot | Split-Path -Parent | Join-Path -ChildPath 'TestHelper'
+Import-Module -Name $testHelperPath -Force
 
 Get-AzureServicePrincipal
 

--- a/test/Unit/CosmosDB.accounts.Tests.ps1
+++ b/test/Unit/CosmosDB.accounts.Tests.ps1
@@ -1,16 +1,16 @@
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
 [CmdletBinding()]
-param (
-)
+param ()
 
-$ModuleManifestName = 'CosmosDB.psd1'
-$ModuleManifestPath = "$PSScriptRoot\..\..\src\$ModuleManifestName"
+$moduleManifestName = 'CosmosDB.psd1'
+$moduleRootPath = $PSScriptRoot | Split-Path -Parent | Split-Path -Parent | Join-Path -ChildPath 'src'
+$moduleManifestPath = Join-Path -Path $moduleRootPath -ChildPath $moduleManifestName
 
-Import-Module -Name $ModuleManifestPath -Force -Verbose:$false
+Import-Module -Name $moduleManifestPath -Force -Verbose:$false
 
 InModuleScope CosmosDB {
-    $TestHelperPath = "$PSScriptRoot\..\TestHelper"
-    Import-Module -Name $TestHelperPath -Force
+    $testHelperPath = $PSScriptRoot | Split-Path -Parent | Join-Path -ChildPath 'TestHelper'
+    Import-Module -Name $testHelperPath -Force
 
     # Variables for use in tests
     $script:testName = 'testName'

--- a/test/Unit/CosmosDB.accounts.Tests.ps1
+++ b/test/Unit/CosmosDB.accounts.Tests.ps1
@@ -1,10 +1,14 @@
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
 [CmdletBinding()]
-param ()
+param
+(
+    [Parameter()]
+    [System.String]
+    $ModuleRootPath = ($PSScriptRoot | Split-Path -Parent | Split-Path -Parent | Join-Path -ChildPath 'src')
+)
 
 $moduleManifestName = 'CosmosDB.psd1'
-$moduleRootPath = $PSScriptRoot | Split-Path -Parent | Split-Path -Parent | Join-Path -ChildPath 'src'
-$moduleManifestPath = Join-Path -Path $moduleRootPath -ChildPath $moduleManifestName
+$moduleManifestPath = Join-Path -Path $ModuleRootPath -ChildPath $moduleManifestName
 
 Import-Module -Name $moduleManifestPath -Force -Verbose:$false
 

--- a/test/Unit/CosmosDB.attachments.Tests.ps1
+++ b/test/Unit/CosmosDB.attachments.Tests.ps1
@@ -1,16 +1,16 @@
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
 [CmdletBinding()]
-param (
-)
+param ()
 
-$ModuleManifestName = 'CosmosDB.psd1'
-$ModuleManifestPath = "$PSScriptRoot\..\..\src\$ModuleManifestName"
+$moduleManifestName = 'CosmosDB.psd1'
+$moduleRootPath = $PSScriptRoot | Split-Path -Parent | Split-Path -Parent | Join-Path -ChildPath 'src'
+$moduleManifestPath = Join-Path -Path $moduleRootPath -ChildPath $moduleManifestName
 
-Import-Module -Name $ModuleManifestPath -Force -Verbose:$false
+Import-Module -Name $moduleManifestPath -Force -Verbose:$false
 
 InModuleScope CosmosDB {
-    $TestHelperPath = "$PSScriptRoot\..\TestHelper"
-    Import-Module -Name $TestHelperPath -Force
+    $testHelperPath = $PSScriptRoot | Split-Path -Parent | Join-Path -ChildPath 'TestHelper'
+    Import-Module -Name $testHelperPath -Force
 
     # Variables for use in tests
     $script:testAccount = 'testAccount'

--- a/test/Unit/CosmosDB.attachments.Tests.ps1
+++ b/test/Unit/CosmosDB.attachments.Tests.ps1
@@ -1,10 +1,14 @@
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
 [CmdletBinding()]
-param ()
+param
+(
+    [Parameter()]
+    [System.String]
+    $ModuleRootPath = ($PSScriptRoot | Split-Path -Parent | Split-Path -Parent | Join-Path -ChildPath 'src')
+)
 
 $moduleManifestName = 'CosmosDB.psd1'
-$moduleRootPath = $PSScriptRoot | Split-Path -Parent | Split-Path -Parent | Join-Path -ChildPath 'src'
-$moduleManifestPath = Join-Path -Path $moduleRootPath -ChildPath $moduleManifestName
+$moduleManifestPath = Join-Path -Path $ModuleRootPath -ChildPath $moduleManifestName
 
 Import-Module -Name $moduleManifestPath -Force -Verbose:$false
 

--- a/test/Unit/CosmosDB.collections.Tests.ps1
+++ b/test/Unit/CosmosDB.collections.Tests.ps1
@@ -1,16 +1,16 @@
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
 [CmdletBinding()]
-param (
-)
+param ()
 
-$ModuleManifestName = 'CosmosDB.psd1'
-$ModuleManifestPath = "$PSScriptRoot\..\..\src\$ModuleManifestName"
+$moduleManifestName = 'CosmosDB.psd1'
+$moduleRootPath = $PSScriptRoot | Split-Path -Parent | Split-Path -Parent | Join-Path -ChildPath 'src'
+$moduleManifestPath = Join-Path -Path $moduleRootPath -ChildPath $moduleManifestName
 
-Import-Module -Name $ModuleManifestPath -Force -Verbose:$false
+Import-Module -Name $moduleManifestPath -Force -Verbose:$false
 
 InModuleScope CosmosDB {
-    $TestHelperPath = "$PSScriptRoot\..\TestHelper"
-    Import-Module -Name $TestHelperPath -Force
+    $testHelperPath = $PSScriptRoot | Split-Path -Parent | Join-Path -ChildPath 'TestHelper'
+    Import-Module -Name $testHelperPath -Force
 
     # Variables for use in tests
     $script:testAccount = 'testAccount'

--- a/test/Unit/CosmosDB.collections.Tests.ps1
+++ b/test/Unit/CosmosDB.collections.Tests.ps1
@@ -1,10 +1,14 @@
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
 [CmdletBinding()]
-param ()
+param
+(
+    [Parameter()]
+    [System.String]
+    $ModuleRootPath = ($PSScriptRoot | Split-Path -Parent | Split-Path -Parent | Join-Path -ChildPath 'src')
+)
 
 $moduleManifestName = 'CosmosDB.psd1'
-$moduleRootPath = $PSScriptRoot | Split-Path -Parent | Split-Path -Parent | Join-Path -ChildPath 'src'
-$moduleManifestPath = Join-Path -Path $moduleRootPath -ChildPath $moduleManifestName
+$moduleManifestPath = Join-Path -Path $ModuleRootPath -ChildPath $moduleManifestName
 
 Import-Module -Name $moduleManifestPath -Force -Verbose:$false
 

--- a/test/Unit/CosmosDB.databases.Tests.ps1
+++ b/test/Unit/CosmosDB.databases.Tests.ps1
@@ -1,16 +1,16 @@
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
 [CmdletBinding()]
-param (
-)
+param ()
 
-$ModuleManifestName = 'CosmosDB.psd1'
-$ModuleManifestPath = "$PSScriptRoot\..\..\src\$ModuleManifestName"
+$moduleManifestName = 'CosmosDB.psd1'
+$moduleRootPath = $PSScriptRoot | Split-Path -Parent | Split-Path -Parent | Join-Path -ChildPath 'src'
+$moduleManifestPath = Join-Path -Path $moduleRootPath -ChildPath $moduleManifestName
 
-Import-Module -Name $ModuleManifestPath -Force -Verbose:$false
+Import-Module -Name $moduleManifestPath -Force -Verbose:$false
 
 InModuleScope CosmosDB {
-    $TestHelperPath = "$PSScriptRoot\..\TestHelper"
-    Import-Module -Name $TestHelperPath -Force
+    $testHelperPath = $PSScriptRoot | Split-Path -Parent | Join-Path -ChildPath 'TestHelper'
+    Import-Module -Name $testHelperPath -Force
 
     # Variables for use in tests
     $script:testAccount = 'testAccount'

--- a/test/Unit/CosmosDB.databases.Tests.ps1
+++ b/test/Unit/CosmosDB.databases.Tests.ps1
@@ -1,12 +1,14 @@
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
 [CmdletBinding()]
-param ()
+param
+(
+    [Parameter()]
+    [System.String]
+    $ModuleRootPath = ($PSScriptRoot | Split-Path -Parent | Split-Path -Parent | Join-Path -ChildPath 'src')
+)
 
 $moduleManifestName = 'CosmosDB.psd1'
-$moduleRootPath = $PSScriptRoot | Split-Path -Parent | Split-Path -Parent | Join-Path -ChildPath 'src'
-$moduleManifestPath = Join-Path -Path $moduleRootPath -ChildPath $moduleManifestName
-
-Import-Module -Name $moduleManifestPath -Force -Verbose:$false
+$moduleManifestPath = Join-Path -Path $ModuleRootPath -ChildPath $moduleManifestName
 
 InModuleScope CosmosDB {
     $testHelperPath = $PSScriptRoot | Split-Path -Parent | Join-Path -ChildPath 'TestHelper'

--- a/test/Unit/CosmosDB.documents.Tests.ps1
+++ b/test/Unit/CosmosDB.documents.Tests.ps1
@@ -1,10 +1,14 @@
-[System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoIdUsingConvertToSecureStringWithPlainText', '')]
+[System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
 [CmdletBinding()]
-param ()
+param
+(
+    [Parameter()]
+    [System.String]
+    $ModuleRootPath = ($PSScriptRoot | Split-Path -Parent | Split-Path -Parent | Join-Path -ChildPath 'src')
+)
 
 $moduleManifestName = 'CosmosDB.psd1'
-$moduleRootPath = $PSScriptRoot | Split-Path -Parent | Split-Path -Parent | Join-Path -ChildPath 'src'
-$moduleManifestPath = Join-Path -Path $moduleRootPath -ChildPath $moduleManifestName
+$moduleManifestPath = Join-Path -Path $ModuleRootPath -ChildPath $moduleManifestName
 
 Import-Module -Name $moduleManifestPath -Force -Verbose:$false
 

--- a/test/Unit/CosmosDB.documents.Tests.ps1
+++ b/test/Unit/CosmosDB.documents.Tests.ps1
@@ -1,16 +1,16 @@
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoIdUsingConvertToSecureStringWithPlainText', '')]
 [CmdletBinding()]
-param (
-)
+param ()
 
-$ModuleManifestName = 'CosmosDB.psd1'
-$ModuleManifestPath = "$PSScriptRoot\..\..\src\$ModuleManifestName"
+$moduleManifestName = 'CosmosDB.psd1'
+$moduleRootPath = $PSScriptRoot | Split-Path -Parent | Split-Path -Parent | Join-Path -ChildPath 'src'
+$moduleManifestPath = Join-Path -Path $moduleRootPath -ChildPath $moduleManifestName
 
-Import-Module -Name $ModuleManifestPath -Force -Verbose:$false
+Import-Module -Name $moduleManifestPath -Force -Verbose:$false
 
 InModuleScope CosmosDB {
-    $TestHelperPath = "$PSScriptRoot\..\TestHelper"
-    Import-Module -Name $TestHelperPath -Force
+    $testHelperPath = $PSScriptRoot | Split-Path -Parent | Join-Path -ChildPath 'TestHelper'
+    Import-Module -Name $testHelperPath -Force
 
     # Variables for use in tests
     $script:testAccount = 'testAccount'

--- a/test/Unit/CosmosDB.generic.Tests.ps1
+++ b/test/Unit/CosmosDB.generic.Tests.ps1
@@ -39,7 +39,7 @@ Describe 'CosmosDB Module'{
 
                 Write-Warning -Message  'For instructions on how to run PSScriptAnalyzer on your own machine, please go to https://github.com/powershell/psscriptAnalyzer/'
 
-                $PSScriptAnalyzerErrors.Count | Should -Be $null
+                $PSScriptAnalyzerErrors.Count | Should -BeNullOrEmpty
             }
         }
 

--- a/test/Unit/CosmosDB.generic.Tests.ps1
+++ b/test/Unit/CosmosDB.generic.Tests.ps1
@@ -1,21 +1,18 @@
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
 [CmdletBinding()]
-param (
-)
+param ()
 
 $moduleManifestName = 'CosmosDB.psd1'
-$moduleRootPath = "$PSScriptRoot\..\..\src\"
+$moduleRootPath = $PSScriptRoot | Split-Path -Parent | Split-Path -Parent | Join-Path -ChildPath 'src'
 $moduleManifestPath = Join-Path -Path $moduleRootPath -ChildPath $moduleManifestName
 
 Describe 'CosmosDB Module'{
     Context 'PSScriptAnalyzer' {
         Import-Module -Name 'PSScriptAnalyzer'
 
-        $modulePath = Join-Path -Path $moduleRootPath -ChildPath 'CosmosDB.psm1'
-
         # Perform PSScriptAnalyzer scan
         $PSScriptAnalyzerResult = Invoke-ScriptAnalyzer `
-            -Path $modulePath `
+            -Path $moduleManifestPath `
             -Settings (Join-Path -Path $moduleRootPath -ChildPath '..\PSScriptAnalyzerSettings.psd1') `
             -ErrorAction SilentlyContinue `
             -Verbose:$false

--- a/test/Unit/CosmosDB.generic.Tests.ps1
+++ b/test/Unit/CosmosDB.generic.Tests.ps1
@@ -1,10 +1,14 @@
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
 [CmdletBinding()]
-param ()
+param
+(
+    [Parameter()]
+    [System.String]
+    $ModuleRootPath = ($PSScriptRoot | Split-Path -Parent | Split-Path -Parent | Join-Path -ChildPath 'src')
+)
 
 $moduleManifestName = 'CosmosDB.psd1'
-$moduleRootPath = $PSScriptRoot | Split-Path -Parent | Split-Path -Parent | Join-Path -ChildPath 'src'
-$moduleManifestPath = Join-Path -Path $moduleRootPath -ChildPath $moduleManifestName
+$moduleManifestPath = Join-Path -Path $ModuleRootPath -ChildPath $moduleManifestName
 
 Describe 'CosmosDB Module'{
     Context 'PSScriptAnalyzer' {

--- a/test/Unit/CosmosDB.offers.Tests.ps1
+++ b/test/Unit/CosmosDB.offers.Tests.ps1
@@ -1,16 +1,16 @@
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
 [CmdletBinding()]
-param (
-)
+param ()
 
-$ModuleManifestName = 'CosmosDB.psd1'
-$ModuleManifestPath = "$PSScriptRoot\..\..\src\$ModuleManifestName"
+$moduleManifestName = 'CosmosDB.psd1'
+$moduleRootPath = $PSScriptRoot | Split-Path -Parent | Split-Path -Parent | Join-Path -ChildPath 'src'
+$moduleManifestPath = Join-Path -Path $moduleRootPath -ChildPath $moduleManifestName
 
-Import-Module -Name $ModuleManifestPath -Force -Verbose:$false
+Import-Module -Name $moduleManifestPath -Force -Verbose:$false
 
 InModuleScope CosmosDB {
-    $TestHelperPath = "$PSScriptRoot\..\TestHelper"
-    Import-Module -Name $TestHelperPath -Force
+    $testHelperPath = $PSScriptRoot | Split-Path -Parent | Join-Path -ChildPath 'TestHelper'
+    Import-Module -Name $testHelperPath -Force
 
     # Variables for use in tests
     $script:testAccount = 'testAccount'

--- a/test/Unit/CosmosDB.offers.Tests.ps1
+++ b/test/Unit/CosmosDB.offers.Tests.ps1
@@ -1,10 +1,14 @@
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
 [CmdletBinding()]
-param ()
+param
+(
+    [Parameter()]
+    [System.String]
+    $ModuleRootPath = ($PSScriptRoot | Split-Path -Parent | Split-Path -Parent | Join-Path -ChildPath 'src')
+)
 
 $moduleManifestName = 'CosmosDB.psd1'
-$moduleRootPath = $PSScriptRoot | Split-Path -Parent | Split-Path -Parent | Join-Path -ChildPath 'src'
-$moduleManifestPath = Join-Path -Path $moduleRootPath -ChildPath $moduleManifestName
+$moduleManifestPath = Join-Path -Path $ModuleRootPath -ChildPath $moduleManifestName
 
 Import-Module -Name $moduleManifestPath -Force -Verbose:$false
 

--- a/test/Unit/CosmosDB.permissions.Tests.ps1
+++ b/test/Unit/CosmosDB.permissions.Tests.ps1
@@ -1,16 +1,16 @@
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
 [CmdletBinding()]
-param (
-)
+param ()
 
-$ModuleManifestName = 'CosmosDB.psd1'
-$ModuleManifestPath = "$PSScriptRoot\..\..\src\$ModuleManifestName"
+$moduleManifestName = 'CosmosDB.psd1'
+$moduleRootPath = $PSScriptRoot | Split-Path -Parent | Split-Path -Parent | Join-Path -ChildPath 'src'
+$moduleManifestPath = Join-Path -Path $moduleRootPath -ChildPath $moduleManifestName
 
-Import-Module -Name $ModuleManifestPath -Force -Verbose:$false
+Import-Module -Name $moduleManifestPath -Force -Verbose:$false
 
 InModuleScope CosmosDB {
-    $TestHelperPath = "$PSScriptRoot\..\TestHelper"
-    Import-Module -Name $TestHelperPath -Force
+    $testHelperPath = $PSScriptRoot | Split-Path -Parent | Join-Path -ChildPath 'TestHelper'
+    Import-Module -Name $testHelperPath -Force
 
     # Variables for use in tests
     $script:testAccount = 'testAccount'

--- a/test/Unit/CosmosDB.permissions.Tests.ps1
+++ b/test/Unit/CosmosDB.permissions.Tests.ps1
@@ -1,10 +1,14 @@
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
 [CmdletBinding()]
-param ()
+param
+(
+    [Parameter()]
+    [System.String]
+    $ModuleRootPath = ($PSScriptRoot | Split-Path -Parent | Split-Path -Parent | Join-Path -ChildPath 'src')
+)
 
 $moduleManifestName = 'CosmosDB.psd1'
-$moduleRootPath = $PSScriptRoot | Split-Path -Parent | Split-Path -Parent | Join-Path -ChildPath 'src'
-$moduleManifestPath = Join-Path -Path $moduleRootPath -ChildPath $moduleManifestName
+$moduleManifestPath = Join-Path -Path $ModuleRootPath -ChildPath $moduleManifestName
 
 Import-Module -Name $moduleManifestPath -Force -Verbose:$false
 

--- a/test/Unit/CosmosDB.storedprocedures.Tests.ps1
+++ b/test/Unit/CosmosDB.storedprocedures.Tests.ps1
@@ -1,10 +1,14 @@
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
 [CmdletBinding()]
-param ()
+param
+(
+    [Parameter()]
+    [System.String]
+    $ModuleRootPath = ($PSScriptRoot | Split-Path -Parent | Split-Path -Parent | Join-Path -ChildPath 'src')
+)
 
 $moduleManifestName = 'CosmosDB.psd1'
-$moduleRootPath = $PSScriptRoot | Split-Path -Parent | Split-Path -Parent | Join-Path -ChildPath 'src'
-$moduleManifestPath = Join-Path -Path $moduleRootPath -ChildPath $moduleManifestName
+$moduleManifestPath = Join-Path -Path $ModuleRootPath -ChildPath $moduleManifestName
 
 Import-Module -Name $moduleManifestPath -Force -Verbose:$false
 

--- a/test/Unit/CosmosDB.storedprocedures.Tests.ps1
+++ b/test/Unit/CosmosDB.storedprocedures.Tests.ps1
@@ -1,17 +1,16 @@
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
 [CmdletBinding()]
-param (
-)
+param ()
 
-$ModuleManifestName = 'CosmosDB.psd1'
-$ModuleManifestPath = "$PSScriptRoot\..\..\src\$ModuleManifestName"
+$moduleManifestName = 'CosmosDB.psd1'
+$moduleRootPath = $PSScriptRoot | Split-Path -Parent | Split-Path -Parent | Join-Path -ChildPath 'src'
+$moduleManifestPath = Join-Path -Path $moduleRootPath -ChildPath $moduleManifestName
 
-Import-Module -Name $ModuleManifestPath -Force -Verbose:$false
-
+Import-Module -Name $moduleManifestPath -Force -Verbose:$false
 
 InModuleScope CosmosDB {
-    $TestHelperPath = "$PSScriptRoot\..\TestHelper"
-    Import-Module -Name $TestHelperPath -Force
+    $testHelperPath = $PSScriptRoot | Split-Path -Parent | Join-Path -ChildPath 'TestHelper'
+    Import-Module -Name $testHelperPath -Force
 
     # Variables for use in tests
     $script:testAccount = 'testAccount'

--- a/test/Unit/CosmosDB.triggers.Tests.ps1
+++ b/test/Unit/CosmosDB.triggers.Tests.ps1
@@ -1,16 +1,16 @@
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
 [CmdletBinding()]
-param (
-)
+param ()
 
-$ModuleManifestName = 'CosmosDB.psd1'
-$ModuleManifestPath = "$PSScriptRoot\..\..\src\$ModuleManifestName"
+$moduleManifestName = 'CosmosDB.psd1'
+$moduleRootPath = $PSScriptRoot | Split-Path -Parent | Split-Path -Parent | Join-Path -ChildPath 'src'
+$moduleManifestPath = Join-Path -Path $moduleRootPath -ChildPath $moduleManifestName
 
-Import-Module -Name $ModuleManifestPath -Force -Verbose:$false
+Import-Module -Name $moduleManifestPath -Force -Verbose:$false
 
 InModuleScope CosmosDB {
-    $TestHelperPath = "$PSScriptRoot\..\TestHelper"
-    Import-Module -Name $TestHelperPath -Force
+    $testHelperPath = $PSScriptRoot | Split-Path -Parent | Join-Path -ChildPath 'TestHelper'
+    Import-Module -Name $testHelperPath -Force
 
     # Variables for use in tests
     $script:testAccount = 'testAccount'

--- a/test/Unit/CosmosDB.triggers.Tests.ps1
+++ b/test/Unit/CosmosDB.triggers.Tests.ps1
@@ -1,10 +1,14 @@
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
 [CmdletBinding()]
-param ()
+param
+(
+    [Parameter()]
+    [System.String]
+    $ModuleRootPath = ($PSScriptRoot | Split-Path -Parent | Split-Path -Parent | Join-Path -ChildPath 'src')
+)
 
 $moduleManifestName = 'CosmosDB.psd1'
-$moduleRootPath = $PSScriptRoot | Split-Path -Parent | Split-Path -Parent | Join-Path -ChildPath 'src'
-$moduleManifestPath = Join-Path -Path $moduleRootPath -ChildPath $moduleManifestName
+$moduleManifestPath = Join-Path -Path $ModuleRootPath -ChildPath $moduleManifestName
 
 Import-Module -Name $moduleManifestPath -Force -Verbose:$false
 

--- a/test/Unit/CosmosDB.userdefinedfunctions.Tests.ps1
+++ b/test/Unit/CosmosDB.userdefinedfunctions.Tests.ps1
@@ -1,16 +1,16 @@
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
 [CmdletBinding()]
-param (
-)
+param ()
 
-$ModuleManifestName = 'CosmosDB.psd1'
-$ModuleManifestPath = "$PSScriptRoot\..\..\src\$ModuleManifestName"
+$moduleManifestName = 'CosmosDB.psd1'
+$moduleRootPath = $PSScriptRoot | Split-Path -Parent | Split-Path -Parent | Join-Path -ChildPath 'src'
+$moduleManifestPath = Join-Path -Path $moduleRootPath -ChildPath $moduleManifestName
 
-Import-Module -Name $ModuleManifestPath -Force -Verbose:$false
+Import-Module -Name $moduleManifestPath -Force -Verbose:$false
 
 InModuleScope CosmosDB {
-    $TestHelperPath = "$PSScriptRoot\..\TestHelper"
-    Import-Module -Name $TestHelperPath -Force
+    $testHelperPath = $PSScriptRoot | Split-Path -Parent | Join-Path -ChildPath 'TestHelper'
+    Import-Module -Name $testHelperPath -Force
 
     # Variables for use in tests
     $script:testAccount = 'testAccount'

--- a/test/Unit/CosmosDB.userdefinedfunctions.Tests.ps1
+++ b/test/Unit/CosmosDB.userdefinedfunctions.Tests.ps1
@@ -1,10 +1,14 @@
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
 [CmdletBinding()]
-param ()
+param
+(
+    [Parameter()]
+    [System.String]
+    $ModuleRootPath = ($PSScriptRoot | Split-Path -Parent | Split-Path -Parent | Join-Path -ChildPath 'src')
+)
 
 $moduleManifestName = 'CosmosDB.psd1'
-$moduleRootPath = $PSScriptRoot | Split-Path -Parent | Split-Path -Parent | Join-Path -ChildPath 'src'
-$moduleManifestPath = Join-Path -Path $moduleRootPath -ChildPath $moduleManifestName
+$moduleManifestPath = Join-Path -Path $ModuleRootPath -ChildPath $moduleManifestName
 
 Import-Module -Name $moduleManifestPath -Force -Verbose:$false
 

--- a/test/Unit/CosmosDB.users.Tests.ps1
+++ b/test/Unit/CosmosDB.users.Tests.ps1
@@ -1,16 +1,16 @@
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
 [CmdletBinding()]
-param (
-)
+param ()
 
-$ModuleManifestName = 'CosmosDB.psd1'
-$ModuleManifestPath = "$PSScriptRoot\..\..\src\$ModuleManifestName"
+$moduleManifestName = 'CosmosDB.psd1'
+$moduleRootPath = $PSScriptRoot | Split-Path -Parent | Split-Path -Parent | Join-Path -ChildPath 'src'
+$moduleManifestPath = Join-Path -Path $moduleRootPath -ChildPath $moduleManifestName
 
-Import-Module -Name $ModuleManifestPath -Force -Verbose:$false
+Import-Module -Name $moduleManifestPath -Force -Verbose:$false
 
 InModuleScope CosmosDB {
-    $TestHelperPath = "$PSScriptRoot\..\TestHelper"
-    Import-Module -Name $TestHelperPath -Force
+    $testHelperPath = $PSScriptRoot | Split-Path -Parent | Join-Path -ChildPath 'TestHelper'
+    Import-Module -Name $testHelperPath -Force
 
     # Variables for use in tests
     $script:testAccount = 'testAccount'

--- a/test/Unit/CosmosDB.users.Tests.ps1
+++ b/test/Unit/CosmosDB.users.Tests.ps1
@@ -1,10 +1,14 @@
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
 [CmdletBinding()]
-param ()
+param
+(
+    [Parameter()]
+    [System.String]
+    $ModuleRootPath = ($PSScriptRoot | Split-Path -Parent | Split-Path -Parent | Join-Path -ChildPath 'src')
+)
 
 $moduleManifestName = 'CosmosDB.psd1'
-$moduleRootPath = $PSScriptRoot | Split-Path -Parent | Split-Path -Parent | Join-Path -ChildPath 'src'
-$moduleManifestPath = Join-Path -Path $moduleRootPath -ChildPath $moduleManifestName
+$moduleManifestPath = Join-Path -Path $ModuleRootPath -ChildPath $moduleManifestName
 
 Import-Module -Name $moduleManifestPath -Force -Verbose:$false
 

--- a/test/Unit/CosmosDB.utils.Tests.ps1
+++ b/test/Unit/CosmosDB.utils.Tests.ps1
@@ -1,16 +1,16 @@
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
 [CmdletBinding()]
-param (
-)
+param ()
 
-$ModuleManifestName = 'CosmosDB.psd1'
-$ModuleManifestPath = "$PSScriptRoot\..\..\src\$ModuleManifestName"
+$moduleManifestName = 'CosmosDB.psd1'
+$moduleRootPath = $PSScriptRoot | Split-Path -Parent | Split-Path -Parent | Join-Path -ChildPath 'src'
+$moduleManifestPath = Join-Path -Path $moduleRootPath -ChildPath $moduleManifestName
 
-Import-Module -Name $ModuleManifestPath -Force -Verbose:$false
+Import-Module -Name $moduleManifestPath -Force -Verbose:$false
 
 InModuleScope CosmosDB {
-    $TestHelperPath = "$PSScriptRoot\..\TestHelper"
-    Import-Module -Name $TestHelperPath -Force
+    $testHelperPath = $PSScriptRoot | Split-Path -Parent | Join-Path -ChildPath 'TestHelper'
+    Import-Module -Name $testHelperPath -Force
 
     # Variables for use in tests
     $script:testAccount = 'testAccount'

--- a/test/Unit/CosmosDB.utils.Tests.ps1
+++ b/test/Unit/CosmosDB.utils.Tests.ps1
@@ -1,10 +1,14 @@
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
 [CmdletBinding()]
-param ()
+param
+(
+    [Parameter()]
+    [System.String]
+    $ModuleRootPath = ($PSScriptRoot | Split-Path -Parent | Split-Path -Parent | Join-Path -ChildPath 'src')
+)
 
 $moduleManifestName = 'CosmosDB.psd1'
-$moduleRootPath = $PSScriptRoot | Split-Path -Parent | Split-Path -Parent | Join-Path -ChildPath 'src'
-$moduleManifestPath = Join-Path -Path $moduleRootPath -ChildPath $moduleManifestName
+$moduleManifestPath = Join-Path -Path $ModuleRootPath -ChildPath $moduleManifestName
 
 Import-Module -Name $moduleManifestPath -Force -Verbose:$false
 


### PR DESCRIPTION
- Moved CosmosDB namespace class definitions into C# project to be built
  into a .NET Standard 2.0 DLL that can be loaded instead of a CS file.
  This is to work around a problem with Azure Functions 2.0 where
  types can not be compiled in the runtime (see [this issue](https://github.com/Azure/azure-functions-powershell-worker/issues/220)) -
  fixes [Issue #290](https://github.com/PlagueHO/CosmosDB/issues/290).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plagueho/cosmosdb/294)
<!-- Reviewable:end -->
