### PR TITLE
Refactor Request Exception to move Exception Generation string to new function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `Get-CosmosDbRequestExceptionString` function to get the exception string
   from a Cosmos DB response. Refactored `Invoke-CosmosDbRequest` to use this
   function to get the exception string from the response.
+- Added testing for MacOS-13, MacOS-14, MacOS-15, Windows Server 2025, Ubuntu-24.04
+  and PowerShell 7.x on Windows Server 2019, 2022 and 2025 to the CI pipeline.
 
 ### Fixed
 
-- Updated CI pipeline to test on MacOS-13.
 - Converted CI pipeline Test stage to use matrix to reduce duplication of code.
 
 ## [5.1.0] - 2024-12-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Converted CI pipeline Test stage to use matrix to reduce duplication of code.
+- FIx spelling error of `ApplicationObjectId` variable in CI pipeline.
 
 ## [5.1.0] - 2024-12-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Updated CI pipeline to test on MacOS-13.
+- Converted CI pipeline Test stage to use matrix to reduce duplication of code.
 
 ## [5.1.0] - 2024-12-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `Get-CosmosDbRequestExceptionString` function to get the exception string
+  from a Cosmos DB response. Refactored `Invoke-CosmosDbRequest` to use this
+  function to get the exception string from the response.
+
+### Fixed
+
+- Updated CI pipeline to test on MacOS-13.
+
 ## [5.1.0] - 2024-12-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1250,12 +1250,13 @@ on the following systems:
 - Windows Server (using Windows PowerShell 5.1):
   - Windows Server 2019: Using [Azure Pipelines](https://dev.azure.com/dscottraynsford/GitHub/_build?definitionId=4).
   - Windows Server 2022: Using [Azure Pipelines](https://dev.azure.com/dscottraynsford/GitHub/_build?definitionId=4).
+  - Windows Server 2025: Using [Azure Pipelines](https://dev.azure.com/dscottraynsford/GitHub/_build?definitionId=4).
 - Linux (using PowerShell 7.x):
   - Ubuntu 20.04: Using [Azure Pipelines](https://dev.azure.com/dscottraynsford/GitHub/_build?definitionId=4).
   - Ubuntu 22.04: Using [Azure Pipelines](https://dev.azure.com/dscottraynsford/GitHub/_build?definitionId=4).
-- macOS (using PowerShell Core 6.x - to be changed to in future 7.x):
-  - macOS 11: Using [Azure Pipelines](https://dev.azure.com/dscottraynsford/GitHub/_build?definitionId=4).
-  - macOS 12: Using [Azure Pipelines](https://dev.azure.com/dscottraynsford/GitHub/_build?definitionId=4).
+  - Ubuntu 24.04: Using [Azure Pipelines](https://dev.azure.com/dscottraynsford/GitHub/_build?definitionId=4).
+- macOS (using PowerShell 7.x):
+  - macOS 13: Using [Azure Pipelines](https://dev.azure.com/dscottraynsford/GitHub/_build?definitionId=4).
 
 > This module is no longer tested on PowerShell Core 6.x as PowerShell 7.x
 > should be used. It should still work, but will no longer be verified. Issues with

--- a/README.md
+++ b/README.md
@@ -1257,6 +1257,8 @@ on the following systems:
   - Ubuntu 24.04: Using [Azure Pipelines](https://dev.azure.com/dscottraynsford/GitHub/_build?definitionId=4).
 - macOS (using PowerShell 7.x):
   - macOS 13: Using [Azure Pipelines](https://dev.azure.com/dscottraynsford/GitHub/_build?definitionId=4).
+  - macOS 14: Using [Azure Pipelines](https://dev.azure.com/dscottraynsford/GitHub/_build?definitionId=4).
+  - macOS 15: Using [Azure Pipelines](https://dev.azure.com/dscottraynsford/GitHub/_build?definitionId=4).
 
 > This module is no longer tested on PowerShell Core 6.x as PowerShell 7.x
 > should be used. It should still work, but will no longer be verified. Issues with

--- a/README.md
+++ b/README.md
@@ -1251,6 +1251,10 @@ on the following systems:
   - Windows Server 2019: Using [Azure Pipelines](https://dev.azure.com/dscottraynsford/GitHub/_build?definitionId=4).
   - Windows Server 2022: Using [Azure Pipelines](https://dev.azure.com/dscottraynsford/GitHub/_build?definitionId=4).
   - Windows Server 2025: Using [Azure Pipelines](https://dev.azure.com/dscottraynsford/GitHub/_build?definitionId=4).
+- Windows Server (using Windows PowerShell 7.x):
+  - Windows Server 2019: Using [Azure Pipelines](https://dev.azure.com/dscottraynsford/GitHub/_build?definitionId=4).
+  - Windows Server 2022: Using [Azure Pipelines](https://dev.azure.com/dscottraynsford/GitHub/_build?definitionId=4).
+  - Windows Server 2025: Using [Azure Pipelines](https://dev.azure.com/dscottraynsford/GitHub/_build?definitionId=4).
 - Linux (using PowerShell 7.x):
   - Ubuntu 20.04: Using [Azure Pipelines](https://dev.azure.com/dscottraynsford/GitHub/_build?definitionId=4).
   - Ubuntu 22.04: Using [Azure Pipelines](https://dev.azure.com/dscottraynsford/GitHub/_build?definitionId=4).

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ object using the `New-CosmosDbContext` cmdlet which you can then
 use to pass to the other Cosmos DB cmdlets in the module.
 
 To create the context object you will either need access to the
-primary primary or secondary keys from your Cosmos DB account or allow
+primary or secondary keys from your Cosmos DB account or allow
 the _CosmosDB Powershell module_ to retrieve the keys directly from
 the Azure management portal for you.
 
@@ -144,7 +144,7 @@ that will be used to authenticate requests to Cosmos DB.
 To create a context object using an _Entra ID Authorization Token_ you will need
 to set the `EntraIdToken` parameter to the token you have retrieved from Entra ID
 for the identity that you have given appropriate permissions to the `account`,
-`database` and/or `collection`. See [this page](https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-setup-rbac#concepts) for more infomration.
+`database` and/or `collection`. See [this page](https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-setup-rbac#concepts) for more information.
 
 ```powershell
 # Get an OAuth2 resource token from Entra ID for the Cosmos DB account.
@@ -463,7 +463,7 @@ New-CosmosDbCollection -Context $cosmosDbContext -Id MyNewCollection -PartitionK
 ```
 
 Create a collection in the database with the partition key 'id' using
-autoscaling with the maximum throughput of 40,000 RU/s and a mimimum of
+autoscaling with the maximum throughput of 40,000 RU/s and a minimum of
 4,000 RU/s:
 
 ```powershell

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,6 +67,7 @@ stages:
       - job: Unit_Test_Matrix
         displayName: 'Unit Test Matrix'
         strategy:
+          maxParallel: 5
           matrix:
             PS_Win2019:
               vmImage: windows-2019
@@ -83,6 +84,21 @@ stages:
               pesterScript: 'tests/Unit'
               testRunTitle: 'Unit (PowerShell 5.1 on Windows Server 2025)'
               pwsh: false
+            PS7_Win2019:
+              vmImage: windows-2019
+              pesterScript: 'tests/Unit'
+              testRunTitle: 'Unit (PowerShell 7 on Windows Server 2019)'
+              pwsh: true
+            PS7_Win2022:
+              vmImage: windows-2022
+              pesterScript: 'tests/Unit'
+              testRunTitle: 'Unit (PowerShell 7 on Windows Server 2022)'
+              pwsh: true
+            PS7_Win2025:
+              vmImage: windows-2025
+              pesterScript: 'tests/Unit'
+              testRunTitle: 'Unit (PowerShell 7 on Windows Server 2025)'
+              pwsh: true
             PS7_Ubuntu2004:
               vmImage: ubuntu-20.04
               pesterScript: 'tests/Unit'
@@ -159,6 +175,7 @@ stages:
         displayName: 'Integration Test Matrix'
         dependsOn: Unit_Test_Matrix
         strategy:
+          maxParallel: 5
           matrix:
             PS_Win2019:
               vmImage: windows-2019
@@ -175,6 +192,21 @@ stages:
               pesterScript: 'tests/Integration'
               testRunTitle: 'Integration (PowerShell 5.1 on Windows Server 2025)'
               pwsh: false
+            PS7_Win2019:
+              vmImage: windows-2019
+              pesterScript: 'tests/Integration'
+              testRunTitle: 'Integration (PowerShell 7 on Windows Server 2019)'
+              pwsh: true
+            PS7_Win2022:
+              vmImage: windows-2022
+              pesterScript: 'tests/Integration'
+              testRunTitle: 'Integration (PowerShell 7 on Windows Server 2022)'
+              pwsh: true
+            PS7_Win2025:
+              vmImage: windows-2025
+              pesterScript: 'tests/Integration'
+              testRunTitle: 'Integration (PowerShell 7 on Windows Server 2025)'
+              pwsh: true
             PS7_Ubuntu2004:
               vmImage: ubuntu-20.04
               pesterScript: 'tests/Integration'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -379,10 +379,10 @@ stages:
               testResultsFiles: '$(buildFolderName)/$(testResultFolderName)/NUnit*.xml'
               testRunTitle: 'Integration (Powershell 7 on Ubuntu 22.04)'
 
-      - job: Unit_Test_PSCore6_MacOS12
-        displayName: 'Unit Test (Powershell Core 6 on MacOS 12)'
+      - job: Unit_Test_PSCore6_MacOS13
+        displayName: 'Unit Test (Powershell Core 6 on MacOS 13)'
         pool:
-          vmImage: macos-12
+          vmImage: macos-13
 
         steps:
           - powershell: |
@@ -416,7 +416,7 @@ stages:
             inputs:
               testResultsFormat: 'NUnit'
               testResultsFiles: '$(buildFolderName)/$(testResultFolderName)/NUnit*.xml'
-              testRunTitle: 'Unit (Powershell Core 6 on MacOS 12)'
+              testRunTitle: 'Unit (Powershell Core 6 on MacOS 13)'
 
           - task: PublishCodeCoverageResults@2
             displayName: 'Publish Code Coverage'
@@ -425,11 +425,11 @@ stages:
               summaryFileLocation: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)/CodeCov*.xml'
               pathToSources: '$(Build.SourcesDirectory)/$(sourceFolderName)/'
 
-      - job: Integration_Test_PSCore6_MacOS12
-        dependsOn: Unit_Test_PSCore6_MacOS12
-        displayName: 'Integration Test (Powershell Core 6 on MacOS 12)'
+      - job: Integration_Test_PSCore6_MacOS13
+        dependsOn: Unit_Test_PSCore6_MacOS13
+        displayName: 'Integration Test (Powershell Core 6 on MacOS 13)'
         pool:
-          vmImage: macos-12
+          vmImage: macos-13
         timeoutInMinutes: 0
 
         steps:
@@ -465,7 +465,7 @@ stages:
             inputs:
               testResultsFormat: 'NUnit'
               testResultsFiles: '$(buildFolderName)/$(testResultFolderName)/NUnit*.xml'
-              testRunTitle: 'Integration (Powershell Core 6 on MacOS 12)'
+              testRunTitle: 'Integration (Powershell Core 6 on MacOS 13)'
 
   - stage: Deploy
     dependsOn: Test

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,6 +78,11 @@ stages:
               pesterScript: 'tests/Unit'
               testRunTitle: 'Unit (PowerShell 5.1 on Windows Server 2022)'
               pwsh: false
+            PS_Win2025:
+              vmImage: windows-2025
+              pesterScript: 'tests/Unit'
+              testRunTitle: 'Unit (PowerShell 5.1 on Windows Server 2025)'
+              pwsh: false
             PS7_Ubuntu2004:
               vmImage: ubuntu-20.04
               pesterScript: 'tests/Unit'
@@ -87,6 +92,11 @@ stages:
               vmImage: ubuntu-22.04
               pesterScript: 'tests/Unit'
               testRunTitle: 'Unit (PowerShell 7 on Ubuntu 22.04)'
+              pwsh: true
+            PS7_Ubuntu2404:
+              vmImage: ubuntu-24.04
+              pesterScript: 'tests/Unit'
+              testRunTitle: 'Unit (PowerShell 7 on Ubuntu 24.04)'
               pwsh: true
             PS7_MacOS13:
               vmImage: macos-13
@@ -149,6 +159,11 @@ stages:
               pesterScript: 'tests/Integration'
               testRunTitle: 'Integration (PowerShell 5.1 on Windows Server 2022)'
               pwsh: false
+            PS_Win2025:
+              vmImage: windows-2025
+              pesterScript: 'tests/Integration'
+              testRunTitle: 'Integration (PowerShell 5.1 on Windows Server 2025)'
+              pwsh: false
             PS7_Ubuntu2004:
               vmImage: ubuntu-20.04
               pesterScript: 'tests/Integration'
@@ -158,6 +173,11 @@ stages:
               vmImage: ubuntu-22.04
               pesterScript: 'tests/Integration'
               testRunTitle: 'Integration (PowerShell 7 on Ubuntu 22.04)'
+              pwsh: true
+            PS7_Ubuntu2404:
+              vmImage: ubuntu-24.04
+              pesterScript: 'tests/Integration'
+              testRunTitle: 'Integration (PowerShell 7 on Ubuntu 24.04)'
               pwsh: true
             PS7_MacOS13:
               vmImage: macos-13

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -103,6 +103,17 @@ stages:
               pesterScript: 'tests/Unit'
               testRunTitle: 'Unit (PowerShell 7 on MacOS 13)'
               pwsh: true
+            PS7_MacOS14:
+              vmImage: macos-14
+              pesterScript: 'tests/Unit'
+              testRunTitle: 'Unit (PowerShell 7 on MacOS 14)'
+              pwsh: true
+            PS7_MacOS15:
+              vmImage: macos-15
+              pesterScript: 'tests/Unit'
+              testRunTitle: 'Unit (PowerShell 7 on MacOS 15)'
+              pwsh: true
+
         pool:
           vmImage: $(vmImage)
         steps:
@@ -184,6 +195,17 @@ stages:
               pesterScript: 'tests/Integration'
               testRunTitle: 'Integration (PowerShell 7 on MacOS 13)'
               pwsh: true
+            PS7_MacOS14:
+              vmImage: macos-14
+              pesterScript: 'tests/Integration'
+              testRunTitle: 'Integration (PowerShell 7 on MacOS 14)'
+              pwsh: true
+            PS7_MacOS15:
+              vmImage: macos-15
+              pesterScript: 'tests/Integration'
+              testRunTitle: 'Integration (PowerShell 7 on MacOS 15)'
+              pwsh: true
+
         pool:
           vmImage: $(vmImage)
         steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -256,7 +256,7 @@ stages:
               azureApplicationPassword: $(azureApplicationPassword)
               azureSubscriptionId: $(azureSubscriptionId)
               azureTenantId: $(azureTenantId)
-              azureAppicationObjectId: $(azureAppicationObjectId)
+              azureApplicationObjectId: $(azureApplicationObjectId)
             inputs:
               filePath: './build.ps1'
               arguments: "-Tasks test -PesterScript '$(pesterScript)' -CodeCoverageThreshold 0"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,135 +63,41 @@ stages:
     variables:
       - group: CosmosDB.AzureSP
     jobs:
-      - job: Unit_Test_PS_Win2019
-        displayName: 'Unit Test (Powershell 5.1 on Windows Server 2019)'
-        pool:
-          vmImage: windows-2019
-
-        steps:
-          - powershell: |
-              $repositoryOwner,$repositoryName = $env:BUILD_REPOSITORY_NAME -split '/'
-              echo "##vso[task.setvariable variable=RepositoryOwner;isOutput=true]$repositoryOwner"
-              echo "##vso[task.setvariable variable=RepositoryName;isOutput=true]$repositoryName"
-            name: moduleBuildVariable
-            displayName: 'Set Environment Variables'
-
-          - task: DownloadPipelineArtifact@2
-            displayName: 'Download Pipeline Artifact'
-            inputs:
-              buildType: 'current'
-              artifactName: $(buildArtifactName)
-              targetPath: '$(Build.SourcesDirectory)/$(buildArtifactName)'
-
-          - task: PowerShell@2
-            name: test
-            displayName: 'Run Unit Test'
-            inputs:
-              filePath: './build.ps1'
-              arguments: "-tasks test -PesterScript 'tests/Unit'"
-
-          - task: PublishTestResults@2
-            displayName: 'Publish Test Results'
-            condition: succeededOrFailed()
-            inputs:
-              testResultsFormat: 'NUnit'
-              testResultsFiles: '$(buildFolderName)/$(testResultFolderName)/NUnit*.xml'
+      # Unit Test Matrix
+      - job: Unit_Test_Matrix
+        displayName: 'Unit Test Matrix'
+        strategy:
+          matrix:
+            PS_Win2019:
+              vmImage: windows-2019
+              pesterScript: 'tests/Unit'
               testRunTitle: 'Unit (PowerShell 5.1 on Windows Server 2019)'
-
-          - task: PublishCodeCoverageResults@2
-            displayName: 'Publish Code Coverage'
-            condition: succeededOrFailed()
-            inputs:
-              summaryFileLocation: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)/CodeCov*.xml'
-              pathToSources: '$(Build.SourcesDirectory)/$(sourceFolderName)/'
-
-      - job: Integration_Test_PS_Win2019
-        dependsOn: Unit_Test_PS_Win2019
-        displayName: 'Integration Test (Powershell 5.1 on Windows Server 2019)'
-        pool:
-          vmImage: windows-2019
-        timeoutInMinutes: 0
-
-        steps:
-          - task: DownloadPipelineArtifact@2
-            displayName: 'Download Pipeline Artifact'
-            inputs:
-              buildType: 'current'
-              artifactName: $(buildArtifactName)
-              targetPath: '$(Build.SourcesDirectory)/$(buildArtifactName)'
-
-          - task: PowerShell@2
-            name: test
-            displayName: 'Run Integration Test'
-            env:
-              azureApplicationId: $(azureApplicationId)
-              azureApplicationPassword: $(azureApplicationPassword)
-              azureSubscriptionId: $(azureSubscriptionId)
-              azureTenantId: $(azureTenantId)
-              azureAppicationObjectId: $(azureAppicationObjectId)
-            inputs:
-              filePath: './build.ps1'
-              arguments: "-Tasks test -PesterScript 'tests/Integration' -CodeCoverageThreshold 0"
-              pwsh: false
-
-          - task: PublishTestResults@2
-            displayName: 'Publish Test Results'
-            condition: succeededOrFailed()
-            inputs:
-              testResultsFormat: 'NUnit'
-              testResultsFiles: '$(buildFolderName)/$(testResultFolderName)/NUnit*.xml'
-              testRunTitle: 'Integration (PowerShell 5.1 on Windows Server 2019)'
-
-      - job: Unit_Test_PS_Win2022
-        displayName: 'Unit Test (Powershell 5.1 on Windows Server 2022)'
-        pool:
-          vmImage: windows-2022
-
-        steps:
-          - powershell: |
-              $repositoryOwner,$repositoryName = $env:BUILD_REPOSITORY_NAME -split '/'
-              echo "##vso[task.setvariable variable=RepositoryOwner;isOutput=true]$repositoryOwner"
-              echo "##vso[task.setvariable variable=RepositoryName;isOutput=true]$repositoryName"
-            name: moduleBuildVariable
-            displayName: 'Set Environment Variables'
-
-          - task: DownloadPipelineArtifact@2
-            displayName: 'Download Pipeline Artifact'
-            inputs:
-              buildType: 'current'
-              artifactName: $(buildArtifactName)
-              targetPath: '$(Build.SourcesDirectory)/$(buildArtifactName)'
-
-          - task: PowerShell@2
-            name: test
-            displayName: 'Run Unit Test'
-            inputs:
-              filePath: './build.ps1'
-              arguments: "-tasks test -PesterScript 'tests/Unit'"
-
-          - task: PublishTestResults@2
-            displayName: 'Publish Test Results'
-            condition: succeededOrFailed()
-            inputs:
-              testResultsFormat: 'NUnit'
-              testResultsFiles: '$(buildFolderName)/$(testResultFolderName)/NUnit*.xml'
+            PS_Win2022:
+              vmImage: windows-2022
+              pesterScript: 'tests/Unit'
               testRunTitle: 'Unit (PowerShell 5.1 on Windows Server 2022)'
-
-          - task: PublishCodeCoverageResults@2
-            displayName: 'Publish Code Coverage'
-            condition: succeededOrFailed()
-            inputs:
-              summaryFileLocation: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)/CodeCov*.xml'
-              pathToSources: '$(Build.SourcesDirectory)/$(sourceFolderName)/'
-
-      - job: Integration_Test_PS_Win2022
-        dependsOn: Unit_Test_PS_Win2022
-        displayName: 'Integration Test (Powershell 5.1 on Windows Server 2022)'
+            PS7_Ubuntu2004:
+              vmImage: ubuntu-20.04
+              pesterScript: 'tests/Unit'
+              testRunTitle: 'Unit (PowerShell 7 on Ubuntu 20.04)'
+            PS7_Ubuntu2204:
+              vmImage: ubuntu-22.04
+              pesterScript: 'tests/Unit'
+              testRunTitle: 'Unit (PowerShell 7 on Ubuntu 22.04)'
+            PS7_MacOS13:
+              vmImage: macos-13
+              pesterScript: 'tests/Unit'
+              testRunTitle: 'Unit (PowerShell 7 on MacOS 13)'
         pool:
-          vmImage: windows-2022
-        timeoutInMinutes: 0
-
+          vmImage: $(vmImage)
         steps:
+          - powershell: |
+              $repositoryOwner,$repositoryName = $env:BUILD_REPOSITORY_NAME -split '/'
+              echo "##vso[task.setvariable variable=RepositoryOwner;isOutput=true]$repositoryOwner"
+              echo "##vso[task.setvariable variable=RepositoryName;isOutput=true]$repositoryName"
+            name: moduleBuildVariable
+            displayName: 'Set Environment Variables'
+
           - task: DownloadPipelineArtifact@2
             displayName: 'Download Pipeline Artifact'
             inputs:
@@ -201,17 +107,10 @@ stages:
 
           - task: PowerShell@2
             name: test
-            displayName: 'Run Integration Test'
-            env:
-              azureApplicationId: $(azureApplicationId)
-              azureApplicationPassword: $(azureApplicationPassword)
-              azureSubscriptionId: $(azureSubscriptionId)
-              azureTenantId: $(azureTenantId)
-              azureAppicationObjectId: $(azureAppicationObjectId)
+            displayName: 'Run Unit Test'
             inputs:
               filePath: './build.ps1'
-              arguments: "-Tasks test -PesterScript 'tests/Integration' -CodeCoverageThreshold 0"
-              pwsh: false
+              arguments: "-tasks test -PesterScript '$(pesterScript)'"
 
           - task: PublishTestResults@2
             displayName: 'Publish Test Results'
@@ -219,57 +118,48 @@ stages:
             inputs:
               testResultsFormat: 'NUnit'
               testResultsFiles: '$(buildFolderName)/$(testResultFolderName)/NUnit*.xml'
+              testRunTitle: '$(testRunTitle)'
+
+          - task: PublishCodeCoverageResults@2
+            displayName: 'Publish Code Coverage'
+            condition: succeededOrFailed()
+            inputs:
+              summaryFileLocation: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)/CodeCov*.xml'
+              pathToSources: '$(Build.SourcesDirectory)/$(sourceFolderName)/'
+
+      # Integration Test Matrix
+      - job: Integration_Test_Matrix
+        displayName: 'Integration Test Matrix'
+        dependsOn: Unit_Test_Matrix
+        strategy:
+          matrix:
+            PS_Win2019:
+              vmImage: windows-2019
+              pesterScript: 'tests/Integration'
+              testRunTitle: 'Integration (PowerShell 5.1 on Windows Server 2019)'
+              dependsOnJob: Unit_Test_Matrix.PS_Win2019
+            PS_Win2022:
+              vmImage: windows-2022
+              pesterScript: 'tests/Integration'
               testRunTitle: 'Integration (PowerShell 5.1 on Windows Server 2022)'
-
-      - job: Unit_Test_PS7_Ubuntu2004
-        displayName: 'Unit Test (Powershell 7 on Ubuntu 20.04)'
+              dependsOnJob: Unit_Test_Matrix.PS_Win2022
+            PS7_Ubuntu2004:
+              vmImage: ubuntu-20.04
+              pesterScript: 'tests/Integration'
+              testRunTitle: 'Integration (PowerShell 7 on Ubuntu 20.04)'
+              dependsOnJob: Unit_Test_Matrix.PS7_Ubuntu2004
+            PS7_Ubuntu2204:
+              vmImage: ubuntu-22.04
+              pesterScript: 'tests/Integration'
+              testRunTitle: 'Integration (PowerShell 7 on Ubuntu 22.04)'
+              dependsOnJob: Unit_Test_Matrix.PS7_Ubuntu2204
+            PS7_MacOS13:
+              vmImage: macos-13
+              pesterScript: 'tests/Integration'
+              testRunTitle: 'Integration (PowerShell 7 on MacOS 13)'
+              dependsOnJob: Unit_Test_Matrix.PS7_MacOS13
         pool:
-          vmImage: ubuntu-20.04
-
-        steps:
-          - powershell: |
-              $repositoryOwner,$repositoryName = $env:BUILD_REPOSITORY_NAME -split '/'
-              echo "##vso[task.setvariable variable=RepositoryOwner;isOutput=true]$repositoryOwner"
-              echo "##vso[task.setvariable variable=RepositoryName;isOutput=true]$repositoryName"
-            name: moduleBuildVariable
-            displayName: 'Set Environment Variables'
-
-          - task: DownloadPipelineArtifact@2
-            displayName: 'Download Pipeline Artifact'
-            inputs:
-              buildType: 'current'
-              artifactName: $(buildArtifactName)
-              targetPath: '$(Build.SourcesDirectory)/$(buildArtifactName)'
-
-          - task: PowerShell@2
-            name: test
-            displayName: 'Run Unit Test'
-            inputs:
-              filePath: './build.ps1'
-              arguments: "-tasks test -PesterScript 'tests/Unit'"
-
-          - task: PublishTestResults@2
-            displayName: 'Publish Test Results'
-            condition: succeededOrFailed()
-            inputs:
-              testResultsFormat: 'NUnit'
-              testResultsFiles: '$(buildFolderName)/$(testResultFolderName)/NUnit*.xml'
-              testRunTitle: 'Unit (Powershell 7 on Ubuntu 20.04)'
-
-          - task: PublishCodeCoverageResults@2
-            displayName: 'Publish Code Coverage'
-            condition: succeededOrFailed()
-            inputs:
-              summaryFileLocation: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)/CodeCov*.xml'
-              pathToSources: '$(Build.SourcesDirectory)/$(sourceFolderName)/'
-
-      - job: Integration_Test_PS7_Ubuntu2004
-        dependsOn: Unit_Test_PS7_Ubuntu2004
-        displayName: 'Integration Test (Powershell 7 on Ubuntu 20.04)'
-        pool:
-          vmImage: ubuntu-20.04
-        timeoutInMinutes: 0
-
+          vmImage: $(vmImage)
         steps:
           - task: DownloadPipelineArtifact@2
             displayName: 'Download Pipeline Artifact'
@@ -289,7 +179,7 @@ stages:
               azureAppicationObjectId: $(azureAppicationObjectId)
             inputs:
               filePath: './build.ps1'
-              arguments: "-Tasks test -PesterScript 'tests/Integration' -CodeCoverageThreshold 0"
+              arguments: "-Tasks test -PesterScript '$(pesterScript)' -CodeCoverageThreshold 0"
               pwsh: false
 
           - task: PublishTestResults@2
@@ -298,174 +188,7 @@ stages:
             inputs:
               testResultsFormat: 'NUnit'
               testResultsFiles: '$(buildFolderName)/$(testResultFolderName)/NUnit*.xml'
-              testRunTitle: 'Integration (Powershell 7 on Ubuntu 20.04)'
-
-      - job: Unit_Test_PS7_Ubuntu2204
-        displayName: 'Unit Test (Powershell 7 on Ubuntu 22.04)'
-        pool:
-          vmImage: ubuntu-22.04
-
-        steps:
-          - powershell: |
-              $repositoryOwner,$repositoryName = $env:BUILD_REPOSITORY_NAME -split '/'
-              echo "##vso[task.setvariable variable=RepositoryOwner;isOutput=true]$repositoryOwner"
-              echo "##vso[task.setvariable variable=RepositoryName;isOutput=true]$repositoryName"
-            name: moduleBuildVariable
-            displayName: 'Set Environment Variables'
-
-          - task: DownloadPipelineArtifact@2
-            displayName: 'Download Pipeline Artifact'
-            inputs:
-              buildType: 'current'
-              artifactName: $(buildArtifactName)
-              targetPath: '$(Build.SourcesDirectory)/$(buildArtifactName)'
-
-          - task: PowerShell@2
-            name: test
-            displayName: 'Run Unit Test'
-            inputs:
-              filePath: './build.ps1'
-              arguments: "-tasks test -PesterScript 'tests/Unit'"
-
-          - task: PublishTestResults@2
-            displayName: 'Publish Test Results'
-            condition: succeededOrFailed()
-            inputs:
-              testResultsFormat: 'NUnit'
-              testResultsFiles: '$(buildFolderName)/$(testResultFolderName)/NUnit*.xml'
-              testRunTitle: 'Unit (Powershell 7 on Ubuntu 22.04)'
-
-          - task: PublishCodeCoverageResults@2
-            displayName: 'Publish Code Coverage'
-            condition: succeededOrFailed()
-            inputs:
-              summaryFileLocation: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)/CodeCov*.xml'
-              pathToSources: '$(Build.SourcesDirectory)/$(sourceFolderName)/'
-
-      - job: Integration_Test_PS7_Ubuntu2204
-        dependsOn: Unit_Test_PS7_Ubuntu2204
-        displayName: 'Integration Test (Powershell 7 on Ubuntu 22.04)'
-        pool:
-          vmImage: ubuntu-22.04
-        timeoutInMinutes: 0
-
-        steps:
-          - task: DownloadPipelineArtifact@2
-            displayName: 'Download Pipeline Artifact'
-            inputs:
-              buildType: 'current'
-              artifactName: $(buildArtifactName)
-              targetPath: '$(Build.SourcesDirectory)/$(buildArtifactName)'
-
-          - task: PowerShell@2
-            name: test
-            displayName: 'Run Integration Test'
-            env:
-              azureApplicationId: $(azureApplicationId)
-              azureApplicationPassword: $(azureApplicationPassword)
-              azureSubscriptionId: $(azureSubscriptionId)
-              azureTenantId: $(azureTenantId)
-              azureAppicationObjectId: $(azureAppicationObjectId)
-            inputs:
-              filePath: './build.ps1'
-              arguments: "-Tasks test -PesterScript 'tests/Integration' -CodeCoverageThreshold 0"
-              pwsh: false
-
-          - task: PublishTestResults@2
-            displayName: 'Publish Test Results'
-            condition: succeededOrFailed()
-            inputs:
-              testResultsFormat: 'NUnit'
-              testResultsFiles: '$(buildFolderName)/$(testResultFolderName)/NUnit*.xml'
-              testRunTitle: 'Integration (Powershell 7 on Ubuntu 22.04)'
-
-      - job: Unit_Test_PSCore6_MacOS13
-        displayName: 'Unit Test (Powershell Core 6 on MacOS 13)'
-        pool:
-          vmImage: macos-13
-
-        steps:
-          - powershell: |
-              $repositoryOwner,$repositoryName = $env:BUILD_REPOSITORY_NAME -split '/'
-              echo "##vso[task.setvariable variable=RepositoryOwner;isOutput=true]$repositoryOwner"
-              echo "##vso[task.setvariable variable=RepositoryName;isOutput=true]$repositoryName"
-            name: moduleBuildVariable
-            displayName: 'Set Environment Variables'
-
-          - task: DownloadPipelineArtifact@2
-            displayName: 'Download Pipeline Artifact'
-            inputs:
-              buildType: 'current'
-              artifactName: $(buildArtifactName)
-              targetPath: '$(Build.SourcesDirectory)/$(buildArtifactName)'
-
-          - powershell: |
-              Uninstall-Module -Name Az -Force
-            displayName: 'Uninstall Az Module'
-
-          - task: PowerShell@2
-            name: test
-            displayName: 'Run Unit Test'
-            inputs:
-              filePath: './build.ps1'
-              arguments: "-tasks test -PesterScript 'tests/Unit'"
-
-          - task: PublishTestResults@2
-            displayName: 'Publish Test Results'
-            condition: succeededOrFailed()
-            inputs:
-              testResultsFormat: 'NUnit'
-              testResultsFiles: '$(buildFolderName)/$(testResultFolderName)/NUnit*.xml'
-              testRunTitle: 'Unit (Powershell Core 6 on MacOS 13)'
-
-          - task: PublishCodeCoverageResults@2
-            displayName: 'Publish Code Coverage'
-            condition: succeededOrFailed()
-            inputs:
-              summaryFileLocation: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)/CodeCov*.xml'
-              pathToSources: '$(Build.SourcesDirectory)/$(sourceFolderName)/'
-
-      - job: Integration_Test_PSCore6_MacOS13
-        dependsOn: Unit_Test_PSCore6_MacOS13
-        displayName: 'Integration Test (Powershell Core 6 on MacOS 13)'
-        pool:
-          vmImage: macos-13
-        timeoutInMinutes: 0
-
-        steps:
-          - task: DownloadPipelineArtifact@2
-            displayName: 'Download Pipeline Artifact'
-            inputs:
-              buildType: 'current'
-              artifactName: $(buildArtifactName)
-              targetPath: '$(Build.SourcesDirectory)/$(buildArtifactName)'
-
-          - powershell: |
-              Uninstall-Module -Name Az -Force
-              $null = Remove-Item -Path '~/.Azure' -Recurse -Force
-            displayName: 'Uninstall Az Module'
-
-          - task: PowerShell@2
-            name: test
-            displayName: 'Run Integration Test'
-            env:
-              azureApplicationId: $(azureApplicationId)
-              azureApplicationPassword: $(azureApplicationPassword)
-              azureSubscriptionId: $(azureSubscriptionId)
-              azureTenantId: $(azureTenantId)
-              azureAppicationObjectId: $(azureAppicationObjectId)
-            inputs:
-              filePath: './build.ps1'
-              arguments: "-Tasks test -PesterScript 'tests/Integration' -CodeCoverageThreshold 0"
-              pwsh: false
-
-          - task: PublishTestResults@2
-            displayName: 'Publish Test Results'
-            condition: succeededOrFailed()
-            inputs:
-              testResultsFormat: 'NUnit'
-              testResultsFiles: '$(buildFolderName)/$(testResultFolderName)/NUnit*.xml'
-              testRunTitle: 'Integration (Powershell Core 6 on MacOS 13)'
+              testRunTitle: '$(testRunTitle)'
 
   - stage: Deploy
     dependsOn: Test

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,22 +72,27 @@ stages:
               vmImage: windows-2019
               pesterScript: 'tests/Unit'
               testRunTitle: 'Unit (PowerShell 5.1 on Windows Server 2019)'
+              pwsh: false
             PS_Win2022:
               vmImage: windows-2022
               pesterScript: 'tests/Unit'
               testRunTitle: 'Unit (PowerShell 5.1 on Windows Server 2022)'
+              pwsh: false
             PS7_Ubuntu2004:
               vmImage: ubuntu-20.04
               pesterScript: 'tests/Unit'
               testRunTitle: 'Unit (PowerShell 7 on Ubuntu 20.04)'
+              pwsh: true
             PS7_Ubuntu2204:
               vmImage: ubuntu-22.04
               pesterScript: 'tests/Unit'
               testRunTitle: 'Unit (PowerShell 7 on Ubuntu 22.04)'
+              pwsh: true
             PS7_MacOS13:
               vmImage: macos-13
               pesterScript: 'tests/Unit'
               testRunTitle: 'Unit (PowerShell 7 on MacOS 13)'
+              pwsh: true
         pool:
           vmImage: $(vmImage)
         steps:
@@ -111,6 +116,7 @@ stages:
             inputs:
               filePath: './build.ps1'
               arguments: "-tasks test -PesterScript '$(pesterScript)'"
+              pwsh: $(pwsh)
 
           - task: PublishTestResults@2
             displayName: 'Publish Test Results'
@@ -137,27 +143,27 @@ stages:
               vmImage: windows-2019
               pesterScript: 'tests/Integration'
               testRunTitle: 'Integration (PowerShell 5.1 on Windows Server 2019)'
-              dependsOnJob: Unit_Test_Matrix.PS_Win2019
+              pwsh: false
             PS_Win2022:
               vmImage: windows-2022
               pesterScript: 'tests/Integration'
               testRunTitle: 'Integration (PowerShell 5.1 on Windows Server 2022)'
-              dependsOnJob: Unit_Test_Matrix.PS_Win2022
+              pwsh: false
             PS7_Ubuntu2004:
               vmImage: ubuntu-20.04
               pesterScript: 'tests/Integration'
               testRunTitle: 'Integration (PowerShell 7 on Ubuntu 20.04)'
-              dependsOnJob: Unit_Test_Matrix.PS7_Ubuntu2004
+              pwsh: true
             PS7_Ubuntu2204:
               vmImage: ubuntu-22.04
               pesterScript: 'tests/Integration'
               testRunTitle: 'Integration (PowerShell 7 on Ubuntu 22.04)'
-              dependsOnJob: Unit_Test_Matrix.PS7_Ubuntu2204
+              pwsh: true
             PS7_MacOS13:
               vmImage: macos-13
               pesterScript: 'tests/Integration'
               testRunTitle: 'Integration (PowerShell 7 on MacOS 13)'
-              dependsOnJob: Unit_Test_Matrix.PS7_MacOS13
+              pwsh: true
         pool:
           vmImage: $(vmImage)
         steps:
@@ -180,7 +186,7 @@ stages:
             inputs:
               filePath: './build.ps1'
               arguments: "-Tasks test -PesterScript '$(pesterScript)' -CodeCoverageThreshold 0"
-              pwsh: false
+              pwsh: $(pwsh)
 
           - task: PublishTestResults@2
             displayName: 'Publish Test Results'

--- a/source/Private/utils/Get-CosmosDbRequestExceptionString.ps1
+++ b/source/Private/utils/Get-CosmosDbRequestExceptionString.ps1
@@ -34,7 +34,7 @@ function Get-CosmosDbRequestExceptionString
         $ErrorRecord
     )
 
-    if ($PSEdition -eq 'Core')
+    if ((Get-Variable -Name 'PSEdition').Value -eq 'Core')
     {
         # PowerShell Core: Use ErrorDetails
         return $ErrorRecord.ErrorDetails
@@ -42,7 +42,7 @@ function Get-CosmosDbRequestExceptionString
     else
     {
         # Windows PowerShell: Read the response stream
-        if ($null -ne $ErrorRecord.Exception.Response)
+        if ($null -ne $ErrorRecord.Exception)
         {
             $exceptionStream = $ErrorRecord.Exception.Response.GetResponseStream()
             $streamReader = New-Object -TypeName System.IO.StreamReader -ArgumentList $exceptionStream
@@ -50,7 +50,7 @@ function Get-CosmosDbRequestExceptionString
         }
         else
         {
-            return 'Exception response is null.'
+            return 'Exception is null.'
         }
     }
 }

--- a/source/Private/utils/Get-CosmosDbRequestExceptionString.ps1
+++ b/source/Private/utils/Get-CosmosDbRequestExceptionString.ps1
@@ -1,0 +1,48 @@
+<#
+.SYNOPSIS
+    Extracts detailed exception information from an ErrorRecord for Cosmos DB requests.
+
+.DESCRIPTION
+    The Get-CosmosDbRequestExceptionString function retrieves detailed exception information
+    from an ErrorRecord object. It handles both PowerShell Core and Windows PowerShell
+    environments by using the appropriate method to extract the exception details.
+
+    In PowerShell Core, it uses the ErrorDetails property. In Windows PowerShell, it reads
+    the response stream from the exception object.
+
+.PARAMETER ErrorRecord
+    The ErrorRecord object containing the exception details. This parameter is mandatory.
+
+.OUTPUTS
+    System.String
+        Returns a string containing the detailed exception information.
+
+.EXAMPLE
+    $errorRecord = Get-ErrorRecordFromSomeOperation
+    $exceptionDetails = Get-CosmosDbRequestExceptionString -ErrorRecord $errorRecord
+
+    Retrieves the detailed exception information from the provided ErrorRecord.
+#>
+function Get-CosmosDbRequestExceptionString
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.ErrorRecord]
+        $ErrorRecord
+    )
+
+    if ($PSEdition -eq 'Core')
+    {
+        # PowerShell Core: Use ErrorDetails
+        return $ErrorRecord.ErrorDetails
+    }
+    else
+    {
+        # Windows PowerShell: Read the response stream
+        $exceptionStream = $ErrorRecord.Exception.Response.GetResponseStream()
+        $streamReader = New-Object -TypeName System.IO.StreamReader -ArgumentList $exceptionStream
+        return $streamReader.ReadToEnd()
+    }
+}

--- a/source/Private/utils/Get-CosmosDbRequestExceptionString.ps1
+++ b/source/Private/utils/Get-CosmosDbRequestExceptionString.ps1
@@ -26,6 +26,7 @@
 function Get-CosmosDbRequestExceptionString
 {
     [CmdletBinding()]
+    [OutputType([System.String])]
     param
     (
         [Parameter(Mandatory = $true)]
@@ -41,8 +42,15 @@ function Get-CosmosDbRequestExceptionString
     else
     {
         # Windows PowerShell: Read the response stream
-        $exceptionStream = $ErrorRecord.Exception.Response.GetResponseStream()
-        $streamReader = New-Object -TypeName System.IO.StreamReader -ArgumentList $exceptionStream
-        return $streamReader.ReadToEnd()
+        if ($null -ne $ErrorRecord.Exception.Response)
+        {
+            $exceptionStream = $ErrorRecord.Exception.Response.GetResponseStream()
+            $streamReader = New-Object -TypeName System.IO.StreamReader -ArgumentList $exceptionStream
+            return $streamReader.ReadToEnd()
+        }
+        else
+        {
+            return 'Exception response is null.'
+        }
     }
 }

--- a/source/Private/utils/Get-CosmosDbUri.ps1
+++ b/source/Private/utils/Get-CosmosDbUri.ps1
@@ -1,3 +1,37 @@
+<#
+.SYNOPSIS
+    Constructs a Cosmos DB URI based on the account name and environment or base hostname.
+
+.DESCRIPTION
+    The Get-CosmosDbUri function generates a URI for a Cosmos DB account.
+    It supports specifying the environment (e.g., AzureCloud, AzureUSGovernment, AzureChinaCloud)
+    or directly providing a base hostname.
+
+.PARAMETER Account
+    The name of the Cosmos DB account. This is required.
+
+.PARAMETER BaseHostname
+    The base hostname for the Cosmos DB URI. Defaults to 'documents.azure.com'.
+    This parameter is used when the 'Uri' parameter set is selected.
+
+.PARAMETER Environment
+    The environment for the Cosmos DB account (e.g., AzureCloud, AzureUSGovernment, AzureChinaCloud).
+    This parameter is used when the 'Environment' parameter set is selected.
+
+.OUTPUTS
+    System.Uri
+        Returns a URI object representing the Cosmos DB account URI.
+
+.EXAMPLE
+    Get-CosmosDbUri -Account 'mycosmosdbaccount' -Environment AzureCloud
+
+    Constructs a URI for the Cosmos DB account 'mycosmosdbaccount' in the AzureCloud environment.
+
+.EXAMPLE
+    Get-CosmosDbUri -Account 'mycosmosdbaccount' -BaseHostname 'documents.azure.cn'
+
+    Constructs a URI for the Cosmos DB account 'mycosmosdbaccount' using the specified base hostname.
+#>
 function Get-CosmosDbUri
 {
 

--- a/source/Private/utils/Invoke-CosmosDbRequest.ps1
+++ b/source/Private/utils/Invoke-CosmosDbRequest.ps1
@@ -294,18 +294,7 @@ function Invoke-CosmosDbRequest
                     In a future version a custom exception type for CosmosDB that
                     contains this additional information.
                 #>
-
-                if ($PSEdition -eq 'Core')
-                {
-                    # https://get-powershellblog.blogspot.com/2017/11/powershell-core-web-cmdlets-in-depth.html#L13
-                    $exceptionResponse = $_.ErrorDetails
-                }
-                else
-                {
-                    $exceptionStream = $_.Exception.Response.GetResponseStream()
-                    $streamReader = New-Object -TypeName System.IO.StreamReader -ArgumentList $exceptionStream
-                    $exceptionResponse = $streamReader.ReadToEnd()
-                }
+                $exceptionResponse = Get-CosmosDbRequestExceptionString -ErrorRecord $_
 
                 if ($exceptionResponse)
                 {

--- a/tests/Unit/CosmosDB.utils.Tests.ps1
+++ b/tests/Unit/CosmosDB.utils.Tests.ps1
@@ -1054,7 +1054,10 @@ console.log("done");
 
         Context 'When called in PowerShell Core with ErrorDetails' {
             Mock -CommandName Get-Variable -MockWith {
-                return @{ PSEdition = 'Core' }
+                return @{
+                    Name = 'PSEdition'
+                    Value = 'Core'
+                }
             }
             $script:result = $null
 
@@ -1063,7 +1066,9 @@ console.log("done");
                 $errorRecord = [System.Management.Automation.ErrorRecord]::new($exception, 'CoreErrorId', [System.Management.Automation.ErrorCategory]::NotSpecified, $null)
                 $errorRecord.ErrorDetails = [System.Management.Automation.ErrorDetails]::new('Core Error Details')
 
-                { $script:result = Get-CosmosDbRequestExceptionString -ErrorRecord $errorRecord } | Should -Not -Throw
+                {
+                    $script:result = Get-CosmosDbRequestExceptionString -ErrorRecord $errorRecord
+                } | Should -Not -Throw
             }
 
             It 'Should return ErrorDetails' {
@@ -1073,7 +1078,10 @@ console.log("done");
 
         Context 'When called with ErrorRecord missing Response in Windows PowerShell' {
             Mock -CommandName Get-Variable -MockWith {
-                return @{ PSEdition = 'Desktop' }
+                return @{
+                    Name = 'PSEdition'
+                    Value = 'Core'
+                }
             }
             $script:result = $null
 
@@ -1081,7 +1089,9 @@ console.log("done");
                 $webException = [System.Net.WebException]::new('Windows PowerShell Exception')
                 $errorRecord = [System.Management.Automation.ErrorRecord]::new($webException, 'WindowsErrorId', [System.Management.Automation.ErrorCategory]::NotSpecified, $null)
 
-                { $script:result = Get-CosmosDbRequestExceptionString -ErrorRecord $errorRecord } | Should -Not -Throw
+                {
+                    $script:result = Get-CosmosDbRequestExceptionString -ErrorRecord $errorRecord
+                } | Should -Not -Throw
             }
 
             It 'Should return null' {

--- a/tests/Unit/CosmosDB.utils.Tests.ps1
+++ b/tests/Unit/CosmosDB.utils.Tests.ps1
@@ -1057,9 +1057,9 @@ console.log("done");
             $script:result = $null
 
             It 'Should not throw exception' {
-                $errorRecord = [pscustomobject]@{
-                    ErrorDetails = 'Core Error Details'
-                }
+                $exception = [System.Exception]::new('Core Exception')
+                $errorRecord = [System.Management.Automation.ErrorRecord]::new($exception, 'CoreErrorId', [System.Management.Automation.ErrorCategory]::NotSpecified, $null)
+                $errorRecord.ErrorDetails = [System.Management.Automation.ErrorDetails]::new('Core Error Details')
 
                 { $script:result = Get-CosmosDbRequestExceptionString -ErrorRecord $errorRecord } | Should -Not -Throw
             }
@@ -1080,13 +1080,11 @@ console.log("done");
                 $writer.Flush()
                 $mockStream.Position = 0
 
-                $errorRecord = [pscustomobject]@{
-                    Exception = [pscustomobject]@{
-                        Response = [pscustomobject]@{
-                            GetResponseStream = { $mockStream }
-                        }
-                    }
+                $webException = [System.Net.WebException]::new('Windows Exception')
+                $webException.Response = [pscustomobject]@{
+                    GetResponseStream = { $mockStream }
                 }
+                $errorRecord = [System.Management.Automation.ErrorRecord]::new($webException, 'WindowsErrorId', [System.Management.Automation.ErrorCategory]::NotSpecified, $null)
 
                 { $script:result = Get-CosmosDbRequestExceptionString -ErrorRecord $errorRecord } | Should -Not -Throw
             }
@@ -1101,7 +1099,8 @@ console.log("done");
             $script:result = $null
 
             It 'Should not throw exception' {
-                $errorRecord = [pscustomobject]@{}
+                $exception = [System.Exception]::new('Core Exception')
+                $errorRecord = [System.Management.Automation.ErrorRecord]::new($exception, 'CoreErrorId', [System.Management.Automation.ErrorCategory]::NotSpecified, $null)
 
                 { $script:result = Get-CosmosDbRequestExceptionString -ErrorRecord $errorRecord } | Should -Not -Throw
             }
@@ -1116,9 +1115,8 @@ console.log("done");
             $script:result = $null
 
             It 'Should not throw exception' {
-                $errorRecord = [pscustomobject]@{
-                    Exception = [pscustomobject]@{}
-                }
+                $webException = [System.Net.WebException]::new('Windows Exception')
+                $errorRecord = [System.Management.Automation.ErrorRecord]::new($webException, 'WindowsErrorId', [System.Management.Automation.ErrorCategory]::NotSpecified, $null)
 
                 { $script:result = Get-CosmosDbRequestExceptionString -ErrorRecord $errorRecord } | Should -Not -Throw
             }
@@ -1133,7 +1131,7 @@ console.log("done");
             $script:result = $null
 
             It 'Should not throw exception' {
-                $errorRecord = [pscustomobject]@{}
+                $errorRecord = [System.Management.Automation.ErrorRecord]::new($null, 'WindowsErrorId', [System.Management.Automation.ErrorCategory]::NotSpecified, $null)
 
                 { $script:result = Get-CosmosDbRequestExceptionString -ErrorRecord $errorRecord } | Should -Not -Throw
             }
@@ -1682,7 +1680,7 @@ console.log("done");
             $InvokeWebRequest_parameterfilter = {
                 $Method -eq 'Get' -and `
                     $ContentType -eq 'application/json' -and `
-                    $Uri -eq ('{0}dbs/{1}/{2}' -f $script:testContext.BaseUri, $script:testContext.Database, 'users')
+                                       $Uri -eq ('{0}dbs/{1}/{2}' -f $script:testContext.BaseUri, $script:testContext.Database, 'users')
             }
 
             Mock `

--- a/tests/Unit/CosmosDB.utils.Tests.ps1
+++ b/tests/Unit/CosmosDB.utils.Tests.ps1
@@ -1053,11 +1053,13 @@ console.log("done");
         }
 
         Context 'When called in PowerShell Core with ErrorDetails' {
-            Mock -CommandName Get-Variable -MockWith { return @{ PSEdition = 'Core' } }
+            Mock -CommandName Get-Variable -MockWith {
+                return @{ PSEdition = 'Core' }
+            }
             $script:result = $null
 
             It 'Should not throw exception' {
-                $exception = [System.Exception]::new('Core Exception')
+                $exception = [System.Exception]::new('PowerShell Core Exception')
                 $errorRecord = [System.Management.Automation.ErrorRecord]::new($exception, 'CoreErrorId', [System.Management.Automation.ErrorCategory]::NotSpecified, $null)
                 $errorRecord.ErrorDetails = [System.Management.Automation.ErrorDetails]::new('Core Error Details')
 
@@ -1069,69 +1071,15 @@ console.log("done");
             }
         }
 
-        Context 'When called in Windows PowerShell with Response Stream' {
-            Mock -CommandName Get-Variable -MockWith { return @{ PSEdition = 'Desktop' } }
-            $script:result = $null
-
-            It 'Should not throw exception' {
-                $mockStream = [System.IO.MemoryStream]::new()
-                $writer = [System.IO.StreamWriter]::new($mockStream)
-                $writer.Write('Windows Error Details')
-                $writer.Flush()
-                $mockStream.Position = 0
-
-                $webException = [System.Net.WebException]::new('Windows Exception')
-                $webException.Response = [pscustomobject]@{
-                    GetResponseStream = { $mockStream }
-                }
-                $errorRecord = [System.Management.Automation.ErrorRecord]::new($webException, 'WindowsErrorId', [System.Management.Automation.ErrorCategory]::NotSpecified, $null)
-
-                { $script:result = Get-CosmosDbRequestExceptionString -ErrorRecord $errorRecord } | Should -Not -Throw
-            }
-
-            It 'Should return Response Stream content' {
-                $script:result | Should -Be 'Windows Error Details'
-            }
-        }
-
-        Context 'When called with ErrorRecord missing ErrorDetails in PowerShell Core' {
-            Mock -CommandName Get-Variable -MockWith { return @{ PSEdition = 'Core' } }
-            $script:result = $null
-
-            It 'Should not throw exception' {
-                $exception = [System.Exception]::new('Core Exception')
-                $errorRecord = [System.Management.Automation.ErrorRecord]::new($exception, 'CoreErrorId', [System.Management.Automation.ErrorCategory]::NotSpecified, $null)
-
-                { $script:result = Get-CosmosDbRequestExceptionString -ErrorRecord $errorRecord } | Should -Not -Throw
-            }
-
-            It 'Should return null' {
-                $script:result | Should -BeNullOrEmpty
-            }
-        }
-
         Context 'When called with ErrorRecord missing Response in Windows PowerShell' {
-            Mock -CommandName Get-Variable -MockWith { return @{ PSEdition = 'Desktop' } }
+            Mock -CommandName Get-Variable -MockWith {
+                return @{ PSEdition = 'Desktop' }
+            }
             $script:result = $null
 
             It 'Should not throw exception' {
-                $webException = [System.Net.WebException]::new('Windows Exception')
+                $webException = [System.Net.WebException]::new('Windows PowerShell Exception')
                 $errorRecord = [System.Management.Automation.ErrorRecord]::new($webException, 'WindowsErrorId', [System.Management.Automation.ErrorCategory]::NotSpecified, $null)
-
-                { $script:result = Get-CosmosDbRequestExceptionString -ErrorRecord $errorRecord } | Should -Not -Throw
-            }
-
-            It 'Should return null' {
-                $script:result | Should -BeNullOrEmpty
-            }
-        }
-
-        Context 'When called with ErrorRecord missing Exception in Windows PowerShell' {
-            Mock -CommandName Get-Variable -MockWith { return @{ PSEdition = 'Desktop' } }
-            $script:result = $null
-
-            It 'Should not throw exception' {
-                $errorRecord = [System.Management.Automation.ErrorRecord]::new($null, 'WindowsErrorId', [System.Management.Automation.ErrorCategory]::NotSpecified, $null)
 
                 { $script:result = Get-CosmosDbRequestExceptionString -ErrorRecord $errorRecord } | Should -Not -Throw
             }


### PR DESCRIPTION
# Pull Request

## Improvements / Enhancements

- Update CI pipeline to use matrix testing to reduce code duplication
- Add Get-CosmosDbRequestExceptionString function to generate the string output when exception occurs. This is to prepare for masking authorization keys.
- Correct name of ApplicationObjectId variable.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/PlagueHO/CosmosDB/499)
<!-- Reviewable:end -->
