### PR TITLE
Improve URI Parameter Handling in New-CosmosDbContext Function - Fixes #381

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `*-CosmosDbDatabase` functions - Fixes [Issue #374](https://github.com/PlagueHO/CosmosDB/issues/374).
 - Refactored `Get-CosmosDbDocument` to be a wrapper for
   new function `Get-CosmosDbDocumentJson`.
+- Added support for specifying a protocol and port in the `URI` parameter
+  of the `New-CosmosDbContext` function - Fixes [Issue #381](https://github.com/PlagueHO/CosmosDB/issues/381).
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -191,11 +191,11 @@ $cosmosDbContext = New-CosmosDbContext -Emulator -Database 'MyDatabase'
 ```
 
 You can also provide a custom URI if the emulator is hosted on another
-machine as well as specifying an alternate Key to use:
+machine or an alternate port as well as specifying an alternate Key to use:
 
 ```powershell
 $primaryKey = ConvertTo-SecureString -String 'GFJqJesi2Rq910E0G7P4WoZkzowzbj23Sm9DUWFX0l0P8o16mYyuaZBN00Nbtj9F1QQnumzZKSGZwknXGERrlA==' -AsPlainText -Force
-$cosmosDbContext = New-CosmosDbContext -Emulator -Database 'MyDatabase' -URI 'myemulator.local' -Key $primaryKey
+$cosmosDbContext = New-CosmosDbContext -Emulator -Database 'MyDatabase' -Uri 'https://cosmosdbemulator.contoso.com:9081' -Key $primaryKey
 ```
 
 #### Create a Context from Resource Authorization Tokens

--- a/docs/New-CosmosDbContext.md
+++ b/docs/New-CosmosDbContext.md
@@ -41,7 +41,7 @@ New-CosmosDbContext -Account <String> [-Database <String>] -Token <ContextToken[
 
 ```powershell
 New-CosmosDbContext [-Database <String>] [-Key <SecureString>] [-Emulator]
- [-Port <Int16>] [-URI <String>] [-Token <ContextToken[]>]
+ [-Port <Int16>] [-Uri <String>] [-Token <ContextToken[]>]
  [-BackoffPolicy <BackoffPolicy>] [<CommonParameters>]
 ```
 
@@ -103,13 +103,23 @@ with a delay of 2 seconds between them.
 
 ```powershell
 PS C:\> $primaryKey = ConvertTo-SecureString -String 'your emulator master key' -AsPlainText -Force
-PS C:\> $cosmosDbContext = New-CosmosDbContext -Emulator -URI 'mycosmosdb' -Key $primaryKey
+PS C:\> $cosmosDbContext = New-CosmosDbContext -Emulator -Uri 'mycosmosdb' -Key $primaryKey
 ```
 
 Creates a Cosmos DB context by using a Cosmos DB Emulator installed onto
 the machine 'mycosmosdb' with a custom key emulator key.
 
 ### EXAMPLE 6
+
+```powershell
+PS C:\> $cosmosDbContext = New-CosmosDbContext -Emulator -Uri 'https://cosmosdbemulator.contoso.com:9091'
+```
+
+Creates a Cosmos DB context by using a Cosmos DB Emulator located at
+'cosmosdbemulator.contoso.com' on port 9091 using HTTPS with the default
+emulator key.
+
+### EXAMPLE 7
 
 ```powershell
 PS C:\> $primaryKey = ConvertTo-SecureString -String 'your master key' -AsPlainText -Force
@@ -281,7 +291,13 @@ Accept wildcard characters: False
 ### -Port
 
 This is the port the Cosmos DB emulator is installed onto.
-If not specified it will use the default port of 8081.
+If the Uri is not specified or does not include a port, then
+the value specified by the Port parameter will be used.
+If the Port parameter is not specified and it is not specified
+in the Uri parameter, then 8081 will be used.
+This parameter will be deprecated at a later date as a breaking
+change. Therefore, it is recommended that the port is specified
+in the Uri parameter.
 
 ```yaml
 Type: Int16
@@ -290,7 +306,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: 8081
+Default value:
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -341,7 +357,7 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -URI
+### -Uri
 
 This is an optional URI to a Cosmos DB emulator.
 
@@ -352,7 +368,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: localhost
+Default value: https://localhost:8081
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/source/Public/utils/New-CosmosDbContext.ps1
+++ b/source/Public/utils/New-CosmosDbContext.ps1
@@ -48,11 +48,11 @@ function New-CosmosDbContext
 
         [Parameter(ParameterSetName = 'Emulator')]
         [System.Int16]
-        $Port = 8081,
+        $Port,
 
         [Parameter(ParameterSetName = 'Emulator')]
         [System.String]
-        $URI = 'localhost',
+        $Uri = 'https://localhost:8081',
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Token')]
         [Parameter(ParameterSetName = 'Emulator')]
@@ -87,7 +87,26 @@ function New-CosmosDbContext
                     -Force
             }
 
-            $BaseUri = [uri]::new(('https://{0}:{1}' -f $URI, $Port))
+            if ($Uri -notmatch '^https?:\/\/')
+            {
+                $Uri = 'https://{0}' -f $Uri
+            }
+
+            if ($Uri -notmatch ':\d*$')
+            {
+                if ($PSBoundParameters.ContainsKey('Port'))
+                {
+                    Write-Warning -Message $LocalizedData.DeprecateEmulatorPortWarning
+                }
+                else
+                {
+                    $Port = 8081
+                }
+
+                $Uri = '{0}:{1}' -f $Uri, $Port
+            }
+
+            $BaseUri = [uri]::new($Uri)
         }
 
         'AzureAccount'

--- a/source/en-US/CosmosDB.strings.psd1
+++ b/source/en-US/CosmosDB.strings.psd1
@@ -54,4 +54,5 @@ ConvertFrom-StringData -StringData @'
     UserIdInvalid = The User Id '{0}' is invalid. A User Id must not contain characters '\','/','#' or '?', end with a space or be longer than 255 characters.
     ErrorPartitionKeyUnsupportedType = The partition key '{0}' uses an unsupported type '{1}'. Partition keys must be be defined in one of the types: String, Int16, Int32 or Int64.
     ResponseHeaderContinuationTokenMissingOrEmpty = The Continuation Token ('x-ms-continuation' attribute) is missing or empty in the Response Header.
+    DeprecateEmulatorPortWarning = The Port parameter may be deprecated at a later date in favor of specifying it in the Uri parameter, e.g. https:\\cosmosdbemulator.local:9081. It is recommended to use that method instead of specifying the port parameter to reduce possible impact when the Port parameter is deprecated.
 '@

--- a/tests/Unit/CosmosDB.utils.Tests.ps1
+++ b/tests/Unit/CosmosDB.utils.Tests.ps1
@@ -26,8 +26,6 @@ InModuleScope $ProjectName {
     $script:testKey = 'GFJqJeri2Rq910E0G7PsWoZkzowzbj23Sm9DUWFC0l0P8o16mYyuaZKN00Nbtj9F1QQnumzZKSGZwknXGERrlA=='
     $script:testKeySecureString = ConvertTo-SecureString -String $script:testKey -AsPlainText -Force
     $script:testEmulatorKey = 'C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=='
-    $script:testURI = 'emulatoruri.local'
-    $script:testPort = '9999'
     $script:testBaseUri = 'documents.contoso.com'
     $script:testBaseUriAzureCloud = 'documents.azure.com'
     $script:testBaseUriAzureUsGov = 'documents.azure.us'
@@ -494,20 +492,20 @@ console.log("done");
                 $script:result.Database | Should -Be $script:testDatabase
                 $tempCredential = New-Object System.Net.NetworkCredential("TestUsername", $result.Key, "TestDomain")
                 $tempCredential.Password | Should -Be $script:testEmulatorKey
-                $script:result.KeyType | Should -Be 'master'
-                $script:result.BaseUri | Should -Be ('https://localhost:8081/')
+                $script:result.KeyType | Should -BeExactly 'master'
+                $script:result.BaseUri | Should -BeExactly 'https://localhost:8081/'
             }
         }
 
-        Context 'When called with Emulator switch and URI and Port specified' {
+        Context 'When called with Emulator switch and URI with no protocol and port and Port parameter passed' {
             $script:result = $null
 
             It 'Should not throw exception' {
                 $newCosmosDbContextParameters = @{
                     Database = $script:testDatabase
                     Emulator = $true
-                    Port     = $script:testPort
-                    URI      = $script:testURI
+                    Port     = '9999'
+                    URI      = 'mycosmosdb.contoso.local'
                     Verbose  = $true
                 }
 
@@ -520,7 +518,128 @@ console.log("done");
                 $tempCredential = New-Object System.Net.NetworkCredential("TestUsername", $result.Key, "TestDomain")
                 $tempCredential.Password | Should -Be $script:testEmulatorKey
                 $script:result.KeyType | Should -Be 'master'
-                $script:result.BaseUri | Should -Be ('https://{0}:{1}/' -f $script:testURI, $script:testPort)
+                $script:result.BaseUri | Should -Be 'https://mycosmosdb.contoso.local:9999/'
+            }
+        }
+
+        Context 'When called with Emulator switch and URI with no protocol and port and Port parameter not passed' {
+            $script:result = $null
+
+            It 'Should not throw exception' {
+                $newCosmosDbContextParameters = @{
+                    Database = $script:testDatabase
+                    Emulator = $true
+                    URI      = 'mycosmosdb.contoso.local'
+                    Verbose  = $true
+                }
+
+                { $script:result = New-CosmosDbContext @newCosmosDbContextParameters } | Should -Not -Throw
+            }
+
+            It 'Should return expected result' {
+                $script:result.Account | Should -Be 'emulator'
+                $script:result.Database | Should -Be $script:testDatabase
+                $tempCredential = New-Object System.Net.NetworkCredential("TestUsername", $result.Key, "TestDomain")
+                $tempCredential.Password | Should -Be $script:testEmulatorKey
+                $script:result.KeyType | Should -Be 'master'
+                $script:result.BaseUri | Should -Be 'https://mycosmosdb.contoso.local:8081/'
+            }
+        }
+
+        Context 'When called with Emulator switch and URI with protocol but no port and Port parameter not passed' {
+            $script:result = $null
+
+            It 'Should not throw exception' {
+                $newCosmosDbContextParameters = @{
+                    Database = $script:testDatabase
+                    Emulator = $true
+                    URI      = 'http://mycosmosdb.contoso.local'
+                    Verbose  = $true
+                }
+
+                { $script:result = New-CosmosDbContext @newCosmosDbContextParameters } | Should -Not -Throw
+            }
+
+            It 'Should return expected result' {
+                $script:result.Account | Should -Be 'emulator'
+                $script:result.Database | Should -Be $script:testDatabase
+                $tempCredential = New-Object System.Net.NetworkCredential("TestUsername", $result.Key, "TestDomain")
+                $tempCredential.Password | Should -Be $script:testEmulatorKey
+                $script:result.KeyType | Should -Be 'master'
+                $script:result.BaseUri | Should -Be 'http://mycosmosdb.contoso.local:8081/'
+            }
+        }
+
+        Context 'When called with Emulator switch and URI with no protocol with port and Port parameter not passed' {
+            $script:result = $null
+
+            It 'Should not throw exception' {
+                $newCosmosDbContextParameters = @{
+                    Database = $script:testDatabase
+                    Emulator = $true
+                    URI      = 'mycosmosdb.contoso.local:9999'
+                    Verbose  = $true
+                }
+
+                { $script:result = New-CosmosDbContext @newCosmosDbContextParameters } | Should -Not -Throw
+            }
+
+            It 'Should return expected result' {
+                $script:result.Account | Should -Be 'emulator'
+                $script:result.Database | Should -Be $script:testDatabase
+                $tempCredential = New-Object System.Net.NetworkCredential("TestUsername", $result.Key, "TestDomain")
+                $tempCredential.Password | Should -Be $script:testEmulatorKey
+                $script:result.KeyType | Should -Be 'master'
+                $script:result.BaseUri | Should -Be 'https://mycosmosdb.contoso.local:9999/'
+            }
+        }
+
+        Context 'When called with Emulator switch and URI with protocol and port and Port parameter not passed' {
+            $script:result = $null
+
+            It 'Should not throw exception' {
+                $newCosmosDbContextParameters = @{
+                    Database = $script:testDatabase
+                    Emulator = $true
+                    URI      = 'https://mycosmosdb.contoso.local:9999'
+                    Verbose  = $true
+                }
+
+                { $script:result = New-CosmosDbContext @newCosmosDbContextParameters } | Should -Not -Throw
+            }
+
+            It 'Should return expected result' {
+                $script:result.Account | Should -Be 'emulator'
+                $script:result.Database | Should -Be $script:testDatabase
+                $tempCredential = New-Object System.Net.NetworkCredential("TestUsername", $result.Key, "TestDomain")
+                $tempCredential.Password | Should -Be $script:testEmulatorKey
+                $script:result.KeyType | Should -Be 'master'
+                $script:result.BaseUri | Should -Be 'https://mycosmosdb.contoso.local:9999/'
+            }
+        }
+
+        Context 'When called with Emulator switch and URI with protocol and port and Port parameter passed' {
+            $script:result = $null
+
+            It 'Should not throw exception' {
+                $newCosmosDbContextParameters = @{
+                    Database = $script:testDatabase
+                    Emulator = $true
+                    Port     = '9999'
+                    URI      = 'https://mycosmosdb.contoso.local:8081'
+                    Verbose  = $true
+                }
+
+                { $script:result = New-CosmosDbContext @newCosmosDbContextParameters } | Should -Not -Throw
+            }
+
+            It 'Should return expected result' {
+                $script:result.Account | Should -Be 'emulator'
+                $script:result.Database | Should -Be $script:testDatabase
+                $tempCredential = New-Object System.Net.NetworkCredential("TestUsername", $result.Key, "TestDomain")
+                $tempCredential.Password | Should -Be $script:testEmulatorKey
+                $script:result.KeyType | Should -Be 'master'
+                $script:result.BaseUri | Should -Be 'https://mycosmosdb.contoso.local:8081/'
             }
         }
 
@@ -531,7 +650,7 @@ console.log("done");
                 $newCosmosDbContextParameters = @{
                     Database = $script:testDatabase
                     Emulator = $true
-                    URI      = $script:testURI
+                    URI      = 'localhost'
                     Key      = $script:testKeySecureString
                     Verbose  = $true
                 }
@@ -545,7 +664,7 @@ console.log("done");
                 $tempCredential = New-Object System.Net.NetworkCredential("TestUsername", $result.Key, "TestDomain")
                 $tempCredential.Password | Should -Be $script:testKey
                 $script:result.KeyType | Should -Be 'master'
-                $script:result.BaseUri | Should -Be ('https://{0}:8081/' -f $script:testURI)
+                $script:result.BaseUri | Should -Be 'https://localhost:8081/'
             }
         }
 


### PR DESCRIPTION
Added support for specifying a protocol and port in the `URI` parameter
  of the `New-CosmosDbContext` function - Fixes [Issue #381](https://github.com/PlagueHO/CosmosDB/issues/381).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plagueho/cosmosdb/385)
<!-- Reviewable:end -->
