### PR TITLE
Update PSCore6_Ubuntu1604 Build Jobs to use PSCore 6.2.4 - Fixes #371

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Changed build jobs `Unit_Test_PSCore6_Ubuntu1604` and
+  `Integration_Test_PSCore6_Ubuntu1604` to install PowerShell Core 6.2.4
+  to support version of Az PowerShell modules that are installed - Fixes [Issue #371](https://github.com/PlagueHO/CosmosDB/issues/371).
+
 ## [4.1.0] - 2020-05-15
 
 ### Added

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -234,7 +234,7 @@ stages:
               curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
               curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list | sudo tee /etc/apt/sources.list.d/microsoft.list
               sudo apt-get update
-              sudo apt-get install -y --allow-downgrades powershell=6.2.3-1.ubuntu.16.04
+              sudo apt-get install -y --allow-downgrades powershell=6.2.4-1.ubuntu.16.04
             displayName: 'Install PowerShell Core 6'
 
           - task: PowerShell@2
@@ -279,7 +279,7 @@ stages:
               curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
               curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list | sudo tee /etc/apt/sources.list.d/microsoft.list
               sudo apt-get update
-              sudo apt-get install -y --allow-downgrades powershell=6.2.3-1.ubuntu.16.04
+              sudo apt-get install -y --allow-downgrades powershell=6.2.4-1.ubuntu.16.04
             displayName: 'Install PowerShell Core 6'
 
           - task: PowerShell@2


### PR DESCRIPTION
- Changed build jobs `Unit_Test_PSCore6_Ubuntu1604` and
  `Integration_Test_PSCore6_Ubuntu1604` to install PowerShell Core 6.2.4
  to support version of Az PowerShell modules that are installed - Fixes [Issue #371](https://github.com/PlagueHO/CosmosDB/issues/371).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plagueho/cosmosdb/372)
<!-- Reviewable:end -->
