### PR TITLE
Update Invoke-CosmosDbReqiest to throw a CosmosDB.ResponseExeption instead of a HttpReponseException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `Get-CosmosDbRequestExceptionString` function to get the exception string
   from a Cosmos DB response. Refactored `Invoke-CosmosDbRequest` to use this
   function to get the exception string from the response.
-- Added testing for MacOS-13, MacOS-14, MacOS-15, Windows Server 2025, Ubuntu-24.04
-  and PowerShell 7.x on Windows Server 2019, 2022 and 2025 to the CI pipeline.
 
 ### Fixed
 
+- Added testing for MacOS-13, MacOS-14, MacOS-15, Windows Server 2025, Ubuntu-24.04
+  and PowerShell 7.x on Windows Server 2019, 2022 and 2025 to the CI pipeline.
 - Converted CI pipeline Test stage to use matrix to reduce duplication of code.
 - FIx spelling error of `ApplicationObjectId` variable in CI pipeline.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Microsoft.PowerShell.Commands.HttpResponseException` (PowerShell 7.x) or
   `System.Net.HttpWebResponse` (PowerShell 5.x) objects. This is to prevent
   authorization Headers from being returned in the exception object. In future
-  the filtered headers may be returned in the `CosmosDb.ResponseException` object.
+  the filtered headers and other response information may be included in the
+  `CosmosDb.ResponseException` object.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- BREAKING CHANGE: Exceptions returned by `Invoke-CosmosDbRequest` are now
+  `CosmosDb.ResponseException` objects instead of either
+  `Microsoft.PowerShell.Commands.HttpResponseException` (PowerShell 7.x) or
+  `System.Net.HttpWebResponse` (PowerShell 5.x) objects. This is to prevent
+  authorization Headers from being returned in the exception object. In future
+  the filtered headers may be returned in the `CosmosDb.ResponseException` object.
+
 ### Added
 
 - Added `Get-CosmosDbRequestExceptionString` function to get the exception string

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,7 +67,6 @@ stages:
       - job: Unit_Test_Matrix
         displayName: 'Unit Test Matrix'
         strategy:
-          maxParallel: 5
           matrix:
             PS_Win2019:
               vmImage: windows-2019
@@ -163,7 +162,6 @@ stages:
         displayName: 'Integration Test Matrix'
         dependsOn: Unit_Test_Matrix
         strategy:
-          maxParallel: 5
           matrix:
             PS_Win2019:
               vmImage: windows-2019

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,62 +71,50 @@ stages:
           matrix:
             PS_Win2019:
               vmImage: windows-2019
-              pesterScript: 'tests/Unit'
               testRunTitle: 'Unit (PowerShell 5.1 on Windows Server 2019)'
               pwsh: false
             PS_Win2022:
               vmImage: windows-2022
-              pesterScript: 'tests/Unit'
               testRunTitle: 'Unit (PowerShell 5.1 on Windows Server 2022)'
               pwsh: false
             PS_Win2025:
               vmImage: windows-2025
-              pesterScript: 'tests/Unit'
               testRunTitle: 'Unit (PowerShell 5.1 on Windows Server 2025)'
               pwsh: false
             PS7_Win2019:
               vmImage: windows-2019
-              pesterScript: 'tests/Unit'
               testRunTitle: 'Unit (PowerShell 7 on Windows Server 2019)'
               pwsh: true
             PS7_Win2022:
               vmImage: windows-2022
-              pesterScript: 'tests/Unit'
               testRunTitle: 'Unit (PowerShell 7 on Windows Server 2022)'
               pwsh: true
             PS7_Win2025:
               vmImage: windows-2025
-              pesterScript: 'tests/Unit'
               testRunTitle: 'Unit (PowerShell 7 on Windows Server 2025)'
               pwsh: true
             PS7_Ubuntu2004:
               vmImage: ubuntu-20.04
-              pesterScript: 'tests/Unit'
               testRunTitle: 'Unit (PowerShell 7 on Ubuntu 20.04)'
               pwsh: true
             PS7_Ubuntu2204:
               vmImage: ubuntu-22.04
-              pesterScript: 'tests/Unit'
               testRunTitle: 'Unit (PowerShell 7 on Ubuntu 22.04)'
               pwsh: true
             PS7_Ubuntu2404:
               vmImage: ubuntu-24.04
-              pesterScript: 'tests/Unit'
               testRunTitle: 'Unit (PowerShell 7 on Ubuntu 24.04)'
               pwsh: true
             PS7_MacOS13:
               vmImage: macos-13
-              pesterScript: 'tests/Unit'
               testRunTitle: 'Unit (PowerShell 7 on MacOS 13)'
               pwsh: true
             PS7_MacOS14:
               vmImage: macos-14
-              pesterScript: 'tests/Unit'
               testRunTitle: 'Unit (PowerShell 7 on MacOS 14)'
               pwsh: true
             PS7_MacOS15:
               vmImage: macos-15
-              pesterScript: 'tests/Unit'
               testRunTitle: 'Unit (PowerShell 7 on MacOS 15)'
               pwsh: true
 
@@ -152,7 +140,7 @@ stages:
             displayName: 'Run Unit Test'
             inputs:
               filePath: './build.ps1'
-              arguments: "-tasks test -PesterScript '$(pesterScript)'"
+              arguments: "-tasks test -PesterScript 'tests/Unit'"
               pwsh: $(pwsh)
 
           - task: PublishTestResults@2
@@ -179,62 +167,50 @@ stages:
           matrix:
             PS_Win2019:
               vmImage: windows-2019
-              pesterScript: 'tests/Integration'
               testRunTitle: 'Integration (PowerShell 5.1 on Windows Server 2019)'
               pwsh: false
             PS_Win2022:
               vmImage: windows-2022
-              pesterScript: 'tests/Integration'
               testRunTitle: 'Integration (PowerShell 5.1 on Windows Server 2022)'
               pwsh: false
             PS_Win2025:
               vmImage: windows-2025
-              pesterScript: 'tests/Integration'
               testRunTitle: 'Integration (PowerShell 5.1 on Windows Server 2025)'
               pwsh: false
             PS7_Win2019:
               vmImage: windows-2019
-              pesterScript: 'tests/Integration'
               testRunTitle: 'Integration (PowerShell 7 on Windows Server 2019)'
               pwsh: true
             PS7_Win2022:
               vmImage: windows-2022
-              pesterScript: 'tests/Integration'
               testRunTitle: 'Integration (PowerShell 7 on Windows Server 2022)'
               pwsh: true
             PS7_Win2025:
               vmImage: windows-2025
-              pesterScript: 'tests/Integration'
               testRunTitle: 'Integration (PowerShell 7 on Windows Server 2025)'
               pwsh: true
             PS7_Ubuntu2004:
               vmImage: ubuntu-20.04
-              pesterScript: 'tests/Integration'
               testRunTitle: 'Integration (PowerShell 7 on Ubuntu 20.04)'
               pwsh: true
             PS7_Ubuntu2204:
               vmImage: ubuntu-22.04
-              pesterScript: 'tests/Integration'
               testRunTitle: 'Integration (PowerShell 7 on Ubuntu 22.04)'
               pwsh: true
             PS7_Ubuntu2404:
               vmImage: ubuntu-24.04
-              pesterScript: 'tests/Integration'
               testRunTitle: 'Integration (PowerShell 7 on Ubuntu 24.04)'
               pwsh: true
             PS7_MacOS13:
               vmImage: macos-13
-              pesterScript: 'tests/Integration'
               testRunTitle: 'Integration (PowerShell 7 on MacOS 13)'
               pwsh: true
             PS7_MacOS14:
               vmImage: macos-14
-              pesterScript: 'tests/Integration'
               testRunTitle: 'Integration (PowerShell 7 on MacOS 14)'
               pwsh: true
             PS7_MacOS15:
               vmImage: macos-15
-              pesterScript: 'tests/Integration'
               testRunTitle: 'Integration (PowerShell 7 on MacOS 15)'
               pwsh: true
 
@@ -259,7 +235,7 @@ stages:
               azureApplicationObjectId: $(azureApplicationObjectId)
             inputs:
               filePath: './build.ps1'
-              arguments: "-Tasks test -PesterScript '$(pesterScript)' -CodeCoverageThreshold 0"
+              arguments: "-Tasks test -PesterScript 'tests/Integration' -CodeCoverageThreshold 0"
               pwsh: $(pwsh)
 
           - task: PublishTestResults@2

--- a/build.yaml
+++ b/build.yaml
@@ -80,6 +80,9 @@ BuildWorkflow:
     - Pester_Tests_Stop_On_Fail
     - Pester_if_Code_Coverage_Under_Threshold
 
+  merge:
+    - Merge_CodeCoverage_Files
+
   publish:
     - Publish_Release_To_GitHub
     - Publish_Module_To_gallery
@@ -115,7 +118,18 @@ TaskHeader: |
   ""
 
 ####################################################
-#       PESTER  Configuration                      #
+#           Code Coverage Configuration            #
+####################################################
+
+CodeCoverage:
+  # Filename of the file that will be outputted by the task Merge_CodeCoverage_Files.
+  CodeCoverageMergedOutputFile: JaCoCo_coverage.xml
+  # File pattern used to search for files under the ./output/testResults folder
+  # by task Merge_CodeCoverage_Files.
+  CodeCoverageFilePattern: Codecov*.xml
+
+####################################################
+#       Pester  Configuration                      #
 ####################################################
 Pester:
   OutputFormat: NUnitXML

--- a/source/Private/utils/Invoke-CosmosDbRequest.ps1
+++ b/source/Private/utils/Invoke-CosmosDbRequest.ps1
@@ -305,14 +305,14 @@ function Invoke-CosmosDbRequest
             # A non-recoverable exception occurred
             $fatal = $true
 
-            Throw $_
+            throw $_
         }
         catch
         {
             # A non-recoverable exception occurred
             $fatal = $true
 
-            Throw $_
+            throw $_
         }
     } while ($requestComplete -eq $false -and -not $fatal)
 

--- a/source/Private/utils/Invoke-CosmosDbRequest.ps1
+++ b/source/Private/utils/Invoke-CosmosDbRequest.ps1
@@ -251,6 +251,11 @@ function Invoke-CosmosDbRequest
         }
         catch [System.Net.WebException], [Microsoft.PowerShell.Commands.HttpResponseException]
         {
+            <#
+                When a response exception is thrown by Invoke-WebRequest:
+                PowerShell 5.x throws System.Net.WebException
+                PowerShell 7.x throws Microsoft.PowerShell.Commands.HttpResponseException
+            #>
             if ($_.Exception.Response.StatusCode -eq 429)
             {
                 <#

--- a/source/Private/utils/Invoke-CosmosDbRequest.ps1
+++ b/source/Private/utils/Invoke-CosmosDbRequest.ps1
@@ -294,11 +294,6 @@ function Invoke-CosmosDbRequest
 
             if ($_.Exception.Response)
             {
-                <#
-                    Write out additional exception information into the verbose stream
-                    In a future version a custom exception type for CosmosDB that
-                    contains this additional information.
-                #>
                 $exceptionResponse = Get-CosmosDbRequestExceptionString -ErrorRecord $_
 
                 if ($exceptionResponse)
@@ -310,14 +305,15 @@ function Invoke-CosmosDbRequest
             # A non-recoverable exception occurred
             $fatal = $true
 
-            throw $_
+            throw (New-CosmosDbResponseException -InputObject $_.Exception)
         }
+
         catch
         {
             # A non-recoverable exception occurred
             $fatal = $true
 
-            throw $_
+            throw (New-CosmosDbResponseException -InputObject $_.Exception)
         }
     } while ($requestComplete -eq $false -and -not $fatal)
 

--- a/source/Private/utils/New-CosmosDbInvalidOperationException.ps1
+++ b/source/Private/utils/New-CosmosDbInvalidOperationException.ps1
@@ -22,13 +22,13 @@ function New-CosmosDbInvalidOperationException
     elseif ($null -eq $ErrorRecord)
     {
         $invalidOperationException =
-        New-Object -TypeName 'InvalidOperationException' -ArgumentList @( $Message )
+            New-Object -TypeName 'InvalidOperationException' -ArgumentList @( $Message )
     }
     else
     {
         $invalidOperationException =
-        New-Object -TypeName 'InvalidOperationException' -ArgumentList @( $Message,
-            $ErrorRecord.Exception )
+            New-Object -TypeName 'InvalidOperationException' -ArgumentList @( $Message,
+                $ErrorRecord.Exception )
     }
 
     $newObjectParams = @{

--- a/source/Private/utils/New-CosmosDbResponseException.ps1
+++ b/source/Private/utils/New-CosmosDbResponseException.ps1
@@ -30,7 +30,10 @@ function New-CosmosDbResponseException
                 $webResponse = $InputObject.Response
                 if ($webResponse -is [System.Net.HttpWebResponse])
                 {
-                    $message = $webResponse.Message
+                    if ($null -ne $WebRespons.Message)
+                    {
+                        $message = $webResponse.Message
+                    }
                 }
             }
 

--- a/source/Private/utils/New-CosmosDbResponseException.ps1
+++ b/source/Private/utils/New-CosmosDbResponseException.ps1
@@ -13,8 +13,7 @@ function New-CosmosDbResponseException
 
     process
     {
-        # Create the target CosmosDB.ResponseException
-        $responseException = [CosmosDB.ResponseException]::new($InputObject.Message)
+        $statusCode = $null
 
         switch ($InputObject)
         {
@@ -22,16 +21,19 @@ function New-CosmosDbResponseException
             {
                 # PowerShell 7.0+
                 $httpResponse = $InputObject.Response
-                $responseException.StatusCode = $httpResponse.StatusCode
+                $message = $httpResponse.Message
+                $statusCode = $httpResponse.StatusCode
             }
 
             { $_ -is [System.Net.WebException] }
             {
                 # PowerShell 5.1
+                $message = $InputObject.Message
                 $webResponse = $InputObject.Response
                 if ($webResponse -is [System.Net.HttpWebResponse])
                 {
-                    $responseException.StatusCode = $webResponse.StatusCode
+                    $message = $webResponse.Message
+                    $statusCode = $webResponse.StatusCode
                 }
             }
 
@@ -40,6 +42,7 @@ function New-CosmosDbResponseException
             }
         }
 
+        $responseException = [CosmosDB.ResponseException]::new($message, $statusCode)
         return $responseException
     }
 }

--- a/source/Private/utils/New-CosmosDbResponseException.ps1
+++ b/source/Private/utils/New-CosmosDbResponseException.ps1
@@ -4,7 +4,7 @@ function New-CosmosDbResponseException
     [OutputType([CosmosDB.ResponseException])]
     param
     (
-        [Parameter(Mandatory, ValueFromPipeline)]
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
         [ValidateNotNull()]
         [Alias('Exception')]
         [System.Exception]
@@ -36,7 +36,7 @@ function New-CosmosDbResponseException
             }
 
             default {
-                throw "Unsupported exception type: $($InputObject.GetType().FullName)"
+                # Other exception types don't set any other properties
             }
         }
 

--- a/source/Private/utils/New-CosmosDbResponseException.ps1
+++ b/source/Private/utils/New-CosmosDbResponseException.ps1
@@ -19,11 +19,13 @@ function New-CosmosDbResponseException
         {
             { $_ -is [Microsoft.PowerShell.Commands.HttpResponseException] }
             {
+                Write-Verbose -Message $($LocalizedData.NewCosmosDbResponseExceptionHttpResponseExceptionMessage -f $message)
                 # PowerShell 7.0+ - just use the message
             }
 
             { $_ -is [System.Net.WebException] }
             {
+                Write-Verbose -Message $($LocalizedData.NewCosmosDbResponseExceptionWebException -f $message)
                 # PowerShell 5.1 - attempt to use the message in the Response
                 $webResponse = $InputObject.Response
                 if ($webResponse -is [System.Net.HttpWebResponse])
@@ -33,6 +35,7 @@ function New-CosmosDbResponseException
             }
 
             default {
+                Write-Verbose -Message $($LocalizedData.NewCosmosDbResponseExceptionDefaultException -f $message)
                 # Other exception types don't set any other properties
             }
         }

--- a/source/Private/utils/New-CosmosDbResponseException.ps1
+++ b/source/Private/utils/New-CosmosDbResponseException.ps1
@@ -1,0 +1,45 @@
+function New-CosmosDbResponseException
+{
+    [CmdletBinding()]
+    [OutputType([CosmosDB.ResponseException])]
+    param
+    (
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [ValidateNotNull()]
+        [Alias('Exception')]
+        [System.Exception]
+        $InputObject
+    )
+
+    process
+    {
+        # Create the target CosmosDB.ResponseException
+        $responseException = [CosmosDB.ResponseException]::new($InputObject.Message)
+
+        switch ($InputObject)
+        {
+            { $_ -is [Microsoft.PowerShell.Commands.HttpResponseException] }
+            {
+                # PowerShell 7.0+
+                $httpResponse = $InputObject.Response
+                $responseException.StatusCode = $httpResponse.StatusCode
+            }
+
+            { $_ -is [System.Net.WebException] }
+            {
+                # PowerShell 5.1
+                $webResponse = $InputObject.Response
+                if ($webResponse -is [System.Net.HttpWebResponse])
+                {
+                    $responseException.StatusCode = $webResponse.StatusCode
+                }
+            }
+
+            default {
+                throw "Unsupported exception type: $($InputObject.GetType().FullName)"
+            }
+        }
+
+        return $responseException
+    }
+}

--- a/source/Private/utils/New-CosmosDbResponseException.ps1
+++ b/source/Private/utils/New-CosmosDbResponseException.ps1
@@ -13,27 +13,22 @@ function New-CosmosDbResponseException
 
     process
     {
-        $statusCode = $null
+        $message = $InputObject.Message
 
         switch ($InputObject)
         {
             { $_ -is [Microsoft.PowerShell.Commands.HttpResponseException] }
             {
-                # PowerShell 7.0+
-                $httpResponse = $InputObject.Response
-                $message = $httpResponse.Message
-                $statusCode = $httpResponse.StatusCode
+                # PowerShell 7.0+ - just use the message
             }
 
             { $_ -is [System.Net.WebException] }
             {
-                # PowerShell 5.1
-                $message = $InputObject.Message
+                # PowerShell 5.1 - attempt to use the message in the Response
                 $webResponse = $InputObject.Response
                 if ($webResponse -is [System.Net.HttpWebResponse])
                 {
                     $message = $webResponse.Message
-                    $statusCode = $webResponse.StatusCode
                 }
             }
 
@@ -42,7 +37,7 @@ function New-CosmosDbResponseException
             }
         }
 
-        $responseException = [CosmosDB.ResponseException]::new($message, $statusCode)
+        $responseException = [CosmosDB.ResponseException]::new($message)
         return $responseException
     }
 }

--- a/source/classes/CosmosDB/CosmosDB.cs
+++ b/source/classes/CosmosDB/CosmosDB.cs
@@ -110,12 +110,12 @@ namespace CosmosDB
         }
     }
 
-    // ResponseExeption is used to handle exceptions that occur during the invocation of CosmosDB operations.
-    public class ResponseExeption : System.Exception
+    // ResponseException is used to handle exceptions that occur during the invocation of CosmosDB operations.
+    public class ResponseException : System.Exception
     {
-        public ResponseExeption(System.String message) : base(message) { }
-        public ResponseExeption(System.String message, System.Exception innerException) : base(message, innerException) { }
-        public ResponseExeption(System.String message, System.Int32 statusCode) : base(message) { StatusCode = statusCode; }
+        public ResponseException(System.String message) : base(message) { }
+        public ResponseException(System.String message, System.Exception innerException) : base(message, innerException) { }
+        public ResponseException(System.String message, System.Int32 statusCode) : base(message) { StatusCode = statusCode; }
         public System.Int32 StatusCode { get; set; } = 0;
     }
 }

--- a/source/classes/CosmosDB/CosmosDB.cs
+++ b/source/classes/CosmosDB/CosmosDB.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 
-namespace CosmosDB {
-    public enum Environment {
+namespace CosmosDB
+{
+    public enum Environment
+    {
         AzureChinaCloud,
         AzureCloud,
         AzureUSGovernment
@@ -32,25 +34,31 @@ namespace CosmosDB {
         public CosmosDB.ContextToken[] Token { get; set; }
         public System.Security.SecureString EntraIdToken { get; set; }
         public CosmosDB.BackoffPolicy BackoffPolicy { get; set; }
-        public CosmosDB.Environment Environment  { get; set; } = Environment.AzureCloud;
+        public CosmosDB.Environment Environment { get; set; } = Environment.AzureCloud;
     }
 
-    namespace IndexingPolicy {
-        namespace Path {
-            public class Index {
+    namespace IndexingPolicy
+    {
+        namespace Path
+        {
+            public class Index
+            {
                 public System.String dataType { get; set; }
                 public System.String kind { get; set; }
             }
 
-            public class IndexRange : CosmosDB.IndexingPolicy.Path.Index {
+            public class IndexRange : CosmosDB.IndexingPolicy.Path.Index
+            {
                 public readonly System.Int32 precision = -1;
             }
 
-            public class IndexHash : CosmosDB.IndexingPolicy.Path.Index {
+            public class IndexHash : CosmosDB.IndexingPolicy.Path.Index
+            {
                 public readonly System.Int32 precision = -1;
             }
 
-            public class IndexSpatial : CosmosDB.IndexingPolicy.Path.Index {
+            public class IndexSpatial : CosmosDB.IndexingPolicy.Path.Index
+            {
             }
 
             public class IncludedPath
@@ -70,7 +78,8 @@ namespace CosmosDB {
         }
 
 
-        namespace CompositeIndex {
+        namespace CompositeIndex
+        {
             public class Element
             {
                 public System.String path { get; set; }
@@ -88,8 +97,10 @@ namespace CosmosDB {
         }
     }
 
-    namespace UniqueKeyPolicy {
-        public class UniqueKey {
+    namespace UniqueKeyPolicy
+    {
+        public class UniqueKey
+        {
             public System.String[] paths { get; set; }
         }
 
@@ -97,5 +108,14 @@ namespace CosmosDB {
         {
             public CosmosDB.UniqueKeyPolicy.UniqueKey[] uniqueKeys { get; set; }
         }
+    }
+
+    // ResponseExeption is used to handle exceptions that occur during the invocation of CosmosDB operations.
+    public class ResponseExeption : System.Exception
+    {
+        public ResponseExeption(System.String message) : base(message) { }
+        public ResponseExeption(System.String message, System.Exception innerException) : base(message, innerException) { }
+        public ResponseExeption(System.String message, System.Int32 statusCode) : base(message) { StatusCode = statusCode; }
+        public System.Int32 StatusCode { get; set; } = 0;
     }
 }

--- a/source/classes/CosmosDB/CosmosDB.cs
+++ b/source/classes/CosmosDB/CosmosDB.cs
@@ -112,6 +112,9 @@ namespace CosmosDB
     }
 
     // ResponseException is used to handle exceptions that occur during the invocation of CosmosDB operations.
+    // Todo: Change to be based on Microsoft.PowerShell.Commands.HttpResponseException in 7.0.0.
+    // This will prevent this module from working in Windows PowerShell 5.1 because this class doesn't exist.
+    // Proposal is to drop support for Windows PowerShell 5.1 in 7.0.0.
     public class ResponseException : System.Exception
     {
         public ResponseException(System.String message) : base(message) { }

--- a/source/classes/CosmosDB/CosmosDB.cs
+++ b/source/classes/CosmosDB/CosmosDB.cs
@@ -115,8 +115,15 @@ namespace CosmosDB
     public class ResponseException : System.Exception
     {
         public ResponseException(System.String message) : base(message) { }
+        public ResponseException(System.String message, System.Net.HttpStatusCode statusCode) : base(message)
+        {
+            this.StatusCode = statusCode;
+        }
         public System.Net.HttpStatusCode? StatusCode { get; set; } = null;
         public System.String Response { get; set; } = "";
-
+        public override System.String ToString()
+        {
+            return this.Message;
+        }
     }
 }

--- a/source/classes/CosmosDB/CosmosDB.cs
+++ b/source/classes/CosmosDB/CosmosDB.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net;
 
 namespace CosmosDB
 {
@@ -114,8 +115,8 @@ namespace CosmosDB
     public class ResponseException : System.Exception
     {
         public ResponseException(System.String message) : base(message) { }
-        public ResponseException(System.String message, System.Exception innerException) : base(message, innerException) { }
-        public ResponseException(System.String message, System.Int32 statusCode) : base(message) { StatusCode = statusCode; }
-        public System.Int32 StatusCode { get; set; } = 0;
+        public System.Net.HttpStatusCode? StatusCode { get; set; } = null;
+        public System.String Response { get; set; } = "";
+
     }
 }

--- a/source/en-US/CosmosDB.strings.psd1
+++ b/source/en-US/CosmosDB.strings.psd1
@@ -67,4 +67,7 @@ ConvertFrom-StringData -StringData @'
     ErrorAuthorizationHeadersEmpty = Authorization headers could not be created for the request. This is usually caused by the context not containing the necessary authorization information.
     ErrorMalformedContextBaseUriEmpty = The context base URI is empty or malformed. Please ensure the context is correctly configured.
     ErrorMalformedContextDatabaseEmpty = The context database is empty or malformed or not passed in to the function. Please ensure the context is correctly configured or a database is specified.
+    NewCosmosDbResponseExceptionHttpResponseExceptionMessage = 'Creating CosmosDb.ResponseException from Microsoft.PowerShell.Commands.HttpResponseException exception: {0}'
+    NewCosmosDbResponseExceptionWebException = 'Creating CosmosDb.ResponseException from System.Net.WebException exception: {0}'
+    NewCosmosDbResponseExceptionDefaultException = 'Creating CosmosDb.ResponseException from System.Exception exception: {0}'
 '@

--- a/tests/Integration/CosmosDB.integration.Tests.ps1
+++ b/tests/Integration/CosmosDB.integration.Tests.ps1
@@ -586,16 +586,21 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
                 catch [CosmosDb.ResponseException]
                 {
 
-                    Write-Verbose -Message "Complete: $($_)" -Verbose
-                    Write-Verbose -Message "Type: $($_.Exception.GetType())" -Verbose
-                    Write-Verbose -Message "Exception: $($_.Exception)" -Verbose
                     $script:cosmosDbResponseException = $_.Exception
-                    Write-Verbose -Message "Message: $($script:cosmosDbResponseException.Message)" -Verbose
                 }
             } | Should -Not -Throw
 
             $script:cosmosDbResponseException | Should -BeOfType [CosmosDb.ResponseException]
-            $script:cosmosDbResponseException.Message | Should -Be 'Response status code does not indicate success: 404 (Not Found).'
+            # If PS 7.0+ then the message will be 'Response status code does not indicate success: 404 (Not Found).'
+            # If PS 5.1 then the message will be 'The remote server returned an error: (404) Not Found.'
+            if ($PSEdition -eq 'Core')
+            {
+                $script:cosmosDbResponseException.Message | Should -Be 'Response status code does not indicate success: 404 (Not Found).'
+            }
+            else
+            {
+                $script:cosmosDbResponseException.Message | Should -Be 'The remote server returned an error: (404) Not Found.'
+            }
         }
     }
 
@@ -1067,8 +1072,16 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
                     }
                 } | Should -Not -Throw
 
-                $script:cosmosDbResponseException | Should -BeOfType [CosmosDb.ResponseException]
-                $script:cosmosDbResponseException.Message | Should -Be 'Response status code does not indicate success: 404 (Not Found).'
+                # If PS 7.0+ then the message will be 'Response status code does not indicate success: 404 (Not Found).'
+                # If PS 5.1 then the message will be 'The remote server returned an error: (404) Not Found.'
+                if ($PSEdition -eq 'Core')
+                {
+                    $script:cosmosDbResponseException.Message | Should -Be 'Response status code does not indicate success: 404 (Not Found).'
+                }
+                else
+                {
+                    $script:cosmosDbResponseException.Message | Should -Be 'The remote server returned an error: (404) Not Found.'
+                }
             }
         }
     }
@@ -1591,8 +1604,16 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
                 }
             } | Should -Not -Throw
 
-            $script:cosmosDbResponseException | Should -BeOfType [CosmosDb.ResponseException]
-            $script:cosmosDbResponseException.Message | Should -Be 'Response status code does not indicate success: 404 (Not Found).'
+            # If PS 7.0+ then the message will be 'Response status code does not indicate success: 404 (Not Found).'
+            # If PS 5.1 then the message will be 'The remote server returned an error: (404) Not Found.'
+            if ($PSEdition -eq 'Core')
+            {
+                $script:cosmosDbResponseException.Message | Should -Be 'Response status code does not indicate success: 404 (Not Found).'
+            }
+            else
+            {
+                $script:cosmosDbResponseException.Message | Should -Be 'The remote server returned an error: (404) Not Found.'
+            }
         }
     }
 

--- a/tests/Integration/CosmosDB.integration.Tests.ps1
+++ b/tests/Integration/CosmosDB.integration.Tests.ps1
@@ -1012,7 +1012,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
                 -Name CosmosDB.OperationException `
                 -Auguments @( 'The specified resource does not exist.', 404 )
 
-            It 'Should throw an CosmosDb.ResponseExeption' {
+            It 'Should throw an CosmosDb.ResponseException' {
                 {
                     $script:result = Get-CosmosDbDocument `
                         -Context $script:testEntraIdContext `

--- a/tests/Integration/CosmosDB.integration.Tests.ps1
+++ b/tests/Integration/CosmosDB.integration.Tests.ps1
@@ -586,9 +586,9 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
                 catch [CosmosDb.ResponseException]
                 {
 
-                    Write-Verbose -Message "Complete: $($_ | fl *)" -Verbose
-                    Write-Verbose -Message "Type: $($_.Exception.GetType() | fl *)" -Verbose
-                    Write-Verbose -Message "Exception: $($_.Exception | fl *)" -Verbose
+                    Write-Verbose -Message "Complete: $($_)" -Verbose
+                    Write-Verbose -Message "Type: $($_.Exception.GetType())" -Verbose
+                    Write-Verbose -Message "Exception: $($_.Exception)" -Verbose
                     $script:cosmosDbResponseException = $_.Exception
                     Write-Verbose -Message "Message: $($script:cosmosDbResponseException.Message)" -Verbose
                 }

--- a/tests/Integration/CosmosDB.integration.Tests.ps1
+++ b/tests/Integration/CosmosDB.integration.Tests.ps1
@@ -585,6 +585,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
                 }
                 catch [CosmosDb.ResponseException]
                 {
+                    Write-Verbose -Message "Exception: $($_.Exception | fl *)" -Verbose
                     $script:cosmosDbResponseException = $_.Exception
                     Write-Verbose -Message "Message: $($script:cosmosDbResponseException.Message)" -Verbose
                 }

--- a/tests/Integration/CosmosDB.integration.Tests.ps1
+++ b/tests/Integration/CosmosDB.integration.Tests.ps1
@@ -566,7 +566,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
             {
                 try
                 {
-                    $script:result = New-CosmosDbCollection `
+                    $script:result = Get-CosmosDbCollection `
                         -Context $script:testContext `
                         -Database $script:testDatabase3 `
                         -Id 'doesnotexist' `
@@ -575,12 +575,14 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
                 catch [CosmosDb.ResponseException]
                 {
                     $script:cosmosDbResponseException = $_.Exception
+                    Write-Verbose -Message "Message: $($script:cosmosDbResponseException.Message)" -Verbose
+                    Write-Verbose -Message "StatusCode: $($script:cosmosDbResponseException.StatusCode)" -Verbose
                 }
             } | Should -Not -Throw
 
             $script:cosmosDbResponseException | Should -BeOfType [CosmosDb.ResponseException]
             $script:cosmosDbResponseException.Message | Should -Be 'Response status code does not indicate success: 400 (Bad Request).'
-            $script:cosmosDbResponseException.StatusCode | Should -Be 400
+            $script:cosmosDbResponseException.StatusCode | Should -Be 404
         }
     }
 
@@ -1042,12 +1044,14 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
                         $script:result = Get-CosmosDbDocument `
                             -Context $script:testEntraIdContext `
                             -CollectionId $script:testCollection `
-                            -Id 'doesnotexist' `
+                            -Id $script:testDocumentId `
                             -Verbose
                     }
                     catch [CosmosDb.ResponseException]
                     {
                         $script:cosmosDbResponseException = $_.Exception
+                        Write-Verbose -Message "Message: $($script:cosmosDbResponseException.Message)" -Verbose
+                        Write-Verbose -Message "StatusCode: $($script:cosmosDbResponseException.StatusCode)" -Verbose
                     }
                 } | Should -Not -Throw
 
@@ -1549,12 +1553,6 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
         }
     }
 
-    Context 'When removing existing collection with a partition key' {
-        It 'Should not throw an exception' {
-            $script:result = Remove-CosmosDbCollection -Context $script:testContext -Id $script:testCollection -Verbose
-        }
-    }
-
     <#
         When a rquest to the CosmosDB is made, but it fails with an HttpResponseException
         the exception should be rethrown as a CosmosDb.ResponseException, otherwise the
@@ -1572,17 +1570,28 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
                         -Context $script:testContext `
                         -CollectionId $script:testCollection `
                         -Id 'doesnotexist' `
+                        -PartitionKey 'doesnotexist' `
                         -Verbose
                 }
                 catch [CosmosDb.ResponseException]
                 {
                     $script:cosmosDbResponseException = $_.Exception
+                    Write-Verbose -Message "Message: $($script:cosmosDbResponseException.Message)" -Verbose
+                    Write-Verbose -Message "StatusCode: $($script:cosmosDbResponseException.StatusCode)" -Verbose
                 }
             } | Should -Not -Throw
 
             $script:cosmosDbResponseException | Should -BeOfType [CosmosDb.ResponseException]
             $script:cosmosDbResponseException.Message | Should -Be 'The specified resource does not exist.'
             $script:cosmosDbResponseException.StatusCode | Should -Be 404
+        }
+    }
+
+    Context 'When removing existing collection with a partition key' {
+        It 'Should not throw an exception' {
+            $script:result = Remove-CosmosDbCollection `
+                -Context $script:testContext `
+                -Id $script:testCollection -Verbose
         }
     }
 

--- a/tests/Integration/CosmosDB.integration.Tests.ps1
+++ b/tests/Integration/CosmosDB.integration.Tests.ps1
@@ -585,6 +585,9 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
                 }
                 catch [CosmosDb.ResponseException]
                 {
+
+                    Write-Verbose -Message "Complete: $($_ | fl *)" -Verbose
+                    Write-Verbose -Message "Type: $($_.Exception.GetType() | fl *)" -Verbose
                     Write-Verbose -Message "Exception: $($_.Exception | fl *)" -Verbose
                     $script:cosmosDbResponseException = $_.Exception
                     Write-Verbose -Message "Message: $($script:cosmosDbResponseException.Message)" -Verbose

--- a/tests/Unit/CosmosDB.utils.Tests.ps1
+++ b/tests/Unit/CosmosDB.utils.Tests.ps1
@@ -2251,18 +2251,19 @@ console.log("done");
 
         Context 'When called with HttpResponseException' {
             $script:result = $null
+            $script:httpResponseMessage = [System.Net.Http.HttpResponseMessage]::new([System.Net.HttpStatusCode]::BadRequest)
+            $script:httpResponseException = [Microsoft.PowerShell.Commands.HttpResponseException]::new('Bad Request', $script:httpResponseMessage)
 
             It 'Should not throw exception' -Skip:$doesNotHaveHttpResponseException {
-                $httpResponseMessage = [System.Net.Http.HttpResponseMessage]::new([System.Net.HttpStatusCode]::BadRequest)
-                $httpResponseException = [Microsoft.PowerShell.Commands.HttpResponseException]::new('Bad Request', $httpResponseMessage)
-
-                { $script:result = New-CosmosDbResponseException -InputObject $httpResponseException } | Should -Not -Throw
+                {
+                    $script:result = New-CosmosDbResponseException -InputObject $script:httpResponseException
+                } | Should -Not -Throw
             }
 
             It 'Should return expected CosmosDB.ResponseException' -Skip:   $doesNotHaveHttpResponseException {
                 $script:result | Should -BeOfType 'CosmosDB.ResponseException'
                 $script:result.StatusCode | Should -Be ([System.Net.HttpStatusCode]::BadRequest)
-                $script:result.Message | Should -Be $httpResponseException.Message
+                $script:result.Message | Should -Be $script:httpResponseException.Message
             }
         }
 

--- a/tests/Unit/CosmosDB.utils.Tests.ps1
+++ b/tests/Unit/CosmosDB.utils.Tests.ps1
@@ -2285,15 +2285,19 @@ console.log("done");
             }
         }
 
-        # -------------------------------------------------------------
-        # Unsupported exception type
-        # -------------------------------------------------------------
-        Context 'When called with unsupported exception type' {
-            It 'Should throw Unsupported exception type message' {
-                $argException = [System.ArgumentException]::new('Bad input')
+        # Other exception type
+        Context 'When called with non web exception type' {
+            It 'Should not throw exception' {
                 {
-                    New-CosmosDbResponseException -InputObject $argException
-                } | Should -Throw "Unsupported exception type: $([System.ArgumentException].FullName)"
+                    $script:testException = [System.Exception]::new('Test Exception')
+
+                    $script:result = New-CosmosDbResponseException -InputObject $script:testException
+                } | Should -Not -Throw
+            }
+
+            It 'Should return expected CosmosDB.ResponseException' {
+                $script:result | Should -BeOfType 'CosmosDB.ResponseException'
+                $script:result.Message | Should -Be $script:testException.Message
             }
         }
     }

--- a/tests/Unit/CosmosDB.utils.Tests.ps1
+++ b/tests/Unit/CosmosDB.utils.Tests.ps1
@@ -2246,14 +2246,14 @@ console.log("done");
 
         # PowerShell 7 test – Microsoft.PowerShell.Commands.HttpResponseException
         Context 'When called with HttpResponseException' {
-            $doesNotHaveHttpResponseException = -not [bool]([System.Management.Automation.PSTypeName]'Microsoft.PowerShell.Commands.HttpResponseException').Type
-            if ($doesNotHaveHttpResponseException) {
+            $script:doesNotHaveHttpResponseException = -not [bool]([System.Management.Automation.PSTypeName]'Microsoft.PowerShell.Commands.HttpResponseException').Type
+            if ($script:doesNotHaveHttpResponseException) {
                 Write-Verbose -Message 'Skipping HttpResponseException test as it is not available in this environment.'
             }
 
             $script:result = $null
 
-            It 'Should not throw exception' -Skip:$doesNotHaveHttpResponseException {
+            It 'Should not throw exception' -Skip $script:doesNotHaveHttpResponseException {
                 {
                     $script:httpResponseMessage = [System.Net.Http.HttpResponseMessage]::new([System.Net.HttpStatusCode]::BadRequest)
                     $script:httpResponseException = [Microsoft.PowerShell.Commands.HttpResponseException]::new('Bad Request', $script:httpResponseMessage)
@@ -2262,7 +2262,7 @@ console.log("done");
                 } | Should -Not -Throw
             }
 
-            It 'Should return expected CosmosDB.ResponseException' -Skip:$doesNotHaveHttpResponseException {
+            It 'Should return expected CosmosDB.ResponseException' -Skip $script:doesNotHaveHttpResponseException {
                 $script:result | Should -BeOfType 'CosmosDB.ResponseException'
                 $script:result.StatusCode | Should -Be ([System.Net.HttpStatusCode]::BadRequest)
                 $script:result.Message | Should -Be $script:httpResponseException.Message
@@ -2272,9 +2272,16 @@ console.log("done");
         # PowerShell 5.x - test System.Net.WebException
         Context 'When called with WebException containing HttpWebResponse' {
             <#
-                It isn't possible to create a WebException mock, so unit testing
-                is difficult. Rely on Integration tests to verify this scenario.
+                It is difficult to create a HttpWebResponse mock, so unit testing
+                isn't possible. Rely on Integration tests to verify this scenario.
             #>
+            Write-Verbose -Message 'Skipping WebException test as it is not possible to mock HttpWebResponse.'
+
+            It 'Should not throw exception' -Skip $true {
+            }
+
+            It 'Should return expected CosmosDB.ResponseException' -Skip $true {
+            }
         }
 
         # -------------------------------------------------------------

--- a/tests/Unit/CosmosDB.utils.Tests.ps1
+++ b/tests/Unit/CosmosDB.utils.Tests.ps1
@@ -2244,36 +2244,36 @@ console.log("done");
             { Get-Command -Name New-CosmosDbResponseException -ErrorAction Stop } | Should -Not -Throw
         }
 
-                # -------------------------------------------------------------
-        # Core‑only test – Microsoft.PowerShell.Commands.HttpResponseException
-        # -------------------------------------------------------------
-        $doesNotHaveHttpResponseException = -not [bool]([System.Management.Automation.PSTypeName]'Microsoft.PowerShell.Commands.HttpResponseException').Type
-
+        # PowerShell 7 test – Microsoft.PowerShell.Commands.HttpResponseException
         Context 'When called with HttpResponseException' {
+            $doesNotHaveHttpResponseException = -not [bool]([System.Management.Automation.PSTypeName]'Microsoft.PowerShell.Commands.HttpResponseException').Type
+            if ($doesNotHaveHttpResponseException) {
+                Write-Verbose -Message 'Skipping HttpResponseException test as it is not available in this environment.'
+            }
+
             $script:result = $null
-            $script:httpResponseMessage = [System.Net.Http.HttpResponseMessage]::new([System.Net.HttpStatusCode]::BadRequest)
-            $script:httpResponseException = [Microsoft.PowerShell.Commands.HttpResponseException]::new('Bad Request', $script:httpResponseMessage)
 
             It 'Should not throw exception' -Skip:$doesNotHaveHttpResponseException {
                 {
+                    $script:httpResponseMessage = [System.Net.Http.HttpResponseMessage]::new([System.Net.HttpStatusCode]::BadRequest)
+                    $script:httpResponseException = [Microsoft.PowerShell.Commands.HttpResponseException]::new('Bad Request', $script:httpResponseMessage)
+
                     $script:result = New-CosmosDbResponseException -InputObject $script:httpResponseException
                 } | Should -Not -Throw
             }
 
-            It 'Should return expected CosmosDB.ResponseException' -Skip:   $doesNotHaveHttpResponseException {
+            It 'Should return expected CosmosDB.ResponseException' -Skip:$doesNotHaveHttpResponseException {
                 $script:result | Should -BeOfType 'CosmosDB.ResponseException'
                 $script:result.StatusCode | Should -Be ([System.Net.HttpStatusCode]::BadRequest)
                 $script:result.Message | Should -Be $script:httpResponseException.Message
             }
         }
 
-        # -------------------------------------------------------------
-        # WebException branch (works both on Windows PowerShell & Core)
-        # -------------------------------------------------------------
+        # PowerShell 5.x - test System.Net.WebException
         Context 'When called with WebException containing HttpWebResponse' {
             <#
                 It isn't possible to create a WebException mock, so unit testing
-                is not possible. Therefore, rely on Integration tests to verify this.
+                is difficult. Rely on Integration tests to verify this scenario.
             #>
         }
 

--- a/tests/Unit/CosmosDB.utils.Tests.ps1
+++ b/tests/Unit/CosmosDB.utils.Tests.ps1
@@ -2245,15 +2245,16 @@ console.log("done");
         }
 
         # PowerShell 7 test – Microsoft.PowerShell.Commands.HttpResponseException
-        Context 'When called with HttpResponseException' {
-            $script:doesNotHaveHttpResponseException = -not [bool]([System.Management.Automation.PSTypeName]'Microsoft.PowerShell.Commands.HttpResponseException').Type
-            if ($script:doesNotHaveHttpResponseException) {
-                Write-Verbose -Message 'Skipping HttpResponseException test as it is not available in this environment.'
+        Context 'When called with HttpResponseException on PowerShell 7.x' {
+            $script:skipHttpResponseException = -not ((Get-Variable -Name 'PSEdition').Value -eq 'Core')
+            if ($script:skipHttpResponseException)
+            {
+                Write-Verbose -Message 'Skipping HttpResponseException test on PowerShell 5.x'
             }
 
             $script:result = $null
 
-            It 'Should not throw exception' -Skip:$script:doesNotHaveHttpResponseException {
+            It 'Should not throw exception' -Skip:$script:skipHttpResponseException {
                 {
                     $script:httpResponseMessage = [System.Net.Http.HttpResponseMessage]::new([System.Net.HttpStatusCode]::BadRequest)
                     $script:httpResponseException = [Microsoft.PowerShell.Commands.HttpResponseException]::new('Bad Request', $script:httpResponseMessage)
@@ -2262,7 +2263,7 @@ console.log("done");
                 } | Should -Not -Throw
             }
 
-            It 'Should return expected CosmosDB.ResponseException' -Skip:$script:doesNotHaveHttpResponseException {
+            It 'Should return expected CosmosDB.ResponseException' -Skip:$script:skipHttpResponseException {
                 $script:result | Should -BeOfType 'CosmosDB.ResponseException'
                 $script:result.StatusCode | Should -Be ([System.Net.HttpStatusCode]::BadRequest)
                 $script:result.Message | Should -Be $script:httpResponseException.Message

--- a/tests/Unit/CosmosDB.utils.Tests.ps1
+++ b/tests/Unit/CosmosDB.utils.Tests.ps1
@@ -2253,7 +2253,7 @@ console.log("done");
 
             $script:result = $null
 
-            It 'Should not throw exception' -Skip $script:doesNotHaveHttpResponseException {
+            It 'Should not throw exception' -Skip:$script:doesNotHaveHttpResponseException {
                 {
                     $script:httpResponseMessage = [System.Net.Http.HttpResponseMessage]::new([System.Net.HttpStatusCode]::BadRequest)
                     $script:httpResponseException = [Microsoft.PowerShell.Commands.HttpResponseException]::new('Bad Request', $script:httpResponseMessage)
@@ -2262,7 +2262,7 @@ console.log("done");
                 } | Should -Not -Throw
             }
 
-            It 'Should return expected CosmosDB.ResponseException' -Skip $script:doesNotHaveHttpResponseException {
+            It 'Should return expected CosmosDB.ResponseException' -Skip:$script:doesNotHaveHttpResponseException {
                 $script:result | Should -BeOfType 'CosmosDB.ResponseException'
                 $script:result.StatusCode | Should -Be ([System.Net.HttpStatusCode]::BadRequest)
                 $script:result.Message | Should -Be $script:httpResponseException.Message
@@ -2277,10 +2277,10 @@ console.log("done");
             #>
             Write-Verbose -Message 'Skipping WebException test as it is not possible to mock HttpWebResponse.'
 
-            It 'Should not throw exception' -Skip $true {
+            It 'Should not throw exception' -Skip:$true {
             }
 
-            It 'Should return expected CosmosDB.ResponseException' -Skip $true {
+            It 'Should return expected CosmosDB.ResponseException' -Skip:$true {
             }
         }
 

--- a/tests/Unit/CosmosDB.utils.Tests.ps1
+++ b/tests/Unit/CosmosDB.utils.Tests.ps1
@@ -2265,7 +2265,6 @@ console.log("done");
 
             It 'Should return expected CosmosDB.ResponseException' -Skip:$script:skipHttpResponseException {
                 $script:result | Should -BeOfType 'CosmosDB.ResponseException'
-                $script:result.StatusCode | Should -Be ([System.Net.HttpStatusCode]::BadRequest)
                 $script:result.Message | Should -Be $script:httpResponseException.Message
             }
         }


### PR DESCRIPTION
# Pull Request

This PR updates the Invoke-CosmosDbRequest function to throw a custom exception of type CosmosDB.ResponseExeption. This is required because the HttpResponseException contains a Response.requestMessage property, which may contain the authorizationHeader.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/PlagueHO/CosmosDB/501)
<!-- Reviewable:end -->
