### PR TITLE
Fix exception when x-ms-retry-after-ms header missing from 429 error - Fixes #458

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix Azure DevOps build pipeline and update to latest sampler pattern.
+- Fix exception being thrown when a 429 is returned by CosmosDB, but the
+  `x-ms-retry-after-ms` header is not returned. This may occur in requests
+  that follow large (> 1MB) insert or updates - Fixes [Issue #439](https://github.com/PlagueHO/CosmosDB/issues/439).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix Azure DevOps build pipeline and update to latest sampler pattern.
 - Fix exception being thrown when a 429 is returned by CosmosDB, but the
   `x-ms-retry-after-ms` header is not returned. This may occur in requests
-  that follow large (> 1MB) insert or updates - Fixes [Issue #439](https://github.com/PlagueHO/CosmosDB/issues/439).
+  that follow large (> 1MB) insert or updates - Fixes [Issue #458](https://github.com/PlagueHO/CosmosDB/issues/458).
 
 ### Changed
 

--- a/source/en-US/CosmosDB.strings.psd1
+++ b/source/en-US/CosmosDB.strings.psd1
@@ -61,4 +61,6 @@ ConvertFrom-StringData -StringData @'
     ErrorNewDatabaseThroughputParameterConflict = Both 'OfferThroughput' and 'AutoscaleThroughput' should not be specified when creating a new database.
     DeprecateAttachmentWarning = Attachments are a legacy feature. Their support is scoped to offer continued functionality if you are already using this feature. See https://aka.ms/cosmosdb-attachments for more information.
     ErrorConvertingDocumentJsonToObject = An error occured converting the document information returned from Cosmsos DB into an object. This might be caused by the document including keys with same name but differing in case. Include the -ReturnJson parameter to return these as JSON instead.
+    ErrorTooManyRequests = The server returned a '429 Too Many Requests' error. This is likely due to the client making too many requests to the server. Please retry your request.
+    ErrorTooManyRequestsWithNoRetryAfter = The server returned a '429 Too Many Requests' error, but the did not include an 'x-ms-retry-after-ms' header in the response. A retry delay of 0ms will be used.
 '@


### PR DESCRIPTION
# Pull Request

- Fix exception being thrown when a 429 is returned by CosmosDB, but the
  `x-ms-retry-after-ms` header is not returned. This may occur in requests
  that follow large (> 1MB) insert or updates - Fixes [Issue #439](https://github.com/PlagueHO/CosmosDB/issues/439).

## Bug Fixes

- Fixes #458

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plagueho/cosmosdb/460)
<!-- Reviewable:end -->
