### PR TITLE
Added a Capacity param on New-CosmosDbAccount - Fixes #439

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to be `ubuntu-latest` - Fixes [Issue #422](https://github.com/PlagueHO/CosmosDB/issues/422).
 - Updated PSScriptAnalyzer tests to be skipped when PowerShell Core
   version is less than 7.0.3 - Fixes [Issue #431](https://github.com/PlagueHO/CosmosDB/issues/431).
+- Updated the New-CosmosDbAccount command to add a new Capability parameter - Fixes [Issue #439](https://github.com/PlagueHO/CosmosDB/issues/439).
 
 ### Added
 

--- a/docs/New-CosmosDbAccount.md
+++ b/docs/New-CosmosDbAccount.md
@@ -16,7 +16,7 @@ Create a new Cosmos DB account in Azure.
 ```powershell
 New-CosmosDbAccount [-Name] <String> [-ResourceGroupName] <String> [-Location] <String>
  [[-LocationRead] <String[]>] [[-DefaultConsistencyLevel] <String>] [[-MaxIntervalInSeconds] <Int32>]
- [[-MaxStalenessPrefix] <Int32>] [[-IpRangeFilter] <String[]>] [[-AllowedOrgin] <String[]>]
+ [[-MaxStalenessPrefix] <Int32>] [[-IpRangeFilter] <String[]>] [[-Capability] <String>] [[-AllowedOrgin] <String[]>]
 [-AsJob] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
@@ -86,6 +86,17 @@ Resource Group caled 'MyData'. The account will be created in the
 'WestUS' Azure region. The Cosmos DB will have the CORS allowed
 origins set to 'https://www.contoso.com' and 'https://www.fabrikam.com'.
 
+### Example 6
+
+```powershell
+PS C:\> New-CosmosDbAccount -Name 'MyCosmosDB' -ResourceGroup 'MyData' -Location 'WestUS' -Capability 'EnableServerless'
+```
+
+Create a new Cosmos DB account called 'MyCosmosDB' in an existing
+Resource Group caled 'MyData'. The account will be created in the
+'WestUS' Azure region. The Cosmos DB will be provisioned in the
+Serverless capacity mode.
+
 ## PARAMETERS
 
 ### -AllowedOrigin
@@ -115,6 +126,24 @@ of the job.
 Type: SwitchParameter
 Parameter Sets: (All)
 Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Capability
+
+The capability of the database account.
+For more information see https://docs.microsoft.com/en-us/azure/templates/microsoft.documentdb/databaseaccounts?tabs=json#capability.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Accepted values: EnableCassandra, EnableTable, EnableGremlin, EnableServerless
 
 Required: False
 Position: Named

--- a/source/Public/accounts/New-CosmosDbAccount.ps1
+++ b/source/Public/accounts/New-CosmosDbAccount.ps1
@@ -48,6 +48,11 @@ function New-CosmosDbAccount
         $IpRangeFilter = @(),
 
         [Parameter()]
+        [ValidateSet('EnableCassandra', 'EnableTable', 'EnableGremlin', 'EnableServerless')]
+        [System.String]
+        $Capability,
+
+        [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String[]]
         $AllowedOrigin,
@@ -91,6 +96,19 @@ function New-CosmosDbAccount
         ipRangeFilter            = ($IpRangeFilter -join ',')
     }
 
+    if ($PSBoundParameters.ContainsKey('Capability'))
+    {
+        $capabilityObject = @(
+            @{
+                name = $Capability
+            }
+        )
+
+        $cosmosDBProperties += @{
+            capabilities = $capabilityObject
+        }
+    }
+
     if ($PSBoundParameters.ContainsKey('AllowedOrigin'))
     {
         $corsObject = @(
@@ -109,6 +127,7 @@ function New-CosmosDbAccount
     $null = $PSBoundParameters.Remove('MaxIntervalInSeconds')
     $null = $PSBoundParameters.Remove('MaxStalenessPrefix')
     $null = $PSBoundParameters.Remove('IpRangeFilter')
+    $null = $PSBoundParameters.Remove('Capability')
     $null = $PSBoundParameters.Remove('AllowedOrigin')
 
     $newAzResource_parameters = $PSBoundParameters + @{


### PR DESCRIPTION
# Pull Request

## Improvements / Enhancements
-  Add a new Capacity param to New-CosmosDbAccount which allows you to create Cosmos DB Accounts that are Serverless or that use Cassandra, Gremlin, etc.

Closes #439 