### PR TITLE
Add Support for AzureChinaCloud - Fixes #365

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added support for AzureChinaCloud (Mooncake) - Fixes [Issue #365](https://github.com/PlagueHO/CosmosDB/issues/365).
+
 ## [4.0.0] - 2020-05-11
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Added support for AzureChinaCloud (Mooncake) - Fixes [Issue #365](https://github.com/PlagueHO/CosmosDB/issues/365).
+- Fix daily build by preventing deployment stage from running on
+  anything build not named `*.master` - Fixes [Issue #366](https://github.com/PlagueHO/CosmosDB/issues/366).
 
 ## [4.0.0] - 2020-05-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
 - Added support for AzureChinaCloud (Mooncake) - Fixes [Issue #365](https://github.com/PlagueHO/CosmosDB/issues/365).
+
+### Changed
+
 - Fix daily build by preventing deployment stage from running on
   anything build not named `*.master` - Fixes [Issue #366](https://github.com/PlagueHO/CosmosDB/issues/366).
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
   - [Working with Contexts](#working-with-contexts)
     - [Create a Context specifying the Key Manually](#create-a-context-specifying-the-key-manually)
     - [Create a Context for a Cosmos DB in Azure US Government Cloud](#create-a-context-for-a-cosmos-db-in-azure-us-government-cloud)
+    - [Create a Context for a Cosmos DB in Azure China Cloud (Mooncake)](#create-a-context-for-a-cosmos-db-in-azure-china-cloud-mooncake)
     - [Use CosmosDB Module to Retrieve Key from Azure Management Portal](#use-cosmosdb-module-to-retrieve-key-from-azure-management-portal)
     - [Create a Context for a Cosmos DB Emulator](#create-a-context-for-a-cosmos-db-emulator)
     - [Create a Context from Resource Authorization Tokens](#create-a-context-from-resource-authorization-tokens)
@@ -150,6 +151,16 @@ create a context variable and set the `Environment` parameter to
 
 ```powershell
 $cosmosDbContext = New-CosmosDbContext -Account 'MyAzureCosmosDB' -Database 'MyDatabase' -Key $primaryKey -Environment AzureUSGovernment
+```
+
+#### Create a Context for a Cosmos DB in Azure China Cloud (Mooncake)
+
+Use the key secure string, Azure Cosmos DB account name and database to
+create a context variable and set the `Environment` parameter to
+`AzureChinaCloud`:
+
+```powershell
+$cosmosDbContext = New-CosmosDbContext -Account 'MyAzureCosmosDB' -Database 'MyDatabase' -Key $primaryKey -Environment AzureChinaCloud
 ```
 
 #### Use CosmosDB Module to Retrieve Key from Azure Management Portal

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -562,7 +562,8 @@ stages:
           eq(variables['Build.SourceBranch'], 'refs/heads/master'),
           startsWith(variables['Build.SourceBranch'], 'refs/tags/')
         ),
-        eq(variables['System.TeamFoundationCollectionUri'], 'https://dscottraynsford.visualstudio.com/')
+        eq(variables['System.TeamFoundationCollectionUri'], 'https://dscottraynsford.visualstudio.com/'),
+        endsWith(variables['Build.DefinitionName'],'master')
       )
     jobs:
       - job: Deploy_Module

--- a/source/Private/utils/Get-CosmosDbUri.ps1
+++ b/source/Private/utils/Get-CosmosDbUri.ps1
@@ -28,6 +28,11 @@ function Get-CosmosDbUri
             {
                 $BaseUri = 'documents.azure.us'
             }
+
+            'AzureChinaCloud'
+            {
+                $BaseUri = 'documents.azure.cn'
+            }
         }
     }
 

--- a/source/classes/CosmosDB/CosmosDB.cs
+++ b/source/classes/CosmosDB/CosmosDB.cs
@@ -2,6 +2,7 @@
 
 namespace CosmosDB {
     public enum Environment {
+        AzureChinaCloud,
         AzureCloud,
         AzureUSGovernment
     }


### PR DESCRIPTION
- Added support for AzureChinaCloud (Mooncake) - Fixes [Issue #365](https://github.com/PlagueHO/CosmosDB/issues/365).
- Fix daily build by preventing deployment stage from running on
  anything build not named `*.master` - Fixes [Issue #366](https://github.com/PlagueHO/CosmosDB/issues/366).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plagueho/cosmosdb/367)
<!-- Reviewable:end -->
