### PR TITLE
Adds -PopulateQueryMetrics to Get-CosmosDbDocument and Fixes cask install for MacOS testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
       osx_image: xcode9.1
       before_install:
         - brew update
-        - brew tap caskroom/cask
+        - brew tap homebrew/cask-cask
         - brew cask install powershell
     - os: linux
       dist: trusty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
   `Get-CosmosDbAuthorizationHeadersFromContext` to split out function to pull
   token out of `Context` object. This was done to reduce the size of the
   `Invoke-CosmosDbRequest` function and to improve testability.
+- Added a `-PopulateQueryMetrics` parameter to `Get-CosmosDbDocument` to return
+  the `x-ms-documentdb-populatequerymetrics` header to the header variable.
+- Fixed issue with MacOS testing by changing the reference to the brew tap `cask`
+  in the Travis and Azure pipeline jobs as the tap has moved.
 
 ## 3.5.0.425
 

--- a/azure-pipelines.daily.yml
+++ b/azure-pipelines.daily.yml
@@ -101,7 +101,7 @@ jobs:
     steps:
     - script: |
         brew update
-        brew tap caskroom/cask
+        brew tap homebrew/cask-cask
         brew cask install powershell
       displayName: 'Install PowerShell Core'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -137,7 +137,7 @@ jobs:
     steps:
     - script: |
         brew update
-        brew tap caskroom/cask
+        brew tap homebrew/cask-cask
         brew cask install powershell
       displayName: 'Install PowerShell Core'
 

--- a/docs/Get-CosmosDbDocument.md
+++ b/docs/Get-CosmosDbDocument.md
@@ -20,7 +20,8 @@ Get-CosmosDbDocument -Context <Context> [-Key <SecureString>] [-KeyType <String>
  -CollectionId <String> [-Id <String>] [-PartitionKey <String[]>] [-MaxItemCount <Int32>]
  [-ContinuationToken <String>] [-ConsistencyLevel <String>] [-SessionToken <String>]
  [-PartitionKeyRangeId <String>] [-Query <String>] [-QueryParameters <Hashtable[]>]
- [-QueryEnableCrossPartition <Boolean>] [-ResponseHeader <PSReference>] [<CommonParameters>]
+ [-QueryEnableCrossPartition <Boolean>] [-PopulateQueryMetrics <bool>] [-ResponseHeader <PSReference>]
+ [<CommonParameters>]
 ```
 
 ### Account
@@ -30,7 +31,8 @@ Get-CosmosDbDocument -Account <String> [-Key <SecureString>] [-KeyType <String>]
  -CollectionId <String> [-Id <String>] [-PartitionKey <String[]>] [-MaxItemCount <Int32>]
  [-ContinuationToken <String>] [-ConsistencyLevel <String>] [-SessionToken <String>]
  [-PartitionKeyRangeId <String>] [-Query <String>] [-QueryParameters <Hashtable[]>]
- [-QueryEnableCrossPartition <Boolean>] [-ResponseHeader <PSReference>] [<CommonParameters>]
+ [-QueryEnableCrossPartition <Boolean>] [-PopulateQueryMetrics <bool>] [-ResponseHeader <PSReference>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -292,6 +294,23 @@ Should not be set if Id is set.
 Type: String
 Parameter Sets: (All)
 Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PopulateQueryMetrics
+
+Use this to return the x-ms-documentdb-query-metrics
+header to the variable defined for -ResponseHeader.
+This should only be specified if Query is specified.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
 
 Required: False
 Position: Named

--- a/src/lib/documents/Get-CosmosDbDocument.ps1
+++ b/src/lib/documents/Get-CosmosDbDocument.ps1
@@ -86,6 +86,11 @@ function Get-CosmosDbDocument
         [System.Boolean]
         $QueryEnableCrossPartition = $False,
 
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.Boolean]
+        $PopulateQueryMetrics = $False,
+
         [Alias("ResultHeaders")]
         [Parameter()]
         [ref]
@@ -102,6 +107,7 @@ function Get-CosmosDbDocument
     $null = $PSBoundParameters.Remove('Query')
     $null = $PSBoundParameters.Remove('QueryParameters')
     $null = $PSBoundParameters.Remove('QueryEnableCrossPartition')
+    $null = $PSBoundParameters.Remove('PopulateQueryMetrics')
 
     if ($PSBoundParameters.ContainsKey('ResponseHeader'))
     {
@@ -150,6 +156,13 @@ function Get-CosmosDbDocument
             {
                 $headers += @{
                     'x-ms-documentdb-query-enablecrosspartition' = $True
+                }
+            }
+
+            if ($PopulateQueryMetrics -eq $True)
+            {
+                $headers += @{
+                    'x-ms-documentdb-populatequerymetrics' = $True
                 }
             }
 


### PR DESCRIPTION
# Pull Request

## Bug Fixes

Use the pound / hash sign to indicate which GitHub issues this Pull Request fixes, if applicable.

- Fixes issue with the Travis and Azure CI pipelines where the brew tap cask was referencing an old path and it has now seemingly moved.

## Improvements / Enhancements

- Added a `-PopulateQueryMetrics` parameter to `Get-CosmosDbDocument` to return
  the `x-ms-documentdb-populatequerymetrics` header to the header variable.

@PlagueHO

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plagueho/cosmosdb/310)
<!-- Reviewable:end -->
