### PR TITLE
Add retry support for document cmdlets

### DIFF
--- a/source/Private/utils/Invoke-CosmosDbRequest.ps1
+++ b/source/Private/utils/Invoke-CosmosDbRequest.ps1
@@ -64,7 +64,15 @@ function Invoke-CosmosDbRequest
         [Parameter()]
         [ValidateSet('Default', 'UTF-8')]
         [System.String]
-        $Encoding = 'Default'
+        $Encoding = 'Default',
+
+        [Parameter()]
+        [int]
+        $MaximumRetryCount,
+
+        [Parameter()]
+        [int]
+        $RetryIntervalSec
     )
 
     if ($PSCmdlet.ParameterSetName -eq 'Account')
@@ -257,6 +265,21 @@ function Invoke-CosmosDbRequest
                     Start-Sleep -Milliseconds $delay
                     continue
                 }
+            }
+            elseif (
+                $_.Exception.Response.StatusCode -ge 400 -and
+                $_.Exception.Response.StatusCode -le 599 -and
+                $MaximumRetryCount -gt $retry
+            )
+            {
+                <#
+                    The exception was caused by an error either in the client request or on the server
+                    If additional retries are specified, retry after RetryIntervalSec until Max count is reached
+                #>
+                $retry++
+                Write-Verbose -Message $($LocalizedData.WebRequestErrorDelay -f $MaximumRetryCount, $RetryIntervalSec)
+                Start-Sleep $RetryIntervalSec
+                continue
             }
 
             if ($_.Exception.Response)

--- a/source/Private/utils/Invoke-CosmosDbRequest.ps1
+++ b/source/Private/utils/Invoke-CosmosDbRequest.ps1
@@ -67,11 +67,11 @@ function Invoke-CosmosDbRequest
         $Encoding = 'Default',
 
         [Parameter()]
-        [int]
+        [System.Int32]
         $MaximumRetryCount,
 
         [Parameter()]
-        [int]
+        [System.Int32]
         $RetryIntervalSec
     )
 

--- a/source/Public/documents/Get-CosmosDbDocumentJson.ps1
+++ b/source/Public/documents/Get-CosmosDbDocumentJson.ps1
@@ -92,11 +92,11 @@ function Get-CosmosDbDocumentJson
         $ResponseHeader,
 
         [Parameter()]
-        [int]
+        [System.Int32]
         $MaximumRetryCount,
 
         [Parameter()]
-        [int]
+        [System.Int32]
         $RetryIntervalSec = 5
     )
 
@@ -204,7 +204,7 @@ function Get-CosmosDbDocumentJson
             Because the headers of this request will contain important information
             then we need to use a plain web request.
         #>
-        $Splat = @{
+        $invokeCosmosDbRequest_parameters = @{
             Method            = $method
             ResourceType      = 'docs'
             ResourcePath      = $resourcePath
@@ -213,7 +213,7 @@ function Get-CosmosDbDocumentJson
             MaximumRetryCount = $MaximumRetryCount
             RetryIntervalSec  = $RetryIntervalSec
         }
-        $result = Invoke-CosmosDbRequest @PSBoundParameters @Splat
+        $result = Invoke-CosmosDbRequest @PSBoundParameters @invokeCosmosDbRequest_parameters
 
         if ($ResponseHeaderPassed)
         {
@@ -232,7 +232,7 @@ function Get-CosmosDbDocumentJson
             $null = $PSBoundParameters.Remove('PartitionKey')
         }
 
-        $Splat = @{
+        $invokeCosmosDbRequest_parameters = @{
             Method            = $method
             Headers           = $headers
             ResourceType      = 'docs'
@@ -240,7 +240,7 @@ function Get-CosmosDbDocumentJson
             MaximumRetryCount = $MaximumRetryCount
             RetryIntervalSec  = $RetryIntervalSec
         }
-        $result = Invoke-CosmosDbRequest @PSBoundParameters @Splat
+        $result = Invoke-CosmosDbRequest @PSBoundParameters @invokeCosmosDbRequest_parameters
     }
 
     $documents = Repair-CosmosDbDocumentEncoding -Content $result.Content

--- a/source/Public/documents/New-CosmosDbDocument.ps1
+++ b/source/Public/documents/New-CosmosDbDocument.ps1
@@ -62,7 +62,15 @@ function New-CosmosDbDocument
 
         [Parameter()]
         [switch]
-        $ReturnJson
+        $ReturnJson,
+
+        [Parameter()]
+        [int]
+        $MaximumRetryCount,
+
+        [Parameter()]
+        [int]
+        $RetryIntervalSec = 5
     )
 
     $null = $PSBoundParameters.Remove('CollectionId')
@@ -98,12 +106,16 @@ function New-CosmosDbDocument
         $null = $PSBoundParameters.Remove('PartitionKey')
     }
 
-    $result = Invoke-CosmosDbRequest @PSBoundParameters `
-        -Method 'Post' `
-        -ResourceType 'docs' `
-        -ResourcePath $resourcePath `
-        -Body $DocumentBody `
-        -Headers $headers
+    $Splat = @{
+        Method            = 'Post'
+        ResourceType      = 'docs'
+        ResourcePath      = $resourcePath
+        Body              = $DocumentBody
+        Headers           = $headers
+        MaximumRetryCount = $MaximumRetryCount
+        RetryIntervalSec  = $RetryIntervalSec
+    }
+    $result = Invoke-CosmosDbRequest @PSBoundParameters @Splat
 
     if ($ReturnJson.IsPresent)
     {

--- a/source/Public/documents/New-CosmosDbDocument.ps1
+++ b/source/Public/documents/New-CosmosDbDocument.ps1
@@ -65,11 +65,11 @@ function New-CosmosDbDocument
         $ReturnJson,
 
         [Parameter()]
-        [int]
+        [System.Int32]
         $MaximumRetryCount,
 
         [Parameter()]
-        [int]
+        [System.Int32]
         $RetryIntervalSec = 5
     )
 
@@ -106,7 +106,7 @@ function New-CosmosDbDocument
         $null = $PSBoundParameters.Remove('PartitionKey')
     }
 
-    $Splat = @{
+    $invokeCosmosDbRequest_parameters = @{
         Method            = 'Post'
         ResourceType      = 'docs'
         ResourcePath      = $resourcePath
@@ -115,7 +115,7 @@ function New-CosmosDbDocument
         MaximumRetryCount = $MaximumRetryCount
         RetryIntervalSec  = $RetryIntervalSec
     }
-    $result = Invoke-CosmosDbRequest @PSBoundParameters @Splat
+    $result = Invoke-CosmosDbRequest @PSBoundParameters @invokeCosmosDbRequest_parameters
 
     if ($ReturnJson.IsPresent)
     {

--- a/source/Public/documents/Remove-CosmosDbDocument.ps1
+++ b/source/Public/documents/Remove-CosmosDbDocument.ps1
@@ -46,11 +46,11 @@ function Remove-CosmosDbDocument
         $PartitionKey,
 
         [Parameter()]
-        [int]
+        [System.Int32]
         $MaximumRetryCount,
 
         [Parameter()]
-        [int]
+        [System.Int32]
         $RetryIntervalSec = 5
     )
 
@@ -68,7 +68,7 @@ function Remove-CosmosDbDocument
         }
         $null = $PSBoundParameters.Remove('PartitionKey')
     }
-    $Splat = @{
+    $invokeCosmosDbRequest_parameters = @{
         Method            = 'Delete'
         ResourceType      = 'docs'
         ResourcePath      = $resourcePath
@@ -76,5 +76,5 @@ function Remove-CosmosDbDocument
         MaximumRetryCount = $MaximumRetryCount
         RetryIntervalSec  = $RetryIntervalSec
     }
-    $null = Invoke-CosmosDbRequest @PSBoundParameters @Splat
+    $null = Invoke-CosmosDbRequest @PSBoundParameters @invokeCosmosDbRequest_parameters
 }

--- a/source/Public/documents/Remove-CosmosDbDocument.ps1
+++ b/source/Public/documents/Remove-CosmosDbDocument.ps1
@@ -43,7 +43,15 @@ function Remove-CosmosDbDocument
         [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.Object[]]
-        $PartitionKey
+        $PartitionKey,
+
+        [Parameter()]
+        [int]
+        $MaximumRetryCount,
+
+        [Parameter()]
+        [int]
+        $RetryIntervalSec = 5
     )
 
     $null = $PSBoundParameters.Remove('CollectionId')
@@ -60,10 +68,13 @@ function Remove-CosmosDbDocument
         }
         $null = $PSBoundParameters.Remove('PartitionKey')
     }
-
-    $null = Invoke-CosmosDbRequest @PSBoundParameters `
-        -Method 'Delete' `
-        -ResourceType 'docs' `
-        -ResourcePath $resourcePath `
-        -Headers $headers
+    $Splat = @{
+        Method            = 'Delete'
+        ResourceType      = 'docs'
+        ResourcePath      = $resourcePath
+        Headers           = $headers
+        MaximumRetryCount = $MaximumRetryCount
+        RetryIntervalSec  = $RetryIntervalSec
+    }
+    $null = Invoke-CosmosDbRequest @PSBoundParameters @Splat
 }

--- a/source/Public/documents/Set-CosmosDbDocument.ps1
+++ b/source/Public/documents/Set-CosmosDbDocument.ps1
@@ -72,11 +72,11 @@ function Set-CosmosDbDocument
         $ReturnJson,
 
         [Parameter()]
-        [int]
+        [System.Int32]
         $MaximumRetryCount,
 
         [Parameter()]
-        [int]
+        [System.Int32]
         $RetryIntervalSec = 5
     )
 
@@ -113,7 +113,7 @@ function Set-CosmosDbDocument
         $null = $PSBoundParameters.Remove('ETag')
     }
 
-    $Splat = @{
+    $invokeCosmosDbRequest_parameters = @{
         Method            = 'Put'
         ResourceType      = 'docs'
         ResourcePath      = $resourcePath
@@ -122,7 +122,7 @@ function Set-CosmosDbDocument
         MaximumRetryCount = $MaximumRetryCount
         RetryIntervalSec  = $RetryIntervalSec
     }
-    $result = Invoke-CosmosDbRequest @PSBoundParameters @Splat
+    $result = Invoke-CosmosDbRequest @PSBoundParameters @invokeCosmosDbRequest_parameters
 
     if ($ReturnJson.IsPresent)
     {

--- a/source/Public/documents/Set-CosmosDbDocument.ps1
+++ b/source/Public/documents/Set-CosmosDbDocument.ps1
@@ -69,7 +69,15 @@ function Set-CosmosDbDocument
 
         [Parameter()]
         [switch]
-        $ReturnJson
+        $ReturnJson,
+
+        [Parameter()]
+        [int]
+        $MaximumRetryCount,
+
+        [Parameter()]
+        [int]
+        $RetryIntervalSec = 5
     )
 
     $null = $PSBoundParameters.Remove('CollectionId')
@@ -105,12 +113,16 @@ function Set-CosmosDbDocument
         $null = $PSBoundParameters.Remove('ETag')
     }
 
-    $result = Invoke-CosmosDbRequest @PSBoundParameters `
-        -Method 'Put' `
-        -ResourceType 'docs' `
-        -ResourcePath $resourcePath `
-        -Body $DocumentBody `
-        -Headers $headers
+    $Splat = @{
+        Method            = 'Put'
+        ResourceType      = 'docs'
+        ResourcePath      = $resourcePath
+        Body              = $DocumentBody
+        Headers           = $headers
+        MaximumRetryCount = $MaximumRetryCount
+        RetryIntervalSec  = $RetryIntervalSec
+    }
+    $result = Invoke-CosmosDbRequest @PSBoundParameters @Splat
 
     if ($ReturnJson.IsPresent)
     {

--- a/source/en-US/CosmosDB.strings.psd1
+++ b/source/en-US/CosmosDB.strings.psd1
@@ -26,6 +26,7 @@ ConvertFrom-StringData -StringData @'
     BackOffPolicyAppliedPolicyDelay = The {0} back-off policy delay {1}ms will be used because it is longer than the requested delay {2}ms.
     BackOffPolicyAppliedRequestedDelay = The requested delay {2}ms will be used because it is longer than the {0} back-off policy delay {1}ms.
     WaitingBackoffPolicyDelay = The collection has exceeded the provisioned throughput limit but retry {0} will be attempted in {1}ms.
+    WebRequestErrorDelay = The request failed but will be retried up to {0} times in {1}s.
     ErrorAuthorizationKeyEmpty = The authorization key is empty. It must be passed in the context or a valid token context for the resource being accessed must be supplied.
     WarningNewCollectionOfferTypeDeprecated = The 'OfferType' parameter is a legacy parameter and is only supported for backwards compatibility and may be removed in future. It is recommended to use 'OfferThroughput' or 'AutopilotThroughput' instead.
     ErrorNewCollectionOfferParameterConflict = Only one of 'OfferType', OfferThroughput' or 'AutoscaleThroughput' should be specified when creating a new collection.


### PR DESCRIPTION
- Adds enhancement #442 

Style guide suggests that using splatting is cool, so I also changed some commands with immediate execution to use splatting.

Marking PR as draft.
- Implements parameters for document cmdlets
- Implements parameters for Invoke-CosmosDbRequest
- Does not yet include any unit tests
- Does not yet include any PlatyPS documentation

@PlagueHO Note: There is no dev branch to open the PR against according to the contrib document. Opening against main.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plagueho/cosmosdb/444)
<!-- Reviewable:end -->
