### PR TITLE
Adding condition to import module

### DIFF
--- a/source/prefix.ps1
+++ b/source/prefix.ps1
@@ -10,8 +10,13 @@ $script:moduleRoot = Split-Path `
     -Parent
 
 # Import dependent Az modules
-Import-Module -Name Az.Accounts -MinimumVersion 1.0.0 -Scope Global
-Import-Module -Name Az.Resources -MinimumVersion 1.0.0 -Scope Global
+if(!(Get-Module -Name Az.Accounts)) {
+    Import-Module -Name Az.Accounts -MinimumVersion 1.0.0 -Scope Global
+}
+
+if(!(Get-Module -Name Az.Resources)) {
+    Import-Module -Name Az.Resources -MinimumVersion 1.0.0 -Scope Global
+}
 
 #region LocalizedData
 $culture = $PSUICulture


### PR DESCRIPTION
# Pull Request

## Bug Fixes

## Improvements / Enhancements

Added support for pre-loading Az.Accounts and Az.Resources modules. This enables things like using Save-Module and storing the modules in folders, which can be useful when running the module as a part of an Azure Function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plagueho/cosmosdb/414)
<!-- Reviewable:end -->
