### PR TITLE
Improve Documentation by reducing focus on Non-Partitioned Collections - Fixes #342

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add warning to `New-CosmosDbCollection` to show when creating a collection
+  without a partition key.
+- Updated `README.MD` to documentation to reduce focus on collections without
+  partition keys - fixes [Issue #342](https://github.com/PlagueHO/CosmosDB/issues/342).
+
 ## [3.6.1] - 2020-03-19
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 
 - [Introduction](#introduction)
 - [Requirements](#requirements)
+- [Recommended Knowledge](#recommended-knowledge)
 - [Installation](#installation)
 - [Getting Started](#getting-started)
   - [Working with Contexts](#working-with-contexts)
@@ -33,8 +34,9 @@
     - [Update an existing Collection with a new Indexing Policy](#update-an-existing-collection-with-a-new-indexing-policy)
     - [Creating a Collection with a custom Unique Key Policy](#creating-a-collection-with-a-custom-unique-key-policy)
     - [Update an existing Collection with a new Unique Key Policy](#update-an-existing-collection-with-a-new-unique-key-policy)
+    - [Creating a Collection without a Partition Key](#creating-a-collection-without-a-partition-key)
   - [Working with Documents](#working-with-documents)
-    - [Working with Documents in a Partitioned Collection](#working-with-documents-in-a-partitioned-collection)
+    - [Working with Documents in a non-partitioned Collection](#working-with-documents-in-a-non-partitioned-collection)
   - [Using Resource Authorization Tokens](#using-resource-authorization-tokens)
   - [Working with Attachments](#working-with-attachments)
   - [Working with Users](#working-with-users)
@@ -84,15 +86,7 @@ This module requires the following:
 > or **AzureRm.NetCore** modules are used then you will need to remain on
 > CosmosDB module 2.x.
 
-## Installation
-
-To install the module from PowerShell Gallery, use the PowerShell Cmdlet:
-
-```powershell
-Install-Module -Name CosmosDB
-```
-
-## Important
+## Recommended Knowledge
 
 It is recommended that before using this module it is important to understand
 the fundamental concepts of Cosmos DB. This will ensure you have an optimal
@@ -104,6 +98,17 @@ concepts:
 - [Overview of Cosmos DB](https://docs.microsoft.com/bs-cyrl-ba/azure/cosmos-db/introduction)
 - [NoSQL vs. Relational Databases](https://docs.microsoft.com/bs-cyrl-ba/azure/cosmos-db/relational-nosql)
 - [Partitioning](https://docs.microsoft.com/bs-cyrl-ba/azure/cosmos-db/partitioning-overview)
+
+It is also recommended to watch [this Ignite video](https://myignite.techcommunity.microsoft.com/sessions/79932)
+on data modelling and partitioning in Cosmos DB.
+
+## Installation
+
+To install the module from PowerShell Gallery, use the PowerShell Cmdlet:
+
+```powershell
+Install-Module -Name CosmosDB
+```
 
 ## Getting Started
 
@@ -429,7 +434,7 @@ $uniqueKeyPolicy = New-CosmosDbCollectionUniqueKeyPolicy -UniqueKey $uniqueKeyNa
 Set-CosmosDbCollection -Context $cosmosDbContext -Id 'MyExistingCollection' -IndexingPolicy $indexingPolicy
 ```
 
-#### Create a Collection without a Partition Key
+#### Creating a Collection without a Partition Key
 
 > **Warning:** It is not recommended to create a collection without a partition
 key. It may result in reduced performance and increased cost. This

--- a/source/Public/collections/New-CosmosDbCollection.ps1
+++ b/source/Public/collections/New-CosmosDbCollection.ps1
@@ -112,6 +112,10 @@ function New-CosmosDbCollection
         }
         $null = $PSBoundParameters.Remove('PartitionKey')
     }
+    else
+    {
+        Write-Warning -Message $($LocalizedData.NonPartitionedCollectionWarning)
+    }
 
     if ($PSBoundParameters.ContainsKey('IndexingPolicy'))
     {

--- a/source/en-US/CosmosDB.strings.psd1
+++ b/source/en-US/CosmosDB.strings.psd1
@@ -19,6 +19,7 @@ ConvertFrom-StringData -StringData @'
     RemovingAzureCosmosDBAccount = Removing Azure Cosmos DB account '{0}' in resource group '{1}'.
     StoredProcedureScriptLogResults = Stored Procedure '{0}' script log results:\n{1}
     RequestChargeResults = Request charge for {0} to '{1}' was {2} RUs.
+    NonPartitionedCollectionWarning = It is not recommended to create a collection without a partition key. It may result in reduced performance and increased cost. This functionality is included for backwards compatibility only.
     CollectionProvisionedThroughputExceededWithBackoffPolicy = The collection has exceeded the provisioned throughput limit but a back-off policy is specified.
     CollectionProvisionedThroughputExceededNoBackoffPolicy = The collection has exceeded the provisioned throughput limit but there is no back-off policy.
     CollectionProvisionedThroughputExceededMaxRetriesHit = The maximum back-off policy retries {0} has been exceeded.


### PR DESCRIPTION
This PR:
- Add warning to `New-CosmosDbCollection` to show when creating a collection
  without a partition key.
- Updated `README.MD` to documentation to reduce focus on collections without
  partition keys - fixes [Issue #342](https://github.com/PlagueHO/CosmosDB/issues/342).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plagueho/cosmosdb/345)
<!-- Reviewable:end -->
