### PR TITLE
Fix typo in Get-CosmosDbDocument syntax

### DIFF
--- a/docs/Get-CosmosDbDocument.md
+++ b/docs/Get-CosmosDbDocument.md
@@ -22,7 +22,7 @@ Get-CosmosDbDocument -Context <Context> [-Key <SecureString>] [-KeyType <String>
  [-ConsistencyLevel <String>] [-SessionToken <String>]
  [-PartitionKeyRangeId <String>] [-Query <String>] [-QueryParameters <Hashtable[]>]
  [-QueryEnableCrossPartition <Boolean>] [-ResponseHeader <PSReference>]
- [-RetrunJson <switch>] [<CommonParameters>]
+ [-ReturnJson <switch>] [<CommonParameters>]
 ```
 
 ### Account
@@ -34,7 +34,7 @@ Get-CosmosDbDocument -Account <String> [-Key <SecureString>] [-KeyType <String>]
  [-ConsistencyLevel <String>] [-SessionToken <String>]
  [-PartitionKeyRangeId <String>] [-Query <String>] [-QueryParameters <Hashtable[]>]
  [-QueryEnableCrossPartition <Boolean>] [-ResponseHeader <PSReference>]
- [-RetrunJson <switch>] [<CommonParameters>]
+ [-ReturnJson <switch>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION


### PR DESCRIPTION
Small typo fix `RetrunJson` -> `ReturnJson`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plagueho/cosmosdb/462)
<!-- Reviewable:end -->
