### PR TITLE
Added IndexingPolicyJson Parameter to create Collection - Fixes #360

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in behavior of indexing policy are also expected. See
   [this page](https://docs.microsoft.com/en-nz/azure/cosmos-db/index-policy#composite-indexes)
   for more information.
+- Added `IndexingPolicyJson` parameter to `New-CosmosDbCollection`
+  and `Set-CosmosDbCollection` functions to enable setting an index policy
+  using JSON - Fixes [Issue #360](https://github.com/PlagueHO/CosmosDB/issues/360).
+- Fixed build pipeline deployment skip function.
 
 ## [3.7.0] - 2020-03-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and `Set-CosmosDbCollection` functions to enable setting an index policy
   using JSON - Fixes [Issue #360](https://github.com/PlagueHO/CosmosDB/issues/360).
 - Fixed build pipeline deployment skip function.
+- Changed Build.yml to support `ModuleBuilder` version to `1.7.0` by changing
+  `CopyDirectories` to `CopyPaths`.
 
 ## [3.7.0] - 2020-03-24
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
     - [Creating a Collection with a custom Indexing Policy](#creating-a-collection-with-a-custom-indexing-policy)
     - [Creating a Collection with a custom Indexing Policy including Composite Indexes](#creating-a-collection-with-a-custom-indexing-policy-including-composite-indexes)
     - [Update an existing Collection with a new Indexing Policy](#update-an-existing-collection-with-a-new-indexing-policy)
+    - [Creating a Collection with a custom Indexing Policy using JSON](#creating-a-collection-with-a-custom-indexing-policy-using-JSON)
     - [Creating a Collection with a custom Unique Key Policy](#creating-a-collection-with-a-custom-unique-key-policy)
     - [Update an existing Collection with a new Unique Key Policy](#update-an-existing-collection-with-a-new-unique-key-policy)
     - [Creating a Collection without a Partition Key](#creating-a-collection-without-a-partition-key)
@@ -432,6 +433,40 @@ $indexStringRange = New-CosmosDbCollectionIncludedPathIndex -Kind Range -DataTyp
 $indexIncludedPath = New-CosmosDbCollectionIncludedPath -Path '/*' -Index $indexStringRange
 $indexingPolicy = New-CosmosDbCollectionIndexingPolicy -Automatic $true -IndexingMode Consistent -IncludedPath $indexIncludedPath
 Set-CosmosDbCollection -Context $cosmosDbContext -Id 'MyExistingCollection' -IndexingPolicy $indexingPolicy
+```
+
+#### Creating a Collection with a custom Indexing Policy using JSON
+
+If the `New-CosmosDbCollection*` functions don't enable you to build
+the index policy to your requirements, you can also pass the raw index
+policy JSON to the function using the `IndexingPolicyJson` parameter:
+
+```powershell
+$indexingPolicyJson = @'
+{
+    "automatic":true,
+    "indexingMode":"Consistent",
+    "includedPaths":[
+        {
+            "path":"/*"
+        }
+    ],
+    "excludedPaths":[],
+    "compositeIndexes":[
+        [
+            {
+                "path":"/name",
+                "order":"ascending"
+            },
+            {
+                "path":"/age",
+                "order":"descending"
+            }
+        ]
+    ]
+}
+'@
+New-CosmosDbCollection -Context $cosmosDbContext -Id 'MyNewCollection' -PartitionKey 'id' -IndexingPolicyJson $indexingPolicyJson
 ```
 
 #### Creating a Collection with a custom Unique Key Policy

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -562,8 +562,7 @@ stages:
           eq(variables['Build.SourceBranch'], 'refs/heads/master'),
           startsWith(variables['Build.SourceBranch'], 'refs/tags/')
         ),
-        eq(variables['System.TeamFoundationCollectionUri'], 'https://dscottraynsford.visualstudio.com/'),
-        endsWith(variables['Build.DefinitionName'],'master')
+        eq(variables['System.TeamFoundationCollectionUri'], 'https://dscottraynsford.visualstudio.com/')
       )
     jobs:
       - deployment: Deploy_Module

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,7 @@ name: $(rev:r)
 trigger:
   branches:
     include:
-    - master
+    - '*'
   paths:
     include:
     - source/*

--- a/build.yaml
+++ b/build.yaml
@@ -2,7 +2,7 @@
 ####################################################
 #          ModuleBuilder Configuration             #
 ####################################################
-CopyDirectories:
+CopyPaths:
   - classes
   - formats
   - en-US

--- a/docs/New-CosmosDbCollection.md
+++ b/docs/New-CosmosDbCollection.md
@@ -13,20 +13,40 @@ Create a new collection in a Cosmos DB database.
 
 ## SYNTAX
 
-### Context (Default)
+### ContextIndexPolicy (Default)
 
 ```powershell
-New-CosmosDbCollection -Context <Context> [-Key <SecureString>] [-KeyType <String>] [-Database <String>]
- -Id <String> [-OfferThroughput <Int32>] [-OfferType <String>] [-PartitionKey <String>]
- [-IndexingPolicy <Policy>] [-DefaultTimeToLive <Int32>] [-UniqueKeyPolicy <Policy>] [<CommonParameters>]
+New-CosmosDbCollection -Context <Context> [-Key <SecureString>] [-KeyType <String>]
+ [-Database <String>] -Id <String> [-OfferThroughput <Int32>] [-OfferType <String>]
+ [-PartitionKey <String>] [-IndexingPolicy <Policy>] [-DefaultTimeToLive <Int32>]
+ [-UniqueKeyPolicy <Policy>] [<CommonParameters>]
 ```
 
-### Account
+### ContextIndexPolicyJson
 
 ```powershell
-New-CosmosDbCollection -Account <String> [-Key <SecureString>] [-KeyType <String>] [-Database <String>]
- -Id <String> [-OfferThroughput <Int32>] [-OfferType <String>] [-PartitionKey <String>]
- [-IndexingPolicy <Policy>] [-DefaultTimeToLive <Int32>] [-UniqueKeyPolicy <Policy>] [<CommonParameters>]
+New-CosmosDbCollection -Context <Context> [-Key <SecureString>] [-KeyType <String>]
+ [-Database <String>] -Id <String> [-OfferThroughput <Int32>] [-OfferType <String>]
+ [-PartitionKey <String>] [-IndexingPolicyJson <String>] [-DefaultTimeToLive <Int32>]
+ [-UniqueKeyPolicy <Policy>] [<CommonParameters>]
+```
+
+### AccountIndexPolicyJson
+
+```powershell
+New-CosmosDbCollection -Account <String> [-Key <SecureString>] [-KeyType <String>]
+ [-Database <String>] -Id <String> [-OfferThroughput <Int32>] [-OfferType <String>]
+ [-PartitionKey <String>] [-IndexingPolicyJson <String>] [-DefaultTimeToLive <Int32>]
+ [-UniqueKeyPolicy <Policy>] [<CommonParameters>]
+```
+
+### AccountIndexPolicy
+
+```powershell
+New-CosmosDbCollection -Account <String> [-Key <SecureString>] [-KeyType <String>]
+ [-Database <String>] -Id <String> [-OfferThroughput <Int32>] [-OfferType <String>]
+ [-PartitionKey <String>] [-IndexingPolicy <Policy>] [-DefaultTimeToLive <Int32>]
+ [-UniqueKeyPolicy <Policy>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -69,7 +89,7 @@ The account name of the Cosmos DB to access.
 
 ```yaml
 Type: String
-Parameter Sets: Account
+Parameter Sets: AccountIndexPolicyJson, AccountIndexPolicy
 Aliases:
 
 Required: True
@@ -86,7 +106,7 @@ that will be deleted. It should be created by \`New-CosmosDbContext\`.
 
 ```yaml
 Type: Context
-Parameter Sets: Context
+Parameter Sets: ContextIndexPolicy, ContextIndexPolicyJson
 Aliases: Connection
 
 Required: True
@@ -149,11 +169,29 @@ Accept wildcard characters: False
 ### -IndexingPolicy
 
 This is an Indexing Policy object that was created by the
-New-CosmosDbCollectionIndexingPolicy function.
+New-CosmosDbCollectionIndexingPolicy function. It should not
+be set if IndexingPolicyJson is set.
 
 ```yaml
 Type: Policy
-Parameter Sets: (All)
+Parameter Sets: ContextIndexPolicy, AccountIndexPolicy
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IndexingPolicyJson
+
+This is a JSON representation of an Indexing Policy. It should not
+be set if IndexingPolicy is set.
+
+```yaml
+Type: String
+Parameter Sets: ContextIndexPolicyJson, AccountIndexPolicyJson
 Aliases:
 
 Required: False
@@ -270,7 +308,9 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable,
+-Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/New-CosmosDbCollectionCompositeIndexElement.md
+++ b/docs/New-CosmosDbCollectionCompositeIndexElement.md
@@ -90,4 +90,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-https://docs.microsoft.com/en-nz/azure/cosmos-db/index-policy#composite-indexes
+[https://docs.microsoft.com/en-nz/azure/cosmos-db/index-policy#composite-indexes](https://docs.microsoft.com/en-nz/azure/cosmos-db/index-policy#composite-indexes)

--- a/docs/New-CosmosDbCollectionExcludedPath.md
+++ b/docs/New-CosmosDbCollectionExcludedPath.md
@@ -73,3 +73,5 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
+
+[https://docs.microsoft.com/en-nz/azure/cosmos-db/index-policy#composite-indexes](https://docs.microsoft.com/en-nz/azure/cosmos-db/index-policy#composite-indexes)

--- a/docs/New-CosmosDbCollectionIncludedPath.md
+++ b/docs/New-CosmosDbCollectionIncludedPath.md
@@ -97,3 +97,5 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
+
+[https://docs.microsoft.com/en-nz/azure/cosmos-db/index-policy#composite-indexes](https://docs.microsoft.com/en-nz/azure/cosmos-db/index-policy#composite-indexes)

--- a/docs/New-CosmosDbCollectionIncludedPathIndex.md
+++ b/docs/New-CosmosDbCollectionIncludedPathIndex.md
@@ -122,3 +122,5 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
+
+[https://docs.microsoft.com/en-nz/azure/cosmos-db/index-policy#composite-indexes](https://docs.microsoft.com/en-nz/azure/cosmos-db/index-policy#composite-indexes)

--- a/docs/New-CosmosDbCollectionIndexingPolicy.md
+++ b/docs/New-CosmosDbCollectionIndexingPolicy.md
@@ -169,3 +169,5 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
+
+[https://docs.microsoft.com/en-nz/azure/cosmos-db/index-policy#composite-indexes](https://docs.microsoft.com/en-nz/azure/cosmos-db/index-policy#composite-indexes)

--- a/docs/New-CosmosDbCollectionUniqueKey.md
+++ b/docs/New-CosmosDbCollectionUniqueKey.md
@@ -73,3 +73,5 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
+
+[https://docs.microsoft.com/en-nz/azure/cosmos-db/index-policy#composite-indexes](https://docs.microsoft.com/en-nz/azure/cosmos-db/index-policy#composite-indexes)

--- a/docs/New-CosmosDbCollectionUniqueKeyPolicy.md
+++ b/docs/New-CosmosDbCollectionUniqueKeyPolicy.md
@@ -73,3 +73,5 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
+
+[https://docs.microsoft.com/en-nz/azure/cosmos-db/index-policy#composite-indexes](https://docs.microsoft.com/en-nz/azure/cosmos-db/index-policy#composite-indexes)

--- a/docs/Set-CosmosDbCollection.md
+++ b/docs/Set-CosmosDbCollection.md
@@ -13,20 +13,40 @@ Update an existing collection in a Cosmos DB database.
 
 ## SYNTAX
 
-### Context (Default)
+### ContextIndexPolicy (Default)
 
 ```powershell
-Set-CosmosDbCollection -Context <Context> [-Key <SecureString>] [-KeyType <String>] [-Database <String>]
- -Id <String> [-IndexingPolicy <Policy>] [-DefaultTimeToLive <Int32>] [-RemoveDefaultTimeToLive]
- [-UniqueKeyPolicy <Policy>] [<CommonParameters>]
+Set-CosmosDbCollection -Context <Context> [-Key <SecureString>] [-KeyType <String>]
+ [-Database <String>] -Id <String> [-IndexingPolicy <Policy>]
+ [-DefaultTimeToLive <Int32>] [-RemoveDefaultTimeToLive] [-UniqueKeyPolicy <Policy>]
+ [<CommonParameters>]
 ```
 
-### Account
+### ContextIndexPolicyJson
 
 ```powershell
-Set-CosmosDbCollection -Account <String> [-Key <SecureString>] [-KeyType <String>] [-Database <String>]
- -Id <String> [-IndexingPolicy <Policy>] [-DefaultTimeToLive <Int32>] [-RemoveDefaultTimeToLive]
- [-UniqueKeyPolicy <Policy>] [<CommonParameters>]
+Set-CosmosDbCollection -Context <Context> [-Key <SecureString>] [-KeyType <String>]
+ [-Database <String>] -Id <String> [-IndexingPolicyJson <String>]
+ [-DefaultTimeToLive <Int32>] [-RemoveDefaultTimeToLive] [-UniqueKeyPolicy <Policy>]
+ [<CommonParameters>]
+```
+
+### AccountIndexPolicyJson
+
+```powershell
+Set-CosmosDbCollection -Account <String> [-Key <SecureString>] [-KeyType <String>]
+ [-Database <String>] -Id <String> [-IndexingPolicyJson <String>]
+ [-DefaultTimeToLive <Int32>] [-RemoveDefaultTimeToLive] [-UniqueKeyPolicy <Policy>]
+ [<CommonParameters>]
+```
+
+### AccountIndexPolicy
+
+```powershell
+Set-CosmosDbCollection -Account <String> [-Key <SecureString>] [-KeyType <String>]
+ [-Database <String>] -Id <String> [-IndexingPolicy <Policy>]
+ [-DefaultTimeToLive <Int32>] [-RemoveDefaultTimeToLive] [-UniqueKeyPolicy <Policy>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -74,7 +94,7 @@ The account name of the Cosmos DB to access.
 
 ```yaml
 Type: String
-Parameter Sets: Account
+Parameter Sets: AccountIndexPolicyJson, AccountIndexPolicy
 Aliases:
 
 Required: True
@@ -91,7 +111,7 @@ that will be deleted. It should be created by \`New-CosmosDbContext\`.
 
 ```yaml
 Type: Context
-Parameter Sets: Context
+Parameter Sets: ContextIndexPolicy, ContextIndexPolicyJson
 Aliases: Connection
 
 Required: True
@@ -154,11 +174,29 @@ Accept wildcard characters: False
 ### -IndexingPolicy
 
 This is an Indexing Policy object that was created by the
-Set-CosmosDbCollectionIndexingPolicy function.
+Set-CosmosDbCollectionIndexingPolicy function. It should not
+be set if IndexingPolicyJson is set.
 
 ```yaml
 Type: Policy
-Parameter Sets: (All)
+Parameter Sets: ContextIndexPolicy, AccountIndexPolicy
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IndexingPolicyJson
+
+This is a JSON representation of an Indexing Policy. It should not
+be set if IndexingPolicy is set.
+
+```yaml
+Type: String
+Parameter Sets: ContextIndexPolicyJson, AccountIndexPolicyJson
 Aliases:
 
 Required: False
@@ -239,7 +277,7 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/source/CosmosDB.psd1
+++ b/source/CosmosDB.psd1
@@ -26,32 +26,11 @@
     # Minimum version of the Windows PowerShell engine required by this module
     PowerShellVersion    = '5.1'
 
-    # Name of the Windows PowerShell host required by this module
-    # PowerShellHostName = ''
-
-    # Minimum version of the Windows PowerShell host required by this module
-    # PowerShellHostVersion = ''
-
-    # Minimum version of Microsoft .NET Framework required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
-    # DotNetFrameworkVersion = ''
-
-    # Minimum version of the common language runtime (CLR) required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
-    # CLRVersion = ''
-
-    # Processor architecture (None, X86, Amd64) required by this module
-    # ProcessorArchitecture = ''
-
     # Modules that must be imported into the global environment prior to importing this module
     RequiredModules      = @(
         @{ ModuleName = 'Az.Accounts'; GUID = '17a2feff-488b-47f9-8729-e2cec094624c'; ModuleVersion = '1.0.0'; },
         @{ ModuleName = 'Az.Resources'; GUID = '48bb344d-4c24-441e-8ea0-589947784700'; ModuleVersion = '1.0.0'; }
     )
-
-    # Assemblies that must be loaded prior to importing this module
-    # RequiredAssemblies = @()
-
-    # Script files (.ps1) that are run in the caller's environment prior to importing this module.
-    # ScriptsToProcess = @()
 
     # Type files (.ps1xml) to be loaded when importing this module
     TypesToProcess       = @(
@@ -80,9 +59,6 @@
         'formats\userdefinedfunctions.formats.ps1xml',
         'formats\users.formats.ps1xml'
     )
-
-    # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
-    # NestedModules = @()
 
     # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
     FunctionsToExport    = @('Get-CosmosDbAccount', 'Get-CosmosDbAccountConnectionString',
@@ -132,20 +108,9 @@
     # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
     AliasesToExport      = 'New-CosmosDbConnection'
 
-    # DSC resources to export from this module
-    # DscResourcesToExport = @()
-
-    # List of all modules packaged with this module
-    # ModuleList = @()
-
-    # List of all files packaged with this module
-    # FileList = @()
-
     # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
     PrivateData          = @{
-
         PSData = @{
-
             # Tags applied to this module. These help with module discovery in online galleries.
             Tags         = @('CosmosDB', 'DocumentDb', 'Azure', 'PSEdition_Core', 'PSEdition_Desktop', 'Windows', 'Linux', 'MacOS')
 
@@ -163,14 +128,5 @@
 
             Prerelease   = ''
         } # End of PSData hashtable
-
     } # End of PrivateData hashtable
-
-    # HelpInfo URI of this module
-    # HelpInfoURI = ''
-
-    # Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.
-    # DefaultCommandPrefix = ''
-
 }
-

--- a/source/Public/collections/New-CosmosDbCollection.ps1
+++ b/source/Public/collections/New-CosmosDbCollection.ps1
@@ -1,17 +1,19 @@
 function New-CosmosDbCollection
 {
 
-    [CmdletBinding(DefaultParameterSetName = 'Context')]
+    [CmdletBinding(DefaultParameterSetName = 'ContextIndexPolicy')]
     [OutputType([Object])]
     param
     (
         [Alias("Connection")]
-        [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ContextIndexPolicy')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ContextIndexPolicyJson')]
         [ValidateNotNullOrEmpty()]
         [CosmosDb.Context]
         $Context,
 
-        [Parameter(Mandatory = $true, ParameterSetName = 'Account')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'AccountIndexPolicy')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'AccountIndexPolicyJson')]
         [ValidateScript({ Assert-CosmosDbAccountNameValid -Name $_ -ArgumentName 'Account' })]
         [System.String]
         $Account,
@@ -51,16 +53,14 @@ function New-CosmosDbCollection
         [System.String]
         $PartitionKey,
 
-        [Parameter(ParameterSetName = 'Context')]
-        [Parameter(ParameterSetName = 'Account')]
-        [Parameter(Mandatory = $true, ParameterSetName = 'IndexingPolicy')]
+        [Parameter(ParameterSetName = 'ContextIndexPolicy')]
+        [Parameter(ParameterSetName = 'AccountIndexPolicy')]
         [ValidateNotNullOrEmpty()]
         [CosmosDB.IndexingPolicy.Policy]
         $IndexingPolicy,
 
-        [Parameter(ParameterSetName = 'Context')]
-        [Parameter(ParameterSetName = 'Account')]
-        [Parameter(Mandatory = $true, ParameterSetName = 'IndexingPolicyJson')]
+        [Parameter(ParameterSetName = 'ContextIndexPolicyJson')]
+        [Parameter(ParameterSetName = 'AccountIndexPolicyJson')]
         [ValidateNotNullOrEmpty()]
         [System.String]
         $IndexingPolicyJson,

--- a/source/Public/collections/New-CosmosDbCollection.ps1
+++ b/source/Public/collections/New-CosmosDbCollection.ps1
@@ -51,10 +51,19 @@ function New-CosmosDbCollection
         [System.String]
         $PartitionKey,
 
-        [Parameter()]
+        [Parameter(ParameterSetName = 'Context')]
+        [Parameter(ParameterSetName = 'Account')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'IndexingPolicy')]
         [ValidateNotNullOrEmpty()]
         [CosmosDB.IndexingPolicy.Policy]
         $IndexingPolicy,
+
+        [Parameter(ParameterSetName = 'Context')]
+        [Parameter(ParameterSetName = 'Account')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'IndexingPolicyJson')]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $IndexingPolicyJson,
 
         [Parameter()]
         [ValidateRange(-1,2147483647)]
@@ -123,6 +132,13 @@ function New-CosmosDbCollection
             indexingPolicy = $IndexingPolicy
         }
         $null = $PSBoundParameters.Remove('IndexingPolicy')
+    }
+    elseif ($PSBoundParameters.ContainsKey('IndexingPolicyJson'))
+    {
+        $bodyObject += @{
+            indexingPolicy = ConvertFrom-Json -InputObject $IndexingPolicyJson
+        }
+        $null = $PSBoundParameters.Remove('IndexingPolicyJson')
     }
 
     if ($PSBoundParameters.ContainsKey('DefaultTimeToLive'))

--- a/source/Public/collections/Set-CosmosDbCollection.ps1
+++ b/source/Public/collections/Set-CosmosDbCollection.ps1
@@ -36,10 +36,19 @@ function Set-CosmosDbCollection
         [System.String]
         $Id,
 
-        [Parameter()]
+        [Parameter(ParameterSetName = 'Context')]
+        [Parameter(ParameterSetName = 'Account')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'IndexingPolicy')]
         [ValidateNotNullOrEmpty()]
         [CosmosDB.IndexingPolicy.Policy]
         $IndexingPolicy,
+
+        [Parameter(ParameterSetName = 'Context')]
+        [Parameter(ParameterSetName = 'Account')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'IndexingPolicyJson')]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $IndexingPolicyJson,
 
         [Parameter()]
         [ValidateRange(-1,2147483647)]
@@ -69,7 +78,21 @@ function Set-CosmosDbCollection
         id = $id
     }
 
-    $indexingPolicyIncluded = $PSBoundParameters.ContainsKey('IndexingPolicy')
+    $indexingPolicyIncluded = $false
+
+    if ($PSBoundParameters.ContainsKey('IndexingPolicy'))
+    {
+        $ActualIndexingPolicy = $IndexingPolicy
+        $indexingPolicyIncluded = $true
+        $null = $PSBoundParameters.Remove('IndexingPolicy')
+    }
+    elseif ($PSBoundParameters.ContainsKey('IndexingPolicyJson'))
+    {
+        $ActualIndexingPolicy = ConvertFrom-Json -InputObject $IndexingPolicyJson
+        $indexingPolicyIncluded = $true
+        $null = $PSBoundParameters.Remove('IndexingPolicyJson')
+    }
+
     $defaultTimeToLiveIncluded = $PSBoundParameters.ContainsKey('DefaultTimeToLive')
     $uniqueKeyPolicyIncluded = $PSBoundParameters.ContainsKey('UniqueKeyPolicy')
 
@@ -90,7 +113,7 @@ function Set-CosmosDbCollection
     if ($indexingPolicyIncluded)
     {
         $bodyObject += @{
-            indexingPolicy = $IndexingPolicy
+            indexingPolicy = $ActualIndexingPolicy
         }
     }
     else

--- a/source/Public/collections/Set-CosmosDbCollection.ps1
+++ b/source/Public/collections/Set-CosmosDbCollection.ps1
@@ -1,17 +1,19 @@
 function Set-CosmosDbCollection
 {
 
-    [CmdletBinding(DefaultParameterSetName = 'Context')]
+    [CmdletBinding(DefaultParameterSetName = 'ContextIndexPolicy')]
     [OutputType([Object])]
     param
     (
         [Alias("Connection")]
-        [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ContextIndexPolicy')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ContextIndexPolicyJson')]
         [ValidateNotNullOrEmpty()]
         [CosmosDb.Context]
         $Context,
 
-        [Parameter(Mandatory = $true, ParameterSetName = 'Account')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'AccountIndexPolicy')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'AccountIndexPolicyJson')]
         [ValidateScript({ Assert-CosmosDbAccountNameValid -Name $_ -ArgumentName 'Account' })]
         [System.String]
         $Account,
@@ -36,16 +38,14 @@ function Set-CosmosDbCollection
         [System.String]
         $Id,
 
-        [Parameter(ParameterSetName = 'Context')]
-        [Parameter(ParameterSetName = 'Account')]
-        [Parameter(Mandatory = $true, ParameterSetName = 'IndexingPolicy')]
+        [Parameter(ParameterSetName = 'ContextIndexPolicy')]
+        [Parameter(ParameterSetName = 'AccountIndexPolicy')]
         [ValidateNotNullOrEmpty()]
         [CosmosDB.IndexingPolicy.Policy]
         $IndexingPolicy,
 
-        [Parameter(ParameterSetName = 'Context')]
-        [Parameter(ParameterSetName = 'Account')]
-        [Parameter(Mandatory = $true, ParameterSetName = 'IndexingPolicyJson')]
+        [Parameter(ParameterSetName = 'ContextIndexPolicyJson')]
+        [Parameter(ParameterSetName = 'AccountIndexPolicyJson')]
         [ValidateNotNullOrEmpty()]
         [System.String]
         $IndexingPolicyJson,

--- a/source/build.psd1
+++ b/source/build.psd1
@@ -1,6 +1,0 @@
-@{
-    Path = 'CosmosDB.psd1' #or build breaks on Linux
-}
-# Waiting for ModuleBuilder to do away with this file
-# when all parameters are provided to the function
-

--- a/source/build.psd1
+++ b/source/build.psd1
@@ -1,0 +1,5 @@
+@{
+    Path = 'CosmosDB.psd1' #or build breaks on Linux
+}
+# Waiting for ModuleBuilder to do away with this file
+# when all parameters are provided to the function

--- a/source/en-US/CosmosDB.strings.psd1
+++ b/source/en-US/CosmosDB.strings.psd1
@@ -19,7 +19,7 @@ ConvertFrom-StringData -StringData @'
     RemovingAzureCosmosDBAccount = Removing Azure Cosmos DB account '{0}' in resource group '{1}'.
     StoredProcedureScriptLogResults = Stored Procedure '{0}' script log results:\n{1}
     RequestChargeResults = Request charge for {0} to '{1}' was {2} RUs.
-    NonPartitionedCollectionWarning = It is not recommended to create a collection without a partition key. It may result in reduced performance and increased cost. This functionality is included for backwards compatibility only.
+    NonPartitionedCollectionWarning = It is not recommended to create a collection without a partition key. It may result in reduced performance and increased cost. This functionality is included for backwards compatibility only and will be removed in a future version.
     CollectionProvisionedThroughputExceededWithBackoffPolicy = The collection has exceeded the provisioned throughput limit but a back-off policy is specified.
     CollectionProvisionedThroughputExceededNoBackoffPolicy = The collection has exceeded the provisioned throughput limit but there is no back-off policy.
     CollectionProvisionedThroughputExceededMaxRetriesHit = The maximum back-off policy retries {0} has been exceeded.

--- a/tests/Integration/CosmosDB.integration.Tests.ps1
+++ b/tests/Integration/CosmosDB.integration.Tests.ps1
@@ -599,6 +599,28 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
         }
     }
 
+    Context 'When creating a new collection with a simple automatic indexing policy using JSON' {
+        It 'Should not throw an exception' {
+            $script:result = New-CosmosDbCollection `
+                -Context $script:testContext `
+                -Id $script:testCollection `
+                -OfferThroughput 400 `
+                -IndexingPolicyJson (ConvertTo-Json -InputObject $script:indexingPolicySimpleAutomatic -Depth 10) `
+                -Verbose
+        }
+
+        It 'Should return expected object' {
+            Test-CollectionDefaultIndexingPolicy -CollectionResult $script:result
+            $script:result.Id | Should -Be $script:testCollection
+        }
+    }
+
+    Context 'When removing existing collection with a simple automatic indexing policy' {
+        It 'Should not throw an exception' {
+            $script:result = Remove-CosmosDbCollection -Context $script:testContext -Id $script:testCollection -Verbose
+        }
+    }
+
     Context 'When creating a new composite index indexing policy' {
         It 'Should not throw an exception' {
             $script:compositeIndexElements = @(


### PR DESCRIPTION
- Added `IndexingPolicyJson` parameter to `New-CosmosDbCollection`
  and `Set-CosmosDbCollection` functions to enable setting an index policy
  using JSON - Fixes [Issue #360](https://github.com/PlagueHO/CosmosDB/issues/360).
- Fixed build pipeline deployment skip function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plagueho/cosmosdb/361)
<!-- Reviewable:end -->
