### PR TITLE
Pin Pester 4.10.1 and add Name Parameter Aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed build jobs `Unit_Test_PSCore6_Ubuntu1604` and
   `Integration_Test_PSCore6_Ubuntu1604` to install PowerShell Core 6.2.4
   to support version of Az PowerShell modules that are installed - Fixes [Issue #371](https://github.com/PlagueHO/CosmosDB/issues/371).
+- Pinned build to Pester v4.10.1 - Fixes [Issue #371](https://github.com/PlagueHO/CosmosDB/issues/378).
+- Added `Name` as an alias for `Id` parameters in
+  `*-CosmosDbCollection` functions - Fixes [Issue #375](https://github.com/PlagueHO/CosmosDB/issues/375).
+- Added `Name` as an alias for `Id` parameters in
+  `*-CosmosDbDatabase` functions - Fixes [Issue #374](https://github.com/PlagueHO/CosmosDB/issues/374).
 
 ## [4.1.0] - 2020-05-15
 

--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -8,7 +8,7 @@
     }
     invokeBuild         = 'latest'
     PSScriptAnalyzer    = 'latest'
-    pester              = 'latest'
+    Pester              = '4.10.1'
     Plaster             = 'latest'
     Platyps             = 'latest'
     ModuleBuilder       = 'latest'

--- a/docs/Get-CosmosDbCollection.md
+++ b/docs/Get-CosmosDbCollection.md
@@ -155,7 +155,7 @@ all collections in the database will be returned.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases:
+Aliases: Name
 
 Required: False
 Position: Named

--- a/docs/Get-CosmosDbCollectionResourcePath.md
+++ b/docs/Get-CosmosDbCollectionResourcePath.md
@@ -57,7 +57,7 @@ This is the Id of the collection.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases:
+Aliases: Name
 
 Required: True
 Position: 1

--- a/docs/Get-CosmosDbCollectionSize.md
+++ b/docs/Get-CosmosDbCollectionSize.md
@@ -109,7 +109,7 @@ This is the id of the collection to get.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases:
+Aliases: Name
 
 Required: False
 Position: Named

--- a/docs/Get-CosmosDbDatabase.md
+++ b/docs/Get-CosmosDbDatabase.md
@@ -95,7 +95,7 @@ This is the Id of the database to get.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases:
+Aliases: Name
 
 Required: False
 Position: Named

--- a/docs/New-CosmosDbCollection.md
+++ b/docs/New-CosmosDbCollection.md
@@ -157,7 +157,7 @@ This is the Id of the collection to create.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases:
+Aliases: Name
 
 Required: True
 Position: Named

--- a/docs/New-CosmosDbDatabase.md
+++ b/docs/New-CosmosDbDatabase.md
@@ -92,7 +92,7 @@ This is the Id of the database to create.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases:
+Aliases: Name
 
 Required: True
 Position: Named

--- a/docs/Remove-CosmosDbCollection.md
+++ b/docs/Remove-CosmosDbCollection.md
@@ -99,7 +99,7 @@ This is the Id of the collection to delete.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases:
+Aliases: Name
 
 Required: True
 Position: Named

--- a/docs/Remove-CosmosDbDatabase.md
+++ b/docs/Remove-CosmosDbDatabase.md
@@ -83,7 +83,7 @@ This is the Id of the database to delete.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases:
+Aliases: Name
 
 Required: True
 Position: Named

--- a/docs/Set-CosmosDbCollection.md
+++ b/docs/Set-CosmosDbCollection.md
@@ -162,7 +162,7 @@ This is the Id of the collection to update.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases:
+Aliases: Name
 
 Required: True
 Position: Named

--- a/source/Private/utils/Invoke-CosmosDbRequest.ps1
+++ b/source/Private/utils/Invoke-CosmosDbRequest.ps1
@@ -4,7 +4,7 @@ function Invoke-CosmosDbRequest
     [OutputType([System.String])]
     param
     (
-        [Alias("Connection")]
+        [Alias('Connection')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
         [CosmosDB.Context]

--- a/source/Public/attachments/Get-CosmosDbAttachment.ps1
+++ b/source/Public/attachments/Get-CosmosDbAttachment.ps1
@@ -5,7 +5,7 @@ function Get-CosmosDbAttachment
     [OutputType([Object])]
     param
     (
-        [Alias("Connection")]
+        [Alias('Connection')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
         [CosmosDb.Context]

--- a/source/Public/attachments/New-CosmosDbAttachment.ps1
+++ b/source/Public/attachments/New-CosmosDbAttachment.ps1
@@ -5,7 +5,7 @@ function New-CosmosDbAttachment
     [OutputType([Object])]
     param
     (
-        [Alias("Connection")]
+        [Alias('Connection')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
         [CosmosDb.Context]

--- a/source/Public/attachments/Remove-CosmosDbAttachment.ps1
+++ b/source/Public/attachments/Remove-CosmosDbAttachment.ps1
@@ -4,7 +4,7 @@ function Remove-CosmosDbAttachment
     [CmdletBinding(DefaultParameterSetName = 'Context')]
     param
     (
-        [Alias("Connection")]
+        [Alias('Connection')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
         [CosmosDb.Context]

--- a/source/Public/attachments/Set-CosmosDbAttachment.ps1
+++ b/source/Public/attachments/Set-CosmosDbAttachment.ps1
@@ -5,7 +5,7 @@ function Set-CosmosDbAttachment
     [OutputType([Object])]
     param
     (
-        [Alias("Connection")]
+        [Alias('Connection')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
         [CosmosDb.Context]

--- a/source/Public/collections/Get-CosmosDbCollection.ps1
+++ b/source/Public/collections/Get-CosmosDbCollection.ps1
@@ -5,7 +5,7 @@ function Get-CosmosDbCollection
     [OutputType([Object])]
     param
     (
-        [Alias("Connection")]
+        [Alias('Connection')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
         [CosmosDb.Context]
@@ -31,6 +31,7 @@ function Get-CosmosDbCollection
         [System.String]
         $Database,
 
+        [Alias('Name')]
         [Parameter()]
         [ValidateScript({ Assert-CosmosDbCollectionIdValid -Id $_ })]
         [System.String]

--- a/source/Public/collections/Get-CosmosDbCollectionResourcePath.ps1
+++ b/source/Public/collections/Get-CosmosDbCollectionResourcePath.ps1
@@ -10,6 +10,7 @@ function Get-CosmosDbCollectionResourcePath
         [System.String]
         $Database,
 
+        [Alias('Name')]
         [Parameter(Mandatory = $true)]
         [ValidateScript({ Assert-CosmosDbCollectionIdValid -Id $_ })]
         [System.String]

--- a/source/Public/collections/Get-CosmosDbCollectionSize.ps1
+++ b/source/Public/collections/Get-CosmosDbCollectionSize.ps1
@@ -5,7 +5,7 @@ function Get-CosmosDbCollectionSize
     [OutputType([System.Collections.Hashtable])]
     param
     (
-        [Alias("Connection")]
+        [Alias('Connection')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
         [CosmosDb.Context]
@@ -31,6 +31,7 @@ function Get-CosmosDbCollectionSize
         [System.String]
         $Database,
 
+        [Alias('Name')]
         [Parameter(Mandatory = $true)]
         [ValidateScript({ Assert-CosmosDbCollectionIdValid -Id $_ })]
         [System.String]

--- a/source/Public/collections/New-CosmosDbCollection.ps1
+++ b/source/Public/collections/New-CosmosDbCollection.ps1
@@ -5,7 +5,7 @@ function New-CosmosDbCollection
     [OutputType([Object])]
     param
     (
-        [Alias("Connection")]
+        [Alias('Connection')]
         [Parameter(Mandatory = $true, ParameterSetName = 'ContextIndexPolicy')]
         [Parameter(Mandatory = $true, ParameterSetName = 'ContextIndexPolicyJson')]
         [ValidateNotNullOrEmpty()]
@@ -33,6 +33,7 @@ function New-CosmosDbCollection
         [System.String]
         $Database,
 
+        [Alias('Name')]
         [Parameter(Mandatory = $true)]
         [ValidateScript({ Assert-CosmosDbCollectionIdValid -Id $_ })]
         [System.String]

--- a/source/Public/collections/Remove-CosmosDbCollection.ps1
+++ b/source/Public/collections/Remove-CosmosDbCollection.ps1
@@ -4,7 +4,7 @@ function Remove-CosmosDbCollection
     [CmdletBinding(DefaultParameterSetName = 'Context')]
     param
     (
-        [Alias("Connection")]
+        [Alias('Connection')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
         [CosmosDb.Context]
@@ -30,6 +30,7 @@ function Remove-CosmosDbCollection
         [System.String]
         $Database,
 
+        [Alias('Name')]
         [Parameter(Mandatory = $true)]
         [ValidateScript({ Assert-CosmosDbCollectionIdValid -Id $_ })]
         [System.String]

--- a/source/Public/collections/Set-CosmosDbCollection.ps1
+++ b/source/Public/collections/Set-CosmosDbCollection.ps1
@@ -5,7 +5,7 @@ function Set-CosmosDbCollection
     [OutputType([Object])]
     param
     (
-        [Alias("Connection")]
+        [Alias('Connection')]
         [Parameter(Mandatory = $true, ParameterSetName = 'ContextIndexPolicy')]
         [Parameter(Mandatory = $true, ParameterSetName = 'ContextIndexPolicyJson')]
         [ValidateNotNullOrEmpty()]
@@ -33,6 +33,7 @@ function Set-CosmosDbCollection
         [System.String]
         $Database,
 
+        [Alias('Name')]
         [Parameter(Mandatory = $true)]
         [ValidateScript({ Assert-CosmosDbCollectionIdValid -Id $_ })]
         [System.String]

--- a/source/Public/databases/Get-CosmosDbDatabase.ps1
+++ b/source/Public/databases/Get-CosmosDbDatabase.ps1
@@ -5,7 +5,7 @@ function Get-CosmosDbDatabase
     [OutputType([Object])]
     param
     (
-        [Alias("Connection")]
+        [Alias('Connection')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
         [CosmosDb.Context]
@@ -26,6 +26,7 @@ function Get-CosmosDbDatabase
         [System.String]
         $KeyType = 'master',
 
+        [Alias('Name')]
         [Parameter()]
         [ValidateScript({ Assert-CosmosDbDatabaseIdValid -Id $_ })]
         [System.String]

--- a/source/Public/databases/Get-CosmosDbDatabaseResourcePath.ps1
+++ b/source/Public/databases/Get-CosmosDbDatabaseResourcePath.ps1
@@ -5,6 +5,7 @@ function Get-CosmosDbDatabaseResourcePath
     [OutputType([System.String])]
     param
     (
+        [Alias('Name')]
         [Parameter(Mandatory = $true)]
         [ValidateScript({ Assert-CosmosDbDatabaseIdValid -Id $_ })]
         [System.String]

--- a/source/Public/databases/New-CosmosDbDatabase.ps1
+++ b/source/Public/databases/New-CosmosDbDatabase.ps1
@@ -5,7 +5,7 @@ function New-CosmosDbDatabase
     [OutputType([Object])]
     param
     (
-        [Alias("Connection")]
+        [Alias('Connection')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
         [CosmosDb.Context]
@@ -26,6 +26,7 @@ function New-CosmosDbDatabase
         [System.String]
         $KeyType = 'master',
 
+        [Alias('Name')]
         [Parameter(Mandatory = $true)]
         [ValidateScript({ Assert-CosmosDbDatabaseIdValid -Id $_ })]
         [System.String]

--- a/source/Public/databases/Remove-CosmosDbDatabase.ps1
+++ b/source/Public/databases/Remove-CosmosDbDatabase.ps1
@@ -4,7 +4,7 @@ function Remove-CosmosDbDatabase
     [CmdletBinding(DefaultParameterSetName = 'Context')]
     param
     (
-        [Alias("Connection")]
+        [Alias('Connection')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
         [CosmosDb.Context]
@@ -25,6 +25,7 @@ function Remove-CosmosDbDatabase
         [System.String]
         $KeyType = 'master',
 
+        [Alias('Name')]
         [Parameter(Mandatory = $true)]
         [ValidateScript({ Assert-CosmosDbDatabaseIdValid -Id $_ })]
         [System.String]

--- a/source/Public/documents/Get-CosmosDbDocument.ps1
+++ b/source/Public/documents/Get-CosmosDbDocument.ps1
@@ -5,7 +5,7 @@ function Get-CosmosDbDocument
     [OutputType([Object])]
     param
     (
-        [Alias("Connection")]
+        [Alias('Connection')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
         [CosmosDb.Context]

--- a/source/Public/documents/New-CosmosDbDocument.ps1
+++ b/source/Public/documents/New-CosmosDbDocument.ps1
@@ -5,7 +5,7 @@ function New-CosmosDbDocument
     [OutputType([Object])]
     param
     (
-        [Alias("Connection")]
+        [Alias('Connection')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
         [CosmosDb.Context]

--- a/source/Public/documents/Remove-CosmosDbDocument.ps1
+++ b/source/Public/documents/Remove-CosmosDbDocument.ps1
@@ -4,7 +4,7 @@ function Remove-CosmosDbDocument
     [CmdletBinding(DefaultParameterSetName = 'Context')]
     param
     (
-        [Alias("Connection")]
+        [Alias('Connection')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
         [CosmosDb.Context]

--- a/source/Public/documents/Set-CosmosDbDocument.ps1
+++ b/source/Public/documents/Set-CosmosDbDocument.ps1
@@ -5,7 +5,7 @@ function Set-CosmosDbDocument
     [OutputType([Object])]
     param
     (
-        [Alias("Connection")]
+        [Alias('Connection')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
         [CosmosDb.Context]

--- a/source/Public/offers/Get-CosmosDbOffer.ps1
+++ b/source/Public/offers/Get-CosmosDbOffer.ps1
@@ -5,7 +5,7 @@ function Get-CosmosDbOffer
     [OutputType([Object])]
     param
     (
-        [Alias("Connection")]
+        [Alias('Connection')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
         [CosmosDb.Context]

--- a/source/Public/offers/Set-CosmosDbOffer.ps1
+++ b/source/Public/offers/Set-CosmosDbOffer.ps1
@@ -5,7 +5,7 @@ function Set-CosmosDbOffer
     [OutputType([Object])]
     param
     (
-        [Alias("Connection")]
+        [Alias('Connection')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
         [CosmosDb.Context]

--- a/source/Public/permissions/Get-CosmosDbPermission.ps1
+++ b/source/Public/permissions/Get-CosmosDbPermission.ps1
@@ -5,7 +5,7 @@ function Get-CosmosDbPermission
     [OutputType([Object])]
     param
     (
-        [Alias("Connection")]
+        [Alias('Connection')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
         [CosmosDb.Context]

--- a/source/Public/permissions/New-CosmosDbPermission.ps1
+++ b/source/Public/permissions/New-CosmosDbPermission.ps1
@@ -5,7 +5,7 @@ function New-CosmosDbPermission
     [OutputType([Object])]
     param
     (
-        [Alias("Connection")]
+        [Alias('Connection')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
         [CosmosDb.Context]

--- a/source/Public/permissions/Remove-CosmosDbPermission.ps1
+++ b/source/Public/permissions/Remove-CosmosDbPermission.ps1
@@ -4,7 +4,7 @@ function Remove-CosmosDbPermission
     [CmdletBinding(DefaultParameterSetName = 'Context')]
     param
     (
-        [Alias("Connection")]
+        [Alias('Connection')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
         [CosmosDb.Context]

--- a/source/Public/storedprocedures/Get-CosmosDbStoredProcedure.ps1
+++ b/source/Public/storedprocedures/Get-CosmosDbStoredProcedure.ps1
@@ -5,7 +5,7 @@ function Get-CosmosDbStoredProcedure
     [OutputType([Object])]
     param
     (
-        [Alias("Connection")]
+        [Alias('Connection')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
         [CosmosDb.Context]

--- a/source/Public/storedprocedures/Invoke-CosmosDbStoredProcedure.ps1
+++ b/source/Public/storedprocedures/Invoke-CosmosDbStoredProcedure.ps1
@@ -5,7 +5,7 @@ function Invoke-CosmosDbStoredProcedure
     [OutputType([Object])]
     param
     (
-        [Alias("Connection")]
+        [Alias('Connection')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
         [CosmosDb.Context]

--- a/source/Public/storedprocedures/New-CosmosDbStoredProcedure.ps1
+++ b/source/Public/storedprocedures/New-CosmosDbStoredProcedure.ps1
@@ -5,7 +5,7 @@ function New-CosmosDbStoredProcedure
     [OutputType([Object])]
     param
     (
-        [Alias("Connection")]
+        [Alias('Connection')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
         [CosmosDb.Context]

--- a/source/Public/storedprocedures/Remove-CosmosDbStoredProcedure.ps1
+++ b/source/Public/storedprocedures/Remove-CosmosDbStoredProcedure.ps1
@@ -4,7 +4,7 @@ function Remove-CosmosDbStoredProcedure
     [CmdletBinding(DefaultParameterSetName = 'Context')]
     param
     (
-        [Alias("Connection")]
+        [Alias('Connection')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
         [CosmosDb.Context]

--- a/source/Public/storedprocedures/Set-CosmosDbStoredProcedure.ps1
+++ b/source/Public/storedprocedures/Set-CosmosDbStoredProcedure.ps1
@@ -5,7 +5,7 @@ function Set-CosmosDbStoredProcedure
     [OutputType([Object])]
     param
     (
-        [Alias("Connection")]
+        [Alias('Connection')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
         [CosmosDb.Context]

--- a/source/Public/triggers/Get-CosmosDbTrigger.ps1
+++ b/source/Public/triggers/Get-CosmosDbTrigger.ps1
@@ -5,7 +5,7 @@ function Get-CosmosDbTrigger
     [OutputType([Object])]
     param
     (
-        [Alias("Connection")]
+        [Alias('Connection')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
         [CosmosDb.Context]

--- a/source/Public/triggers/New-CosmosDbTrigger.ps1
+++ b/source/Public/triggers/New-CosmosDbTrigger.ps1
@@ -5,7 +5,7 @@ function New-CosmosDbTrigger
     [OutputType([Object])]
     param
     (
-        [Alias("Connection")]
+        [Alias('Connection')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
         [CosmosDb.Context]

--- a/source/Public/triggers/Remove-CosmosDbTrigger.ps1
+++ b/source/Public/triggers/Remove-CosmosDbTrigger.ps1
@@ -4,7 +4,7 @@ function Remove-CosmosDbTrigger
     [CmdletBinding(DefaultParameterSetName = 'Context')]
     param
     (
-        [Alias("Connection")]
+        [Alias('Connection')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
         [CosmosDb.Context]

--- a/source/Public/triggers/Set-CosmosDbTrigger.ps1
+++ b/source/Public/triggers/Set-CosmosDbTrigger.ps1
@@ -5,7 +5,7 @@ function Set-CosmosDbTrigger
     [OutputType([Object])]
     param
     (
-        [Alias("Connection")]
+        [Alias('Connection')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
         [CosmosDb.Context]

--- a/source/Public/userdefinedfunctions/Get-CosmosDbUserDefinedFunction.ps1
+++ b/source/Public/userdefinedfunctions/Get-CosmosDbUserDefinedFunction.ps1
@@ -5,7 +5,7 @@ function Get-CosmosDbUserDefinedFunction
     [OutputType([Object])]
     param
     (
-        [Alias("Connection")]
+        [Alias('Connection')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
         [CosmosDb.Context]

--- a/source/Public/userdefinedfunctions/New-CosmosDbUserDefinedFunction.ps1
+++ b/source/Public/userdefinedfunctions/New-CosmosDbUserDefinedFunction.ps1
@@ -5,7 +5,7 @@ function New-CosmosDbUserDefinedFunction
     [OutputType([Object])]
     param
     (
-        [Alias("Connection")]
+        [Alias('Connection')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
         [CosmosDb.Context]

--- a/source/Public/userdefinedfunctions/Remove-CosmosDbUserDefinedFunction.ps1
+++ b/source/Public/userdefinedfunctions/Remove-CosmosDbUserDefinedFunction.ps1
@@ -4,7 +4,7 @@ function Remove-CosmosDbUserDefinedFunction
     [CmdletBinding(DefaultParameterSetName = 'Context')]
     param
     (
-        [Alias("Connection")]
+        [Alias('Connection')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
         [CosmosDb.Context]

--- a/source/Public/userdefinedfunctions/Set-CosmosDbUserDefinedFunction.ps1
+++ b/source/Public/userdefinedfunctions/Set-CosmosDbUserDefinedFunction.ps1
@@ -5,7 +5,7 @@ function Set-CosmosDbUserDefinedFunction
     [OutputType([Object])]
     param
     (
-        [Alias("Connection")]
+        [Alias('Connection')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
         [CosmosDb.Context]

--- a/source/Public/users/Get-CosmosDbUser.ps1
+++ b/source/Public/users/Get-CosmosDbUser.ps1
@@ -4,7 +4,7 @@ function Get-CosmosDbUser
     [OutputType([Object])]
     param
     (
-        [Alias("Connection")]
+        [Alias('Connection')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
         [CosmosDb.Context]

--- a/source/Public/users/New-CosmosDbUser.ps1
+++ b/source/Public/users/New-CosmosDbUser.ps1
@@ -5,7 +5,7 @@ function New-CosmosDbUser
     [OutputType([Object])]
     param
     (
-        [Alias("Connection")]
+        [Alias('Connection')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
         [CosmosDb.Context]

--- a/source/Public/users/Remove-CosmosDbUser.ps1
+++ b/source/Public/users/Remove-CosmosDbUser.ps1
@@ -4,7 +4,7 @@ function Remove-CosmosDbUser
     [CmdletBinding(DefaultParameterSetName = 'Context')]
     param
     (
-        [Alias("Connection")]
+        [Alias('Connection')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
         [CosmosDb.Context]

--- a/source/Public/users/Set-CosmosDbUser.ps1
+++ b/source/Public/users/Set-CosmosDbUser.ps1
@@ -5,7 +5,7 @@ function Set-CosmosDbUser
     [OutputType([Object])]
     param
     (
-        [Alias("Connection")]
+        [Alias('Connection')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
         [ValidateNotNullOrEmpty()]
         [CosmosDb.Context]


### PR DESCRIPTION
- Pinned build to Pester v4.10.1 - Fixes [Issue #371](https://github.com/PlagueHO/CosmosDB/issues/378).
- Added `Name` as an alias for `Id` parameters in
  `*-CosmosDbCollection` functions - Fixes [Issue #375](https://github.com/PlagueHO/CosmosDB/issues/375).
- Added `Name` as an alias for `Id` parameters in
  `*-CosmosDbDatabase` functions - Fixes [Issue #374](https://github.com/PlagueHO/CosmosDB/issues/374).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plagueho/cosmosdb/380)
<!-- Reviewable:end -->
