### PR TITLE
Added ConnectionString parameter to New-CosmosDbContext cmdlet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added `-ConnectionString` parameter to `New-CosmosDbContext` - Fixes [Issue #426](https://github.com/PlagueHO/CosmosDB/issues/426).
+
 ### Fixed
 
 - Fixed spelling errors in documentation.

--- a/docs/New-CosmosDbContext.md
+++ b/docs/New-CosmosDbContext.md
@@ -166,6 +166,16 @@ PS C:\> $cosmosDbContext = New-CosmosDbContext -Account 'AlternateCloud' -Databa
 Creates a CosmosDB context specifying the master key manually connecting
 to an custom Cosmos DB endpoint.
 
+### Example 9
+
+```powershell
+PS C:\> $connectionString = Get-CosmosDbAccountConnectionString -Name 'MyAzureCosmosDB' -ResourceGroupName 'MyCosmosDbResourceGroup'
+PS C:\> $cosmosDbContext = New-CosmosDbContext -ConnectionString ($connectionString | ConvertTo-SecureString -AsPlainText) -Database 'MyDatabase' -MasterKeyType 'PrimaryMasterKey'
+```
+
+Creates a CosmosDB context specifying the connection string connecting
+to the Cosmos DB account.
+
 ## PARAMETERS
 
 ### -Account

--- a/docs/New-CosmosDbContext.md
+++ b/docs/New-CosmosDbContext.md
@@ -55,6 +55,15 @@ New-CosmosDbContext -Account <String> [-Database <String>] -Token <ContextToken[
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
+### ConnectionString
+
+```powershell
+New-CosmosDbContext -ConnectionString <SecureString> [-Database <String>]
+ [-KeyType <String>] [-MasterKeyType <String>]
+ [-BackoffPolicy <BackoffPolicy>] [-Environment <Environment>]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
 ### Emulator
 
 ```powershell
@@ -208,6 +217,22 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -ConnectionString
+
+The connection string used to access the Cosmos DB account.
+
+```yaml
+Type: SecureString
+Parameter Sets: ConnectionString
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Database
 
 The name of the database to access in the Cosmos DB account.
@@ -268,7 +293,7 @@ The supported values are:
 
 ```yaml
 Type: Environment
-Parameter Sets: Account, AzureAccount, Token
+Parameter Sets: Account, AzureAccount, Token, ConnectionString
 Aliases:
 Accepted values: AzureChinaCloud, AzureCloud, AzureUSGovernment
 
@@ -320,7 +345,7 @@ will be deprecated in a future release. Do not use it.
 
 ```yaml
 Type: String
-Parameter Sets: Account, CustomAccount
+Parameter Sets: Account, CustomAccount, ConnectionString
 Aliases:
 Accepted values: master, resource
 
@@ -338,7 +363,7 @@ the Cosmos DB.
 
 ```yaml
 Type: String
-Parameter Sets: CustomAzureAccount, AzureAccount
+Parameter Sets: CustomAzureAccount, AzureAccount, ConnectionString
 Aliases:
 Accepted values: PrimaryMasterKey, SecondaryMasterKey, PrimaryReadonlyMasterKey, SecondaryReadonlyMasterKey
 

--- a/docs/New-CosmosDbContext.md
+++ b/docs/New-CosmosDbContext.md
@@ -170,7 +170,7 @@ to an custom Cosmos DB endpoint.
 
 ```powershell
 PS C:\> $connectionString = Get-CosmosDbAccountConnectionString -Name 'MyAzureCosmosDB' -ResourceGroupName 'MyCosmosDbResourceGroup'
-PS C:\> $cosmosDbContext = New-CosmosDbContext -ConnectionString ($connectionString | ConvertTo-SecureString -AsPlainText) -Database 'MyDatabase' -MasterKeyType 'PrimaryMasterKey'
+PS C:\> $cosmosDbContext = New-CosmosDbContext -ConnectionString ($connectionString | ConvertTo-SecureString -AsPlainText -Force) -Database 'MyDatabase' -MasterKeyType 'PrimaryMasterKey'
 ```
 
 Creates a CosmosDB context specifying the connection string connecting

--- a/source/Public/utils/New-CosmosDbContext.ps1
+++ b/source/Public/utils/New-CosmosDbContext.ps1
@@ -191,7 +191,7 @@ function New-CosmosDbContext
             $connectionStringParts = $decryptedConnectionString -replace ';', [System.Environment]::NewLine | ConvertFrom-StringData
             $BaseUri = [System.Uri]::new($connectionStringParts.AccountEndpoint)
             $Account = $BaseUri.Host.Split('.')[0]
-            $Key = $connectionStringParts.AccountKey | ConvertTo-SecureString -AsPlainText
+            $Key = $connectionStringParts.AccountKey | ConvertTo-SecureString -AsPlainText -Force
         }
     }
 

--- a/tests/Integration/CosmosDB.integration.Tests.ps1
+++ b/tests/Integration/CosmosDB.integration.Tests.ps1
@@ -967,6 +967,26 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
         }
     }
 
+    Context 'When getting existing document using connection string as context' {
+        It 'Should not throw an exception' {
+            $connectionString = Get-CosmosDbAccountConnectionString `
+                -Name $script:testAccountName `
+                -ResourceGroupName $script:testResourceGroupName `
+                -Verbose
+
+            $connectionStringContext = New-CosmosDbContext `
+                -ConnectionString ($connectionString | ConvertTo-SecureString -AsPlainText) `
+                -Database $script:testDatabase `
+                -Verbose
+
+            $script:result = Get-CosmosDbDocument `
+                -Context $connectionStringContext `
+                -CollectionId $script:testCollection `
+                -Id $script:testDocumentId `
+                -Verbose
+        }
+    }
+
     Context 'When adding a stored procedure to the collection' {
         It 'Should not throw an exception' {
             $script:result = New-CosmosDbStoredProcedure `

--- a/tests/Integration/CosmosDB.integration.Tests.ps1
+++ b/tests/Integration/CosmosDB.integration.Tests.ps1
@@ -975,7 +975,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
                 -Verbose
 
             $connectionStringContext = New-CosmosDbContext `
-                -ConnectionString ($connectionString | ConvertTo-SecureString -AsPlainText) `
+                -ConnectionString ($connectionString | ConvertTo-SecureString -AsPlainText -Force) `
                 -Database $script:testDatabase `
                 -Verbose
 

--- a/tests/Unit/CosmosDB.utils.Tests.ps1
+++ b/tests/Unit/CosmosDB.utils.Tests.ps1
@@ -807,7 +807,7 @@ console.log("done");
 
             It 'Should not throw exception' {
                 $newCosmosDbContextParameters = @{
-                    ConnectionString = ($script:testConnectionString | ConvertTo-SecureString -AsPlainText)
+                    ConnectionString = ($script:testConnectionString | ConvertTo-SecureString -AsPlainText -Force)
                     Database = $script:testDatabase
                 }
 

--- a/tests/Unit/CosmosDB.utils.Tests.ps1
+++ b/tests/Unit/CosmosDB.utils.Tests.ps1
@@ -88,6 +88,8 @@ console.log("done");
 
     $script:testRequestBodyJson = '{"Tricky Body":"if (entityAlreadyExists)\r\n    throw new Error(`root entity # ${entity.id} already created`);\r\nconsole.log(`new entity \"${entity.id}\" is about to be created...`);\r\nlet a = \u0027some value\u0027;\r\nconsole.log(\"done\");"}'
 
+    $script:testConnectionString = "AccountEndpoint=https://{0}.documents.azure.com:443/;AccountKey={1};" -f $script:testAccount, $script:testKey
+
     Describe 'Custom types' -Tag 'Unit' {
         Context 'CosmosDB.Context' {
             It 'Should exist' {
@@ -797,6 +799,30 @@ console.log("done");
                 $script:result.Token[0].TimeStamp | Should -Be $script:testDate
                 $script:result.Token[0].Token | Convert-CosmosDbSecureStringToString | Should -Be $script:testToken
                 $script:result.Environment | Should -BeExactly 'AzureCloud'
+            }
+        }
+
+        Context 'When called with Connection String parameter' {
+            $script:result = $null
+
+            It 'Should not throw exception' {
+                $newCosmosDbContextParameters = @{
+                    ConnectionString = ($script:testConnectionString | ConvertTo-SecureString -AsPlainText)
+                    Database = $script:testDatabase
+                }
+
+                { $script:result = New-CosmosDbContext @newCosmosDbContextParameters } | Should -Not -Throw
+            }
+
+            It 'Should return expected result' {
+                $script:result.Account | Should -Be $script:testAccount
+                $script:result.Database | Should -Be $script:testDatabase
+                $script:result.BaseUri | Should -Be ('https://{0}.documents.azure.com/' -f $script:testAccount)
+                $script:result.Environment | Should -BeExactly 'AzureCloud'
+                $script:result.Key | Should -BeOfType [System.Security.SecureString]
+                $decryptedConnectionString = $script:result.Key | Convert-CosmosDbSecureStringToString
+                $decryptedConnectionString | Should -BeExactly $script:testKey
+                $script:result.KeyType | Should -BeExactly 'master'
             }
         }
     }


### PR DESCRIPTION
Fixes #426.

Added `-ConnectionString` parameter to `New-CosmosDbContext`.

The new parameter set:

```powershell
New-CosmosDbContext -ConnectionString <securestring> [-Database <string>] [-KeyType <string>] [-MasterKeyType <string>] [-BackoffPolicy <BackoffPolicy>] [-Environment <Environment>] [-WhatIf] [-Confirm] [<CommonParameters>]
```

Which allows the user to pass in a connection string to set the context. Let me know if I need to tweak this or fix anything else 🙂.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/PlagueHO/CosmosDB/466)
<!-- Reviewable:end -->
