### PR TITLE
Update autoscale throughput minimum and enhance resource cleanup in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed integration tests to display the removal of the Cosmos DB account
   in the teardown phase to ensure the account is removed after the tests are
   completed.
+- Updated collection and database autoscale minimum from 4000 to
+  1000 - Fixes [Issue #493](https://github.com/PlagueHO/CosmosDB/issues/493).
+- Changed integration tests to attempt to clean up the Cosmos DB resource group
+  if it is not removed by the teardown phase - Fixes [Issue #494](https://github.com/PlagueHO/CosmosDB/issues/494).
 
 ## [5.0.0] - 2024-06-07
 

--- a/build.yaml
+++ b/build.yaml
@@ -92,8 +92,8 @@ CopyPaths:
   - formats
   - en-US
   - types
-prefix: prefix.ps1
-suffix: suffix.ps1
+Prefix: prefix.ps1
+Suffix: suffix.ps1
 Encoding: UTF8
 VersionedOutputDirectory: true
 

--- a/docs/New-CosmosDbCollection.md
+++ b/docs/New-CosmosDbCollection.md
@@ -322,7 +322,7 @@ Accept wildcard characters: False
 ### -AutoscaleThroughput
 
 The user specified autoscale throughput for the database expressed in RU/s.
-This can be between 4000 and 1,000,000 and should be specified in increments
+This can be between 1000 and 1,000,000 and should be specified in increments
 of 100 RU/s.
 This parameter can not be specified in OfferThroughput or OfferType is specified.
 

--- a/docs/New-CosmosDbDatabase.md
+++ b/docs/New-CosmosDbDatabase.md
@@ -166,7 +166,7 @@ Accept wildcard characters: False
 ### -AutoscaleThroughput
 
 The user specified autoscale throughput for the database expressed in RU/s.
-This can be between 4000 and 1,000,000 and should be specified in increments
+This can be between 1000 and 1,000,000 and should be specified in increments
 of 100 RU/s.
 This parameter can not be specified in OfferThroughput is specified.
 

--- a/source/Public/collections/New-CosmosDbCollection.ps1
+++ b/source/Public/collections/New-CosmosDbCollection.ps1
@@ -77,7 +77,7 @@ function New-CosmosDbCollection
         $UniqueKeyPolicy,
 
         [Alias('AutopilotThroughput')]
-        [ValidateRange(4000, 1000000)]
+        [ValidateRange(1000, 1000000)]
         [System.Int32]
         $AutoscaleThroughput
     )

--- a/source/Public/databases/New-CosmosDbDatabase.ps1
+++ b/source/Public/databases/New-CosmosDbDatabase.ps1
@@ -37,7 +37,7 @@ function New-CosmosDbDatabase
         $OfferThroughput,
 
         [Alias('AutopilotThroughput','AutoscaleMaxThroughput','AutopilotMaxThroughput')]
-        [ValidateRange(4000, 1000000)]
+        [ValidateRange(1000, 1000000)]
         [System.Int32]
         $AutoscaleThroughput
     )

--- a/tests/Integration/CosmosDB.integration.Tests.ps1
+++ b/tests/Integration/CosmosDB.integration.Tests.ps1
@@ -553,7 +553,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
             $script:result.OfferType | Should -BeOfType [System.String]
             $script:result.OfferResourceId | Should -BeOfType [System.String]
             $script:result.Id | Should -BeOfType [System.String]
-            $script:result.content.offerThroughput | Should -BeExactly 400
+            $script:result.content.offerThroughput | Should -BeExactly 100
             $script:result.content.offerMinimumThroughputParameters.maxThroughputEverProvisioned | Should -BeExactly 1000
             $script:result.content.offerAutopilotSettings.maxThroughput | Should -BeExactly 1000
         }

--- a/tests/Integration/CosmosDB.integration.Tests.ps1
+++ b/tests/Integration/CosmosDB.integration.Tests.ps1
@@ -528,7 +528,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
 
     Context 'When creating third new database with a specified autoscale throughput' {
         It 'Should not throw an exception' {
-            $script:result = New-CosmosDbDatabase -Context $script:testContext -Id $script:testDatabase3 -AutoscaleThroughput 4000 -Verbose
+            $script:result = New-CosmosDbDatabase -Context $script:testContext -Id $script:testDatabase3 -AutoscaleThroughput 1000 -Verbose
         }
 
         It 'Should return expected object' {
@@ -554,8 +554,8 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
             $script:result.OfferResourceId | Should -BeOfType [System.String]
             $script:result.Id | Should -BeOfType [System.String]
             $script:result.content.offerThroughput | Should -BeExactly 400
-            $script:result.content.offerMinimumThroughputParameters.maxThroughputEverProvisioned | Should -BeExactly 4000
-            $script:result.content.offerAutopilotSettings.maxThroughput | Should -BeExactly 4000
+            $script:result.content.offerMinimumThroughputParameters.maxThroughputEverProvisioned | Should -BeExactly 1000
+            $script:result.content.offerAutopilotSettings.maxThroughput | Should -BeExactly 1000
         }
     }
 
@@ -1388,7 +1388,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
                 -Context $script:testContext `
                 -Id $script:testCollection `
                 -PartitionKey $script:testPartitionKey `
-                -AutoscaleThroughput 4000 `
+                -AutoscaleThroughput 1000 `
                 -Verbose
         }
 

--- a/tests/TestHelper/TestHelper.psm1
+++ b/tests/TestHelper/TestHelper.psm1
@@ -314,10 +314,21 @@ function Remove-AzureTestCosmosDbResourceGroup
 
         if ($PSCmdlet.ShouldProcess('Azure', ("Remove Azure Cosmos DB resource group '{0}'" -f $ResourceGroupName)))
         {
-            $null = Remove-AzResourceGroup `
+            Remove-AzResourceGroup `
                 -Name $ResourceGroupName `
-                -Force `
-                -AsJob
+                -Force
+
+            # Check if the resource group was removed
+            $resourceGroup = Get-AzResourceGroup `
+                -Name $ResourceGroupName
+
+            if ($null -ne $resourceGroup)
+            {
+                Write-Warning -Message ('Resource group {0} was not removed. Trying again.' -f $ResourceGroupName)
+                Remove-AzResourceGroup `
+                    -Name $ResourceGroupName `
+                    -Force
+            }
         }
     }
     catch [System.Exception]

--- a/tests/TestHelper/TestHelper.psm1
+++ b/tests/TestHelper/TestHelper.psm1
@@ -320,7 +320,8 @@ function Remove-AzureTestCosmosDbResourceGroup
 
             # Check if the resource group was removed
             $resourceGroup = Get-AzResourceGroup `
-                -Name $ResourceGroupName
+                -Name $ResourceGroupName `
+                -ErrorAction SilentlyContinue
 
             if ($null -ne $resourceGroup)
             {

--- a/tests/Unit/CosmosDB.accounts.Tests.ps1
+++ b/tests/Unit/CosmosDB.accounts.Tests.ps1
@@ -124,7 +124,7 @@ InModuleScope $ProjectName {
 
         Context 'When called with a valid name' {
             It 'Should return $true' {
-                Assert-CosmosDbAccountNameValid -Name 'validaccountname' | Should -Be $true
+                Assert-CosmosDbAccountNameValid -Name 'validaccountname' | Should -BeTrue
             }
         }
 
@@ -196,7 +196,7 @@ InModuleScope $ProjectName {
 
         Context 'When called with a valid resource group name' {
             It 'Should return $true' {
-                Assert-CosmosDbResourceGroupNameValid -ResourceGroupName 'valid_resource-group.name123' | Should -Be $true
+                Assert-CosmosDbResourceGroupNameValid -ResourceGroupName 'valid_resource-group.name123' | Should -BeTrue
             }
         }
 

--- a/tests/Unit/CosmosDB.collections.Tests.ps1
+++ b/tests/Unit/CosmosDB.collections.Tests.ps1
@@ -932,7 +932,7 @@ InModuleScope $ProjectName {
                 $Method -eq 'Post' -and `
                 $ResourceType -eq 'colls' -and `
                 $BodyObject.id -eq $script:testCollection1 -and `
-                $Headers.'x-ms-cosmos-offer-autopilot-settings' -eq "{`"maxThroughput`":4000}"
+                $Headers.'x-ms-cosmos-offer-autopilot-settings' -eq "{`"maxThroughput`":1000}"
             }
 
             Mock `
@@ -943,7 +943,7 @@ InModuleScope $ProjectName {
                 $newCosmosDbCollectionParameters = @{
                     Context             = $script:testContext
                     Id                  = $script:testCollection1
-                    AutoscaleThroughput = 4000
+                    AutoscaleThroughput = 1000
                     PartitionKey        = 'partitionkey'
                     Verbose             = $true
                 }
@@ -972,7 +972,7 @@ InModuleScope $ProjectName {
                 $newCosmosDbCollectionParameters = @{
                     Context             = $script:testContext
                     Id                  = $script:testCollection1
-                    AutoscaleThroughput = 4000
+                    AutoscaleThroughput = 1000
                     Verbose             = $true
                 }
 
@@ -993,7 +993,7 @@ InModuleScope $ProjectName {
                     Context             = $script:testContext
                     Id                  = $script:testCollection1
                     OfferThroughput     = 400
-                    AutoscaleThroughput = 4000
+                    AutoscaleThroughput = 1000
                     Verbose             = $true
                 }
 
@@ -1014,7 +1014,7 @@ InModuleScope $ProjectName {
                     Context             = $script:testContext
                     Id                  = $script:testCollection1
                     OfferType           = 'S1'
-                    AutoscaleThroughput = 4000
+                    AutoscaleThroughput = 1000
                     Verbose             = $true
                 }
 

--- a/tests/Unit/CosmosDB.databases.Tests.ps1
+++ b/tests/Unit/CosmosDB.databases.Tests.ps1
@@ -34,7 +34,7 @@ InModuleScope $ProjectName {
     $script:testDatabase1 = 'testDatabase1'
     $script:testDatabase2 = 'testDatabase2'
     $script:testOfferThroughput = 2000
-    $script:testAutoscaleThroughput = 4000
+    $script:testAutoscaleThroughput = 1000
     $script:testJsonMulti = @'
 {
     "_rid": "",


### PR DESCRIPTION
Adjust the minimum autoscale throughput for Cosmos DB from 4000 to 1000 and improve the cleanup process for Cosmos DB resources in integration tests. This addresses issues related to resource management.

- Fixes #493
- Fixes #494

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/PlagueHO/CosmosDB/495)
<!-- Reviewable:end -->
