### PR TITLE
Update tests to deprecated Ubuntu 16.04 and PS 6.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated PSScriptAnalyzer tests to be skipped when PowerShell Core
   version is less than 7.0.3 - Fixes [Issue #431](https://github.com/PlagueHO/CosmosDB/issues/431).
 
+### Added
+
+- Added tests on PowerShell 7.x on Ubuntu 20.04 - Fixes [Issue #433](https://github.com/PlagueHO/CosmosDB/issues/433).
+- Added tests on Windows 5.1 on Windows Server 2022 - Fixes [Issue #436](https://github.com/PlagueHO/CosmosDB/issues/436).
+
+### Removed
+
+- Removed tests against PowerShell Core 6.x as PowerShell 7.x is recommended - Fixes
+  [Issue #434](https://github.com/PlagueHO/CosmosDB/issues/431).
+- Removed all tests on Ubuntu 16.04 - Fixes [Issue #433](https://github.com/PlagueHO/CosmosDB/issues/433).
+
 ## [4.5.0] - 2021-05-29
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1147,13 +1147,17 @@ on the following systems:
 - Windows Server (using Windows PowerShell 5.1):
   - Windows Server 2016: Using [Azure Pipelines](https://dev.azure.com/dscottraynsford/GitHub/_build?definitionId=4).
   - Windows Server 2019: Using [Azure Pipelines](https://dev.azure.com/dscottraynsford/GitHub/_build?definitionId=4).
-- Linux (using PowerShell Core 6.x):
-  - Ubuntu Trusty 16.04: Using [Azure Pipelines](https://dev.azure.com/dscottraynsford/GitHub/_build?definitionId=4).
+  - Windows Server 2022: Using [Azure Pipelines](https://dev.azure.com/dscottraynsford/GitHub/_build?definitionId=4).
 - Linux (using PowerShell 7.x):
-  - Ubuntu Trusty 16.04: Using [Azure Pipelines](https://dev.azure.com/dscottraynsford/GitHub/_build?definitionId=4).
+  - Ubuntu Trusty 20.04: Using [Azure Pipelines](https://dev.azure.com/dscottraynsford/GitHub/_build?definitionId=4).
   - Ubuntu Xenial 18.04: Using [Azure Pipelines](https://dev.azure.com/dscottraynsford/GitHub/_build?definitionId=4).
-- macOS (using PowerShell Core 6.x):
+- macOS (using PowerShell Core 6.x - to be changed to in future 7.x):
   - macOS 10.14: Using [Azure Pipelines](https://dev.azure.com/dscottraynsford/GitHub/_build?definitionId=4).
+
+> PowerShell Core 6.x is no longer tested on PowerShell Core 6.x as PowerShell 7.x
+> should be used. It should still work, but will no longer be verified. Issues with
+> this module that only exist on PowerShell Core 6.x but not PowerShell 7.x will
+> not be fixed.
 
 This module should function correctly on other systems and configurations
 but is not automatically tested with them in every change.

--- a/README.md
+++ b/README.md
@@ -1149,12 +1149,12 @@ on the following systems:
   - Windows Server 2019: Using [Azure Pipelines](https://dev.azure.com/dscottraynsford/GitHub/_build?definitionId=4).
   - Windows Server 2022: Using [Azure Pipelines](https://dev.azure.com/dscottraynsford/GitHub/_build?definitionId=4).
 - Linux (using PowerShell 7.x):
-  - Ubuntu Trusty 20.04: Using [Azure Pipelines](https://dev.azure.com/dscottraynsford/GitHub/_build?definitionId=4).
-  - Ubuntu Xenial 18.04: Using [Azure Pipelines](https://dev.azure.com/dscottraynsford/GitHub/_build?definitionId=4).
+  - Ubuntu 18.04: Using [Azure Pipelines](https://dev.azure.com/dscottraynsford/GitHub/_build?definitionId=4).
+  - Ubuntu 20.04: Using [Azure Pipelines](https://dev.azure.com/dscottraynsford/GitHub/_build?definitionId=4).
 - macOS (using PowerShell Core 6.x - to be changed to in future 7.x):
   - macOS 10.14: Using [Azure Pipelines](https://dev.azure.com/dscottraynsford/GitHub/_build?definitionId=4).
 
-> PowerShell Core 6.x is no longer tested on PowerShell Core 6.x as PowerShell 7.x
+> This module is no longer tested on PowerShell Core 6.x as PowerShell 7.x
 > should be used. It should still work, but will no longer be verified. Issues with
 > this module that only exist on PowerShell Core 6.x but not PowerShell 7.x will
 > not be fixed.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -213,104 +213,10 @@ stages:
               testRunTitle: 'Integration (PowerShell 5.1 on Windows Server 2019)'
             condition: succeededOrFailed()
 
-      - job: Unit_Test_PSCore6_Ubuntu1604
-        displayName: 'Unit Test (Powershell Core 6 on Ubuntu 16.04)'
+      - job: Unit_Test_PS_Win2022
+        displayName: 'Unit Test (Powershell 5.1 on Windows Server 2022)'
         pool:
-          vmImage: ubuntu-16.04
-
-        steps:
-          - powershell: |
-              $repositoryOwner,$repositoryName = $env:BUILD_REPOSITORY_NAME -split '/'
-              echo "##vso[task.setvariable variable=RepositoryOwner;isOutput=true]$repositoryOwner"
-              echo "##vso[task.setvariable variable=RepositoryName;isOutput=true]$repositoryName"
-            name: moduleBuildVariable
-            displayName: 'Set Environment Variables'
-
-          - task: DownloadBuildArtifacts@0
-            displayName: 'Download Build Artifact'
-            inputs:
-              buildType: 'current'
-              downloadType: 'single'
-              artifactName: 'output'
-              downloadPath: '$(Build.SourcesDirectory)'
-
-          - script: |
-              curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
-              curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list | sudo tee /etc/apt/sources.list.d/microsoft.list
-              sudo apt-get update
-              sudo apt-get install -y --allow-downgrades powershell=6.2.4-1.ubuntu.16.04
-            displayName: 'Install PowerShell Core 6'
-
-          - task: PowerShell@2
-            name: test
-            displayName: 'Run Unit Test'
-            inputs:
-              filePath: './build.ps1'
-              arguments: "-tasks test -PesterScript 'tests/Unit'"
-
-          - task: PublishTestResults@2
-            displayName: 'Publish Test Results'
-            inputs:
-              testResultsFormat: 'NUnit'
-              testResultsFiles: 'output/testResults/NUnit*.xml'
-              testRunTitle: 'Unit (Powershell Core 6 on Ubuntu 16.04)'
-
-          - task: PublishCodeCoverageResults@1
-            displayName: 'Publish Code Coverage'
-            condition: succeededOrFailed()
-            inputs:
-              codeCoverageTool: 'JaCoCo'
-              summaryFileLocation: 'output/testResults/CodeCov*.xml'
-              pathToSources: '$(Build.SourcesDirectory)/output/$(moduleBuildVariable.RepositoryName)'
-
-      - job: Integration_Test_PSCore6_Ubuntu1604
-        dependsOn: Unit_Test_PSCore6_Ubuntu1604
-        displayName: 'Integration Test (Powershell Core 6 on Ubuntu 16.04)'
-        pool:
-          vmImage: ubuntu-16.04
-        timeoutInMinutes: 0
-
-        steps:
-          - task: DownloadBuildArtifacts@0
-            displayName: 'Download Build Artifact'
-            inputs:
-              buildType: 'current'
-              downloadType: 'single'
-              artifactName: 'output'
-              downloadPath: '$(Build.SourcesDirectory)'
-
-          - script: |
-              curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
-              curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list | sudo tee /etc/apt/sources.list.d/microsoft.list
-              sudo apt-get update
-              sudo apt-get install -y --allow-downgrades powershell=6.2.4-1.ubuntu.16.04
-            displayName: 'Install PowerShell Core 6'
-
-          - task: PowerShell@2
-            name: test
-            displayName: 'Run Integration Test'
-            env:
-              azureApplicationId: $(azureApplicationId)
-              azureApplicationPassword: $(azureApplicationPassword)
-              azureSubscriptionId: $(azureSubscriptionId)
-              azureTenantId: $(azureTenantId)
-            inputs:
-              filePath: './build.ps1'
-              arguments: "-Tasks test -PesterScript 'tests/Integration' -CodeCoverageThreshold 0"
-              pwsh: false
-
-          - task: PublishTestResults@2
-            displayName: 'Publish Test Results'
-            inputs:
-              testResultsFormat: 'NUnit'
-              testResultsFiles: 'output/testResults/NUnit*.xml'
-              testRunTitle: 'Integration (Powershell Core 6 on Ubuntu 16.04)'
-            condition: succeededOrFailed()
-
-      - job: Unit_Test_PS7_Ubuntu1604
-        displayName: 'Unit Test (Powershell 7 on Ubuntu 16.04)'
-        pool:
-          vmImage: ubuntu-16.04
+          vmImage: windows-2022
 
         steps:
           - powershell: |
@@ -340,7 +246,7 @@ stages:
             inputs:
               testResultsFormat: 'NUnit'
               testResultsFiles: 'output/testResults/NUnit*.xml'
-              testRunTitle: 'Unit (Powershell 7 on Ubuntu 16.04)'
+              testRunTitle: 'Unit (PowerShell 5.1 on Windows Server 2022)'
 
           - task: PublishCodeCoverageResults@1
             displayName: 'Publish Code Coverage'
@@ -350,11 +256,11 @@ stages:
               summaryFileLocation: 'output/testResults/CodeCov*.xml'
               pathToSources: '$(Build.SourcesDirectory)/output/$(moduleBuildVariable.RepositoryName)'
 
-      - job: Integration_Test_PS7_Ubuntu1604
-        dependsOn: Unit_Test_PS7_Ubuntu1604
-        displayName: 'Integration Test (Powershell 7 on Ubuntu 16.04)'
+      - job: Integration_Test_PS_Win2022
+        dependsOn: Unit_Test_PS_Win2022
+        displayName: 'Integration Test (Powershell 5.1 on Windows Server 2022)'
         pool:
-          vmImage: ubuntu-16.04
+          vmImage: windows-2022
         timeoutInMinutes: 0
 
         steps:
@@ -384,7 +290,87 @@ stages:
             inputs:
               testResultsFormat: 'NUnit'
               testResultsFiles: 'output/testResults/NUnit*.xml'
-              testRunTitle: 'Integration (Powershell 7 on Ubuntu 16.04)'
+              testRunTitle: 'Integration (PowerShell 5.1 on Windows Server 2022)'
+            condition: succeededOrFailed()
+
+      - job: Unit_Test_PS7_Ubuntu2004
+        displayName: 'Unit Test (Powershell 7 on Ubuntu 20.04)'
+        pool:
+          vmImage: ubuntu-20.04
+
+        steps:
+          - powershell: |
+              $repositoryOwner,$repositoryName = $env:BUILD_REPOSITORY_NAME -split '/'
+              echo "##vso[task.setvariable variable=RepositoryOwner;isOutput=true]$repositoryOwner"
+              echo "##vso[task.setvariable variable=RepositoryName;isOutput=true]$repositoryName"
+            name: moduleBuildVariable
+            displayName: 'Set Environment Variables'
+
+          - task: DownloadBuildArtifacts@0
+            displayName: 'Download Build Artifact'
+            inputs:
+              buildType: 'current'
+              downloadType: 'single'
+              artifactName: 'output'
+              downloadPath: '$(Build.SourcesDirectory)'
+
+          - task: PowerShell@2
+            name: test
+            displayName: 'Run Unit Test'
+            inputs:
+              filePath: './build.ps1'
+              arguments: "-tasks test -PesterScript 'tests/Unit'"
+
+          - task: PublishTestResults@2
+            displayName: 'Publish Test Results'
+            inputs:
+              testResultsFormat: 'NUnit'
+              testResultsFiles: 'output/testResults/NUnit*.xml'
+              testRunTitle: 'Unit (Powershell 7 on Ubuntu 20.04)'
+
+          - task: PublishCodeCoverageResults@1
+            displayName: 'Publish Code Coverage'
+            condition: succeededOrFailed()
+            inputs:
+              codeCoverageTool: 'JaCoCo'
+              summaryFileLocation: 'output/testResults/CodeCov*.xml'
+              pathToSources: '$(Build.SourcesDirectory)/output/$(moduleBuildVariable.RepositoryName)'
+
+      - job: Integration_Test_PS7_Ubuntu2004
+        dependsOn: Unit_Test_PS7_Ubuntu2004
+        displayName: 'Integration Test (Powershell 7 on Ubuntu 20.04)'
+        pool:
+          vmImage: ubuntu-20.04
+        timeoutInMinutes: 0
+
+        steps:
+          - task: DownloadBuildArtifacts@0
+            displayName: 'Download Build Artifact'
+            inputs:
+              buildType: 'current'
+              downloadType: 'single'
+              artifactName: 'output'
+              downloadPath: '$(Build.SourcesDirectory)'
+
+          - task: PowerShell@2
+            name: test
+            displayName: 'Run Integration Test'
+            env:
+              azureApplicationId: $(azureApplicationId)
+              azureApplicationPassword: $(azureApplicationPassword)
+              azureSubscriptionId: $(azureSubscriptionId)
+              azureTenantId: $(azureTenantId)
+            inputs:
+              filePath: './build.ps1'
+              arguments: "-Tasks test -PesterScript 'tests/Integration' -CodeCoverageThreshold 0"
+              pwsh: false
+
+          - task: PublishTestResults@2
+            displayName: 'Publish Test Results'
+            inputs:
+              testResultsFormat: 'NUnit'
+              testResultsFiles: 'output/testResults/NUnit*.xml'
+              testRunTitle: 'Integration (Powershell 7 on Ubuntu 20.04)'
             condition: succeededOrFailed()
 
       - job: Unit_Test_PS7_Ubuntu1804
@@ -573,7 +559,7 @@ stages:
       - job: Deploy_Module
         displayName: 'Deploy Module'
         pool:
-          vmImage: ubuntu-16.04
+          vmImage: ubuntu-latest
 
         steps:
           - task: DownloadBuildArtifacts@0


### PR DESCRIPTION
This PR deprecates tests on Ubuntu 16.04 and adds tests on Ubuntu 20.04. It also removes PowerShell 6.x. tests. It also adds tests on Windows Server 2022.

- Fixes #436
- Fixes #434
- Fixes #433

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plagueho/cosmosdb/438)
<!-- Reviewable:end -->
