### PR TITLE
Fixed localization bug - Fixes #373

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `Cannot bind argument to parameter 'Message' because it is null.` error
+  message occurring when displaying messages on systems not using `en-US`
+  UI culture - Fixes [Issue #373](https://github.com/PlagueHO/CosmosDB/issues/373).
+
 ## [4.2.0] - 2020-06-01
 
 ### Added

--- a/source/prefix.ps1
+++ b/source/prefix.ps1
@@ -22,7 +22,7 @@ if ([System.String]::IsNullOrEmpty($culture))
 }
 else
 {
-    if (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath $culture))
+    if (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath $culture)))
     {
         $culture = 'en-US'
     }


### PR DESCRIPTION
- Fixed `Cannot bind argument to parameter 'Message' because it is null.` error
  message occurring when displaying messages on systems not using `en-US`
  UI culture - Fixes [Issue #373](https://github.com/PlagueHO/CosmosDB/issues/373).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plagueho/cosmosdb/387)
<!-- Reviewable:end -->
