### PR TITLE
Added Get-CosmosDbDocumentJson function - Fixes #370

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `Get-CosmosDbDocumentJson` function - Fixes [Issue #370](https://github.com/PlagueHO/CosmosDB/issues/370).
+
 ### Changed
 
 - Changed build jobs `Unit_Test_PSCore6_Ubuntu1604` and
@@ -17,6 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `*-CosmosDbCollection` functions - Fixes [Issue #375](https://github.com/PlagueHO/CosmosDB/issues/375).
 - Added `Name` as an alias for `Id` parameters in
   `*-CosmosDbDatabase` functions - Fixes [Issue #374](https://github.com/PlagueHO/CosmosDB/issues/374).
+- Refactored `Get-CosmosDbDocument` to be a wrapper for
+  new function `Get-CosmosDbDocumentJson`.
+
+### Fixed
+
+- Fixed `Get-CosmosDbDocument` function partition key formatting
+  when an `Id` parameter is passed.
 
 ## [4.1.0] - 2020-05-15
 

--- a/Resolve-Dependency.ps1
+++ b/Resolve-Dependency.ps1
@@ -3,11 +3,11 @@ param
 (
 
     [Parameter()]
-    [String]
+    [System.String]
     $DependencyFile = 'RequiredModules.psd1',
 
     [Parameter()]
-    [String]
+    [System.String]
     # Path for PSDepend to be bootstrapped and save other dependencies.
     # Can also be CurrentUser or AllUsers if you wish to install the modules in such scope
     # Default to $PWD.Path/output/modules
@@ -24,12 +24,12 @@ param
 
     [Parameter()]
     [ValidateSet('CurrentUser', 'AllUsers')]
-    [String]
+    [System.String]
     # Scope to bootstrap the PackageProvider and PSGet if not available
     $Scope = 'CurrentUser',
 
     [Parameter()]
-    [String]
+    [System.String]
     # Gallery to use when bootstrapping PackageProvider, PSGet and when calling PSDepend (can be overridden in Dependency files)
     $Gallery = 'PSGallery',
 
@@ -45,7 +45,7 @@ param
     $AllowOldPowerShellGetModule,
 
     [Parameter()]
-    [String]
+    [System.String]
     # Allow you to specify a minimum version fo PSDepend, if you're after specific features.
     $MinimumPSDependVersion,
 
@@ -77,7 +77,7 @@ try
             try
             {
                 $variableValue = $ResolveDependencyDefaults[$ParamName]
-                if ($variableValue -is [string])
+                if ($variableValue -is [System.String])
                 {
                     $variableValue = $ExecutionContext.InvokeCommand.ExpandString($variableValue)
                 }

--- a/STYLEGUIDELINES.md
+++ b/STYLEGUIDELINES.md
@@ -1136,12 +1136,12 @@ function New-Event
     (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [String]
+        [System.String]
         $Message,
 
         [Parameter()]
         [ValidateSet('operational', 'debug', 'analytic')]
-        [String]
+        [System.String]
         $Channel = 'operational'
     )
     # Implementation...
@@ -1170,12 +1170,12 @@ function New-Event
     (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [String]
+        [System.String]
         $Message,
 
         [Parameter()]
         [ValidateSet('operational', 'debug', 'analytic')]
-        [String]
+        [System.String]
         $Channel = 'operational'
     )
     # Implementation
@@ -1192,7 +1192,7 @@ Functions with no parameters should still display an empty parameter block.
 **Bad:**
 
 ```powershell
-function Write-Text([Parameter(Mandatory = $true)][ValidateNotNullOrEmpty()][String]$Text)
+function Write-Text([Parameter(Mandatory = $true)][ValidateNotNullOrEmpty()][System.String]$Text)
 {
     Write-Verbose -Message $Text
 }
@@ -1216,7 +1216,7 @@ function Write-Text
     (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [String]
+        [System.String]
         $Text
     )
 
@@ -1272,7 +1272,7 @@ function Write-Text
 {
     param([Parameter(Mandatory = $true)]
 [ValidateNotNullOrEmpty()]
-                    [String] $Text )
+                    [System.String] $Text )
 
     Write-Verbose -Message $Text
 }
@@ -1287,12 +1287,12 @@ function Write-Text
     (
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
-        [String]
+        [System.String]
         $Text
 
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
-        [String]
+        [System.String]
         $PrefixText
 
         [Boolean]
@@ -1330,7 +1330,7 @@ function Write-Text
     (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [String]
+        [System.String]
         $Text
     )
 
@@ -1347,12 +1347,12 @@ function Write-Text
     (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [String]
+        [System.String]
         $Text
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
-        [String]
+        [System.String]
         $PrefixText
 
         [Parameter()]
@@ -1428,10 +1428,10 @@ function New-Event
     (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [String]
+        [System.String]
         $Message,
         [ValidateSet('operational', 'debug', 'analytic')]
-        [String]
+        [System.String]
         $Channel = 'operational'
     )
 }
@@ -1446,12 +1446,12 @@ function New-Event
     (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [String]
+        [System.String]
         $Message,
 
         [Parameter()]
         [ValidateSet('operational', 'debug', 'analytic')]
-        [String]
+        [System.String]
         $Channel = 'operational'
     )
 }
@@ -1471,7 +1471,7 @@ function Get-TargetResource
     [CmdletBinding()]
     param
     (
-        [String] $SourcePath = 'c:\'
+        [System.String] $SourcePath = 'c:\'
     )
 }
 ```
@@ -1485,7 +1485,7 @@ function Get-TargetResource
     param
     (
         [Parameter()]
-        [String]
+        [System.String]
         $SourcePath = 'c:\'
     )
 }
@@ -1516,12 +1516,12 @@ function New-Event
     (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [String]
+        [System.String]
         $Message,
 
         [Parameter()]
         [ValidateSet('operational', 'debug', 'analytic')]
-        [String]
+        [System.String]
         $Channel = 'operational'
     )
 }
@@ -1540,10 +1540,10 @@ function New-Event
 {
     param
     (
-        [Parameter(Mandatory = $true)][ValidateNotNullOrEmpty()][String]
+        [Parameter(Mandatory = $true)][ValidateNotNullOrEmpty()][System.String]
         $Message,
 
-        [ValidateSet('operational', 'debug', 'analytic')][String]
+        [ValidateSet('operational', 'debug', 'analytic')][System.String]
         $Channel = 'operational'
     )
 }
@@ -1558,12 +1558,12 @@ function New-Event
     (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [String]
+        [System.String]
         $Message,
 
         [Parameter()]
         [ValidateSet('operational', 'debug', 'analytic')]
-        [String]
+        [System.String]
         $Channel = 'operational'
     )
 }
@@ -1762,10 +1762,10 @@ function Get-Settings
 {
     param
     (
-        [String]
+        [System.String]
         $Username
 
-        [String]
+        [System.String]
         $Password
     )
     ...
@@ -1819,7 +1819,7 @@ Extra type declarations can clutter the code.
 **Bad:**
 
 ```powershell
-[String] $myString = 'My String'
+[System.String] $myString = 'My String'
 ```
 
 **Bad:**
@@ -1971,7 +1971,7 @@ function Get-Something
     param
     (
         [Parameter(Mandatory = $true)]
-        [String]
+        [System.String]
         $Name = 'My Name'
     )
 
@@ -1987,7 +1987,7 @@ function Get-Something
     param
     (
         [Parameter(Mandatory = $true)]
-        [String]
+        [System.String]
         $Name
     )
 

--- a/build.ps1
+++ b/build.ps1
@@ -11,7 +11,7 @@ param
     [string[]]$Tasks = '.',
 
     [Parameter()]
-    [String]
+    [System.String]
     $CodeCoverageThreshold = '',
 
     [Parameter()]

--- a/docs/CosmosDB.md
+++ b/docs/CosmosDB.md
@@ -47,6 +47,10 @@ Return the collections in a Cosmos DB database.
 
 Return the resource path for a collection object.
 
+### [Get-CosmosDbContinuationToken](Get-CosmosDbContinuationToken.md)
+
+Return the continuation token from a response header object.
+
 ### [Get-CosmosDbDatabase](Get-CosmosDbDatabase.md)
 
 Return the databases in a Cosmos DB account.
@@ -57,7 +61,11 @@ Return the resource path for a database object.
 
 ### [Get-CosmosDbDocument](Get-CosmosDbDocument.md)
 
-Return the documents for a Cosmos DB database collection.
+Return documents from a Cosmos DB database collection.
+
+### [Get-CosmosDbDocumentJson](Get-CosmosDbDocumentJson.md)
+
+Return documents from a Cosmos DB database collection as a JSON string.
 
 ### [Get-CosmosDbDocumentResourcePath](Get-CosmosDbDocumentResourcePath.md)
 

--- a/docs/Get-CosmosDbDocumentJson.md
+++ b/docs/Get-CosmosDbDocumentJson.md
@@ -5,18 +5,18 @@ online version:
 schema: 2.0.0
 ---
 
-# Get-CosmosDbDocument
+# Get-CosmosDbDocumentJson
 
 ## SYNOPSIS
 
-Return documents from a Cosmos DB database collection.
+Return documents from a Cosmos DB database collection as a JSON string.
 
 ## SYNTAX
 
 ### Context (Default)
 
 ```powershell
-Get-CosmosDbDocument -Context <Context> [-Key <SecureString>] [-KeyType <String>]
+Get-CosmosDbDocumentJson -Context <Context> [-Key <SecureString>] [-KeyType <String>]
  [-Database <String>] -CollectionId <String> [-Id <String>]
  [-PartitionKey <Object[]>] [-MaxItemCount <Int32>] [-ContinuationToken <String>]
  [-ConsistencyLevel <String>] [-SessionToken <String>]
@@ -27,7 +27,7 @@ Get-CosmosDbDocument -Context <Context> [-Key <SecureString>] [-KeyType <String>
 ### Account
 
 ```powershell
-Get-CosmosDbDocument -Account <String> [-Key <SecureString>] [-KeyType <String>]
+Get-CosmosDbDocumentJson -Account <String> [-Key <SecureString>] [-KeyType <String>]
  [-Database <String>] -CollectionId <String> [-Id <String>]
  [-PartitionKey <Object[]>] [-MaxItemCount <Int32>] [-ContinuationToken <String>]
  [-ConsistencyLevel <String>] [-SessionToken <String>]
@@ -50,7 +50,7 @@ token will need to be used.
 ### Example 1
 
 ```powershell
-PS C:\> Get-CosmosDbDocument -Context $cosmosDbContext -CollectionId 'MyNewCollection' -Id 'ac12345'
+PS C:\> Get-CosmosDbDocumentJson -Context $cosmosDbContext -CollectionId 'MyNewCollection' -Id 'ac12345'
 ```
 
 Return a document with a Id 'ac12345' from a collection in the database.
@@ -59,7 +59,7 @@ Return a document with a Id 'ac12345' from a collection in the database.
 
 ```powershell
 PS C:\> $ResponseHeader = $null
-PS C:\> $documents = Get-CosmosDbDocument -Context $cosmosDbContext -CollectionId 'MyNewCollection' -MaxItemCount 5 -ResponseHeader ([ref] $ResponseHeader)
+PS C:\> $documents = Get-CosmosDbDocumentJson -Context $cosmosDbContext -CollectionId 'MyNewCollection' -MaxItemCount 5 -ResponseHeader ([ref] $ResponseHeader)
 PS C:\> $continuationToken = Get-CosmosDbContinuationToken -ResponseHeader $ResponseHeader
 ```
 
@@ -69,7 +69,7 @@ storing a continuation token.
 ### Example 3
 
 ```powershell
-PS C:\> $documents = Get-CosmosDbDocument -Context $cosmosDbContext -CollectionId 'MyNewCollection' -MaxItemCount 5 -ContinuationToken $continuationToken
+PS C:\> $documents = Get-CosmosDbDocumentJson -Context $cosmosDbContext -CollectionId 'MyNewCollection' -MaxItemCount 5 -ContinuationToken $continuationToken
 ```
 
 Get the next 5 documents from a collection in the database using the
@@ -79,7 +79,7 @@ continuation token found in the headers from the previous example.
 
 ```powershell
 PS C:\> $query = "SELECT * FROM customers c WHERE (c.id = 'user@contoso.com')"
-PS C:\> Get-CosmosDbDocument -Context $cosmosDbContext -CollectionId 'MyNewCollection' -Query $query
+PS C:\> Get-CosmosDbDocumentJson -Context $cosmosDbContext -CollectionId 'MyNewCollection' -Query $query
 ```
 
 Query the documents in a collection.
@@ -91,7 +91,7 @@ PS C:\> $query = "SELECT * FROM customers c WHERE (c.id = @id)"
 PS C:\> $queryParameters = @(
     @{ name = "@id"; value="user@contoso.com"; }
 )
-PS C:\> Get-CosmosDbDocument -Context $cosmosDbContext -CollectionId 'MyNewCollection' -Query $query -QueryParameters $queryParameters
+PS C:\> Get-CosmosDbDocumentJson -Context $cosmosDbContext -CollectionId 'MyNewCollection' -Query $query -QueryParameters $queryParameters
 ```
 
 Query the documents in a collection using a parameterized query.

--- a/source/Private/utils/Invoke-CosmosDbRequest.ps1
+++ b/source/Private/utils/Invoke-CosmosDbRequest.ps1
@@ -83,7 +83,7 @@ function Invoke-CosmosDbRequest
         'dbs'
         {
             # Request for a database object (not containined in a database)
-            if ([String]::IsNullOrEmpty($ResourcePath))
+            if ([System.String]::IsNullOrEmpty($ResourcePath))
             {
                 $ResourceLink = 'dbs'
             }
@@ -97,7 +97,7 @@ function Invoke-CosmosDbRequest
         'offers'
         {
             # Request for an offer object (not contained in a database)
-            if ([String]::IsNullOrEmpty($ResourcePath))
+            if ([System.String]::IsNullOrEmpty($ResourcePath))
             {
                 $ResourceLink = 'offers'
             }
@@ -301,6 +301,7 @@ function Invoke-CosmosDbRequest
 
     # Display the Request Charge as a verbose message
     $requestCharge = [Uri]::UnescapeDataString($requestResult.Headers.'x-ms-request-charge').Trim()
+
     if ($requestCharge)
     {
         Write-Verbose -Message $($LocalizedData.RequestChargeResults -f $method, $uri, $requestCharge)

--- a/source/Public/attachments/Get-CosmosDbAttachment.ps1
+++ b/source/Public/attachments/Get-CosmosDbAttachment.ps1
@@ -67,7 +67,7 @@ function Get-CosmosDbAttachment
 
     $resourcePath = ('colls/{0}/docs/{1}/attachments' -f $CollectionId, $DocumentId)
 
-    if (-not [String]::IsNullOrEmpty($Id))
+    if (-not [System.String]::IsNullOrEmpty($Id))
     {
         $null = $PSBoundParameters.Remove('Id')
 

--- a/source/Public/collections/Get-CosmosDbCollection.ps1
+++ b/source/Public/collections/Get-CosmosDbCollection.ps1
@@ -78,7 +78,7 @@ function Get-CosmosDbCollection
             'x-ms-max-item-count' = $MaxItemCount
         }
 
-        if (-not [String]::IsNullOrEmpty($ContinuationToken))
+        if (-not [System.String]::IsNullOrEmpty($ContinuationToken))
         {
             $headers += @{
                 'x-ms-continuation' = $ContinuationToken

--- a/source/Public/documents/Get-CosmosDbDocument.ps1
+++ b/source/Public/documents/Get-CosmosDbDocument.ps1
@@ -92,146 +92,18 @@ function Get-CosmosDbDocument
         $ResponseHeader
     )
 
-    $null = $PSBoundParameters.Remove('Id')
-    $null = $PSBoundParameters.Remove('CollectionId')
-    $null = $PSBoundParameters.Remove('MaxItemCount')
-    $null = $PSBoundParameters.Remove('ContinuationToken')
-    $null = $PSBoundParameters.Remove('ConsistencyLevel')
-    $null = $PSBoundParameters.Remove('SessionToken')
-    $null = $PSBoundParameters.Remove('PartitionKeyRangeId')
-    $null = $PSBoundParameters.Remove('Query')
-    $null = $PSBoundParameters.Remove('QueryParameters')
-    $null = $PSBoundParameters.Remove('QueryEnableCrossPartition')
+    $documentJson = Get-CosmosDbDocumentJson @PSBoundParameters
 
-    if ($PSBoundParameters.ContainsKey('ResponseHeader'))
+    Write-Verbose -Message ($documentJson | Out-String) -Verbose
+    $documents = ConvertFrom-Json -InputObject $documentJson
+
+    if ([System.String]::IsNullOrEmpty($Id))
     {
-        $ResponseHeaderPassed = $true
-        $null = $PSBoundParameters.Remove('ResponseHeader')
+        $documents = $documents.Documents
     }
 
-    $resourcePath = ('colls/{0}/docs' -f $CollectionId)
-    $method = 'Get'
-    $headers = @{}
-
-    if (-not [String]::IsNullOrEmpty($Id))
+    if ($documents)
     {
-        # A document Id has been specified
-        if ($PSBoundParameters.ContainsKey('PartitionKey'))
-        {
-            $headers += @{
-                'x-ms-documentdb-partitionkey' = '["' + ($PartitionKey -join '","') + '"]'
-            }
-            $null = $PSBoundParameters.Remove('PartitionKey')
-        }
-
-        $result = Invoke-CosmosDbRequest @PSBoundParameters `
-            -Method $method `
-            -Headers $headers `
-            -ResourceType 'docs' `
-            -ResourcePath ('{0}/{1}' -f $resourcePath, $Id)
-
-        $content = Repair-CosmosDbDocumentEncoding -Content $result.Content
-        $document = ConvertFrom-JSON -InputObject $content
-    }
-    else
-    {
-        $body = ''
-
-        if (-not [String]::IsNullOrEmpty($Query))
-        {
-            # A query has been specified
-            $method = 'Post'
-
-            $headers += @{
-                'x-ms-documentdb-isquery' = $True
-            }
-
-            if ($QueryEnableCrossPartition -eq $True)
-            {
-                $headers += @{
-                    'x-ms-documentdb-query-enablecrosspartition' = $True
-                }
-            }
-
-            # Set the content type to application/query+json for querying
-            $null = $PSBoundParameters.Add('ContentType', 'application/query+json')
-
-            # Create the body JSON for the query
-            $bodyObject = @{ query = $Query }
-            if (-not [String]::IsNullOrEmpty($QueryParameters))
-            {
-                $bodyObject += @{ parameters = $QueryParameters }
-            }
-            $body = ConvertTo-Json -InputObject $bodyObject
-        }
-        else
-        {
-            if (-not [String]::IsNullOrEmpty($PartitionKeyRangeId))
-            {
-                $headers += @{
-                    'x-ms-documentdb-partitionkeyrangeid' = $PartitionKeyRangeId
-                }
-            }
-        }
-
-        # The following headers apply when querying documents or just getting a list
-        if ($PSBoundParameters.ContainsKey('PartitionKey'))
-        {
-            $headers += @{
-                'x-ms-documentdb-partitionkey' = Format-CosmosDbDocumentPartitionKey -PartitionKey $PartitionKey
-            }
-            $null = $PSBoundParameters.Remove('PartitionKey')
-        }
-
-        $headers += @{
-            'x-ms-max-item-count' = $MaxItemCount
-        }
-
-        if (-not [String]::IsNullOrEmpty($ContinuationToken))
-        {
-            $headers += @{
-                'x-ms-continuation' = $ContinuationToken
-            }
-        }
-
-        if (-not [String]::IsNullOrEmpty($ConsistencyLevel))
-        {
-            $headers += @{
-                'x-ms-consistency-level' = $ConsistencyLevel
-            }
-        }
-
-        if (-not [String]::IsNullOrEmpty($SessionToken))
-        {
-            $headers += @{
-                'x-ms-session-token' = $SessionToken
-            }
-        }
-
-        <#
-            Because the headers of this request will contain important information
-            then we need to use a plain web request.
-        #>
-        $result = Invoke-CosmosDbRequest @PSBoundParameters `
-            -Method $method `
-            -ResourceType 'docs' `
-            -ResourcePath $resourcePath `
-            -Headers $headers `
-            -Body $body
-
-        $content = Repair-CosmosDbDocumentEncoding -Content $result.Content
-        $body = ConvertFrom-JSON -InputObject $content
-        $document = $body.Documents
-
-        if ($ResponseHeaderPassed)
-        {
-            # Return the result headers
-            $ResponseHeader.value = $result.Headers
-        }
-    }
-
-    if ($document)
-    {
-        return (Set-CosmosDbDocumentType -Document $document)
+        return (Set-CosmosDbDocumentType -Document $documents)
     }
 }

--- a/source/Public/documents/Get-CosmosDbDocumentJson.ps1
+++ b/source/Public/documents/Get-CosmosDbDocumentJson.ps1
@@ -1,0 +1,233 @@
+function Get-CosmosDbDocumentJson
+{
+
+    [CmdletBinding(DefaultParameterSetName = 'Context')]
+    [OutputType([Object])]
+    param
+    (
+        [Alias('Connection')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Context')]
+        [ValidateNotNullOrEmpty()]
+        [CosmosDb.Context]
+        $Context,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'Account')]
+        [ValidateScript({ Assert-CosmosDbAccountNameValid -Name $_ -ArgumentName 'Account' })]
+        [System.String]
+        $Account,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.Security.SecureString]
+        $Key,
+
+        [Parameter()]
+        [ValidateSet('master', 'resource')]
+        [System.String]
+        $KeyType = 'master',
+
+        [Parameter()]
+        [ValidateScript({ Assert-CosmosDbDatabaseIdValid -Id $_ -ArgumentName 'Database' })]
+        [System.String]
+        $Database,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateScript({ Assert-CosmosDbCollectionIdValid -Id $_ -ArgumentName 'CollectionId' })]
+        [System.String]
+        $CollectionId,
+
+        [Parameter()]
+        [ValidateScript({ Assert-CosmosDbDocumentIdValid -Id $_ })]
+        [System.String]
+        $Id,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.Object[]]
+        $PartitionKey,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.Int32]
+        $MaxItemCount = -1,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $ContinuationToken,
+
+        [Parameter()]
+        [ValidateSet('Strong', 'Bounded', 'Session', 'Eventual')]
+        [System.String]
+        $ConsistencyLevel,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $SessionToken,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $PartitionKeyRangeId,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $Query,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [Hashtable[]]
+        $QueryParameters,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.Boolean]
+        $QueryEnableCrossPartition = $False,
+
+        [Alias("ResultHeaders")]
+        [Parameter()]
+        [ref]
+        $ResponseHeader
+    )
+
+    $null = $PSBoundParameters.Remove('Id')
+    $null = $PSBoundParameters.Remove('CollectionId')
+    $null = $PSBoundParameters.Remove('MaxItemCount')
+    $null = $PSBoundParameters.Remove('ContinuationToken')
+    $null = $PSBoundParameters.Remove('ConsistencyLevel')
+    $null = $PSBoundParameters.Remove('SessionToken')
+    $null = $PSBoundParameters.Remove('PartitionKeyRangeId')
+    $null = $PSBoundParameters.Remove('Query')
+    $null = $PSBoundParameters.Remove('QueryParameters')
+    $null = $PSBoundParameters.Remove('QueryEnableCrossPartition')
+
+    if ($PSBoundParameters.ContainsKey('ResponseHeader'))
+    {
+        $ResponseHeaderPassed = $true
+        $null = $PSBoundParameters.Remove('ResponseHeader')
+    }
+
+    $resourcePath = ('colls/{0}/docs' -f $CollectionId)
+    $method = 'Get'
+    $headers = @{}
+
+    if ([System.String]::IsNullOrEmpty($Id))
+    {
+        $body = ''
+
+        if (-not [System.String]::IsNullOrEmpty($Query))
+        {
+            # A query has been specified
+            $method = 'Post'
+
+            $headers += @{
+                'x-ms-documentdb-isquery' = $True
+            }
+
+            if ($QueryEnableCrossPartition -eq $True)
+            {
+                $headers += @{
+                    'x-ms-documentdb-query-enablecrosspartition' = $True
+                }
+            }
+
+            # Set the content type to application/query+json for querying
+            $null = $PSBoundParameters.Add('ContentType', 'application/query+json')
+
+            # Create the body JSON for the query
+            $bodyObject = @{
+                query = $Query
+            }
+
+            if (-not [System.String]::IsNullOrEmpty($QueryParameters))
+            {
+                $bodyObject += @{ parameters = $QueryParameters }
+            }
+
+            $body = ConvertTo-Json -InputObject $bodyObject
+        }
+        else
+        {
+            if (-not [System.String]::IsNullOrEmpty($PartitionKeyRangeId))
+            {
+                $headers += @{
+                    'x-ms-documentdb-partitionkeyrangeid' = $PartitionKeyRangeId
+                }
+            }
+        }
+
+        # The following headers apply when querying documents or just getting a list
+        if ($PSBoundParameters.ContainsKey('PartitionKey'))
+        {
+            $headers += @{
+                'x-ms-documentdb-partitionkey' = Format-CosmosDbDocumentPartitionKey -PartitionKey $PartitionKey
+            }
+            $null = $PSBoundParameters.Remove('PartitionKey')
+        }
+
+        $headers += @{
+            'x-ms-max-item-count' = $MaxItemCount
+        }
+
+        if (-not [System.String]::IsNullOrEmpty($ContinuationToken))
+        {
+            $headers += @{
+                'x-ms-continuation' = $ContinuationToken
+            }
+        }
+
+        if (-not [System.String]::IsNullOrEmpty($ConsistencyLevel))
+        {
+            $headers += @{
+                'x-ms-consistency-level' = $ConsistencyLevel
+            }
+        }
+
+        if (-not [System.String]::IsNullOrEmpty($SessionToken))
+        {
+            $headers += @{
+                'x-ms-session-token' = $SessionToken
+            }
+        }
+
+        <#
+            Because the headers of this request will contain important information
+            then we need to use a plain web request.
+        #>
+        $result = Invoke-CosmosDbRequest @PSBoundParameters `
+            -Method $method `
+            -ResourceType 'docs' `
+            -ResourcePath $resourcePath `
+            -Headers $headers `
+            -Body $body
+
+        if ($ResponseHeaderPassed)
+        {
+            # Return the result headers
+            $ResponseHeader.value = $result.Headers
+        }
+    }
+    else
+    {
+        # A document Id has been specified
+        if ($PSBoundParameters.ContainsKey('PartitionKey'))
+        {
+            $headers += @{
+                'x-ms-documentdb-partitionkey' = Format-CosmosDbDocumentPartitionKey -PartitionKey $PartitionKey
+            }
+            $null = $PSBoundParameters.Remove('PartitionKey')
+        }
+
+        $result = Invoke-CosmosDbRequest @PSBoundParameters `
+            -Method $method `
+            -Headers $headers `
+            -ResourceType 'docs' `
+            -ResourcePath ('{0}/{1}' -f $resourcePath, $Id)
+    }
+
+    $documents = Repair-CosmosDbDocumentEncoding -Content $result.Content
+
+    return $documents
+}

--- a/source/Public/offers/Get-CosmosDbOffer.ps1
+++ b/source/Public/offers/Get-CosmosDbOffer.ps1
@@ -50,7 +50,7 @@ function Get-CosmosDbOffer
     }
     else
     {
-        if (-not [String]::IsNullOrEmpty($Query))
+        if (-not [System.String]::IsNullOrEmpty($Query))
         {
             $null = $PSBoundParameters.Remove('Query')
 

--- a/tests/TestHelper/TestHelper.psm1
+++ b/tests/TestHelper/TestHelper.psm1
@@ -278,12 +278,12 @@ function Get-InvalidArgumentRecord
     (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [String]
+        [System.String]
         $Message,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [String]
+        [System.String]
         $ArgumentName
     )
 
@@ -312,7 +312,7 @@ function Get-InvalidOperationRecord
     param
     (
         [ValidateNotNullOrEmpty()]
-        [String]
+        [System.String]
         $Message,
 
         [ValidateNotNull()]


### PR DESCRIPTION
### Added

- Added `Get-CosmosDbDocumentJson` function - Fixes [Issue #370](https://github.com/PlagueHO/CosmosDB/issues/370).

### Changed

- Refactored `Get-CosmosDbDocument` to be a wrapper for
  new function `Get-CosmosDbDocumentJson`.

### Fixed

- Fixed `Get-CosmosDbDocument` function partition key formatting
  when an `Id` parameter is passed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plagueho/cosmosdb/383)
<!-- Reviewable:end -->
