### PR TITLE
Enhance New-CosmosDbContext to support alternate Azure Cloud endpoints - Fixes #504

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added support for setting `EndpointHostname` in `New-CosmosDbContext` to allow
+  setting the base URI for the Cosmos DB account when using Entra ID authentication
+  or token based authentication. This allows the use of future Azure Clouds that
+  may not be supported by this module.
+- Added alias `BaseUri` for`EndpointHostname` in `New-CosmosDbContext` function.
+
 ## [6.0.0] - 2025-04-26
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
     - [Creating a Collection with a custom Indexing Policy](#creating-a-collection-with-a-custom-indexing-policy)
     - [Creating a Collection with a custom Indexing Policy including Composite Indexes](#creating-a-collection-with-a-custom-indexing-policy-including-composite-indexes)
     - [Update an existing Collection with a new Indexing Policy](#update-an-existing-collection-with-a-new-indexing-policy)
-    - [Creating a Collection with a custom Indexing Policy using JSON](#creating-a-collection-with-a-custom-indexing-policy-using-JSON)
+    - [Creating a Collection with a custom Indexing Policy using JSON](#creating-a-collection-with-a-custom-indexing-policy-using-json)
     - [Creating a Collection with a custom Unique Key Policy](#creating-a-collection-with-a-custom-unique-key-policy)
     - [Update an existing Collection with a new Unique Key Policy](#update-an-existing-collection-with-a-new-unique-key-policy)
     - [Creating a Collection without a Partition Key](#creating-a-collection-without-a-partition-key)
@@ -136,7 +136,8 @@ the Azure management portal for you.
 You can create a context object that can include use an _Entra ID Authorization Token_
 that will be used to authenticate requests to Cosmos DB.
 
-> Important: This is a recommended security practice to use when you've
+> [!IMPORTANT]
+> This is a recommended security practice to use when you've
 > [configured role-based access control with Microsoft Entra ID](https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-setup-rbac)
 > on your Azure Cosmos DB account. It will help you keep your account secure
 > by not exposing the primary or secondary keys in your code.
@@ -174,23 +175,44 @@ $accountContext = New-CosmosDbContext @newCosmosDbContextParams
 Get-CosmosDbCollection -Context $accountContext -Id MyNewCollection
 ```
 
-> Important: Using an Entra ID Authorization Token is only supported by setting it
+> [!IMPORTANT]
+> Using an Entra ID Authorization Token is only supported by setting it
 > in a CosmosDB.Context object and passing that to the commands you want to execute.
 > Not all commands support this method of authentication. If you need to use a command
-> that doesn't support this method of authentication, you will need to use one of the
-> other methods of authentication. See the [Database Operations allowed by Role-Based Access Control](#database-operations-allowed-by-role-based-access-control)
+> that doesn't support this method of authentication, you will need to use one
+> of the other methods of authentication. See the
+> [Database Operations allowed by Role-Based Access Control](#database-operations-allowed-by-role-based-access-control)
 > section for more information.
+
+##### Using Entra ID Authorization Token for a custom cloud environment
+
+You can create a context with Entra ID Authorization Token for an Azure cloud
+environment other than the ones listed in the `Environment` parameter.
+
+To do this, you can use the `EndpointHostname` parameter to specify the custom
+endpoint for the Cosmos DB account.
+
+```powershell
+$newCosmosDbContextParams  = @{
+    Account      = 'MyAzureCosmosDB'
+    AutoGenerateEntraIdToken = $true
+    EndpointHostname = 'documents.azurecustomcloud.com'
+}
+$accountContext = New-CosmosDbContext @newCosmosDbContextParams
+Get-CosmosDbCollection -Context $accountContext -Id MyNewCollection
+```
 
 ##### Configuring Role-Based Access Control (RBAC) with Entra ID
 
 There are several ways to configure a Cosmos DB Account with Role-Based Access Control,
 including:
 
- - *Azure Bicep*: An example can be found in the [\tests\TestHelper\AzureDeploy\CosmosDb.bicep](\tests\TestHelper\AzureDeploy\CosmosDb.bicep) file.
- - *Azure PowerShell*: The integration tests use this method.
- - *AzCli*.
+- _Azure Bicep_: An example can be found in the [\tests\TestHelper\AzureDeploy\CosmosDb.bicep](\tests\TestHelper\AzureDeploy\CosmosDb.bicep) file.
+- _Azure PowerShell_: The integration tests use this method.
+- _AzCli_.
 
-> Important Note: One thing I found when adding a SQL Role Assignment to the Cosmos DB
+> [!IMPORTANT]
+> One thing I found when adding a SQL Role Assignment to the Cosmos DB
 > Account (or Database or Container) is that the principal ID must be the Object ID of
 > the user, group or service principal that you want to assign the role to. You can't use
 > the Application ID for this value.
@@ -216,7 +238,8 @@ For more information on this, please see the [Role-based access control (RBAC) w
 
 #### Create a Context specifying the Key Manually
 
-> Note: This method of authenticating to Cosmos DB is not recommended for
+> [!NOTE]
+> This method of authenticating to Cosmos DB is not recommended for
 > production use. It is recommended to use the _Entra ID Authorization Token_
 > method described above.
 
@@ -235,7 +258,8 @@ $cosmosDbContext = New-CosmosDbContext -Account MyAzureCosmosDB -Database MyData
 
 #### Use CosmosDB Module to Retrieve Key from Azure Management Portal
 
-> Note: This method of authenticating to Cosmos DB is not recommended for
+> [!NOTE]
+> This method of authenticating to Cosmos DB is not recommended for
 > production use. It is recommended to use the _Entra ID Authorization Token_
 > method described above.
 
@@ -247,15 +271,17 @@ Portal, use the following command:
 $cosmosDbContext = New-CosmosDbContext -Account MyAzureCosmosDB -Database MyDatabase -ResourceGroupName MyCosmosDbResourceGroup -MasterKeyType SecondaryMasterKey
 ```
 
-_Note: if PowerShell is not connected to Azure then an interactive
-Azure login will be initiated. If PowerShell is already connected to
-an account that doesn't contain the Cosmos DB you wish to connect to then
-you will first need to connect to the correct account using the
-`Connect-AzAccount` cmdlet._
+> [!NOTE]
+> If PowerShell is not connected to Azure then an interactive
+> Azure login will be initiated. If PowerShell is already connected to
+> an account that doesn't contain the Cosmos DB you wish to connect to then
+> you will first need to connect to the correct account using the
+> `Connect-AzAccount` cmdlet.
 
 #### Create a Context from Resource Authorization Tokens
 
-> Note: This method of authenticating to Cosmos DB is better than using master key
+> [!NOTE]
+> This method of authenticating to Cosmos DB is better than using master key
 > authentication, as it provides the ability to limit access to specific resources.
 > However, it is recommended to use the _Entra ID Authorization Token_ method
 > described above if possible.
@@ -266,7 +292,8 @@ Authorization Tokens_.
 
 #### Create a Context for a Cosmos DB in Azure US Government Cloud
 
-> Note: This method of authenticating to Cosmos DB is not recommended for
+> [!NOTE]
+> This method of authenticating to Cosmos DB is not recommended for
 > production use. It is recommended to use the _Entra ID Authorization Token_
 > method described above.
 
@@ -280,7 +307,8 @@ $cosmosDbContext = New-CosmosDbContext -Account MyAzureCosmosDB -Database MyData
 
 #### Create a Context for a Cosmos DB in Azure China Cloud (Mooncake)
 
-> Note: This method of authenticating to Cosmos DB is not recommended for
+> [!NOTE]
+> This method of authenticating to Cosmos DB is not recommended for
 > production use. It is recommended to use the _Entra ID Authorization Token_
 > method described above.
 
@@ -327,8 +355,9 @@ this module. To use these features you will need to ensure the **Az.Profile**
 and **Az.Resources** modules installed - See [Requirements](#requirements)
 above.
 
-_Note: You must have first logged PowerShell into Azure using the
-`Connect-AzAccount` function before you can use these functions._
+> [!NOTE]
+> You must have first logged PowerShell into Azure using the
+> `Connect-AzAccount` function before you can use these functions.
 
 Create a new Cosmos DB account in Azure:
 
@@ -365,7 +394,8 @@ New-CosmosDbAccountMasterKey -Name MyAzureCosmosDB -ResourceGroupName MyCosmosDb
 Get the connection strings used to connect to an existing Cosmos DB
 account in Azure:
 
-> Note: This function is not currently working due to an issue in the Microsoft/DocumentDB
+> [!NOTE]
+> This function is not currently working due to an issue in the Microsoft/DocumentDB
 > Provider. See [this issue](https://github.com/Azure/azure-powershell/issues/3650) for more information.
 
 ```powershell
@@ -709,8 +739,9 @@ the document ID as the partition key:
 Get-CosmosDbDocument -Context $cosmosDbContext -CollectionId MyNewCollection -Id $documents[0].id -PartitionKey $documents[0].id
 ```
 
-> **Note:** Because this is a partitioned collection, if you don't specify a partition
-key you will receive a `(400) Bad Request` exception.
+> [!NOTE]
+> Because this is a partitioned collection, if you don't specify a partition
+> key you will receive a `(400) Bad Request` exception.
 
 Get the first 5 documents from the collection in the database:
 
@@ -720,9 +751,10 @@ $documents = Get-CosmosDbDocument -Context $cosmosDbContext -CollectionId MyNewC
 $continuationToken = Get-CosmosDbContinuationToken -ResponseHeader $ResponseHeader
 ```
 
-> **Note:** You don't need to specify the partition key here because you are just
-getting the first 5 documents in whatever order they are available so going to
-a specific partition is not required.
+> [!NOTE]
+> You don't need to specify the partition key here because you are just
+> getting the first 5 documents in whatever order they are available so going to
+> a specific partition is not required.
 
 Get the next 5 documents from a collection in the database using
 the continuation token found in the headers from the previous
@@ -769,8 +801,9 @@ Delete a document from a collection in the database:
 Remove-CosmosDbDocument -Context $cosmosDbContext -CollectionId MyNewCollection -Id $documents[0].id -PartitionKey $documents[0].id
 ```
 
-> **Note:** Because this is a partitioned collection, if you don't specify a partition
-key you will receive a `(400) Bad Request` exception.
+> [!NOTE]
+> Because this is a partitioned collection, if you don't specify a partition
+> key you will receive a `(400) Bad Request` exception.
 
 #### Using a While Loop to get all Documents in a Collection
 
@@ -918,10 +951,11 @@ To use a resource authorization token, first a permission must be assigned
 to the user for the resource using the `New-CosmosDbPermission`. A user
 can be created using the `New-CosmosDbUser` function.
 
-**Note: By default, Resource Authorization Tokens expire after an hour.
-This can be extended to a maximum of 5 hours or reduced to minimum of 10
-minutes. Use the `TokenExpiry` parameter to control the length of time
-that the resource authorization tokens will be valid for.**
+> [!NOTE]
+> By default, Resource Authorization Tokens expire after an hour.
+> This can be extended to a maximum of 5 hours or reduced to minimum of 10
+> minutes. Use the `TokenExpiry` parameter to control the length of time
+> that the resource authorization tokens will be valid for.
 
 The typical pattern for using _resource authorization tokens_ is to
 have a **token broker app** that provides some form of user authentication
@@ -1180,9 +1214,10 @@ Cosmos DB.
 Additional Back-off Policy options can be set to override or extend the value
 returned in the `x-ms-retry-after-ms` header.
 
-**Note: if the delay calculated by the policy is less than the value returned in
-the `x-ms-retry-after-ms` header, then the `x-ms-retry-after-ms` value will always
-be used.**
+> [!NOTE]
+> If the delay calculated by the policy is less than the value returned in
+> the `x-ms-retry-after-ms` header, then the `x-ms-retry-after-ms` value will always
+> be used.
 
 The available Back-off Methods are:
 

--- a/docs/New-CosmosDbContext.md
+++ b/docs/New-CosmosDbContext.md
@@ -22,15 +22,6 @@ New-CosmosDbContext -Account <String> [-Database <String>] -Key <SecureString>
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
-### CustomAzureAccount
-
-```powershell
-New-CosmosDbContext -Account <String> [-Database <String>] -ResourceGroupName <String>
- [-MasterKeyType <String>] [-BackoffPolicy <BackoffPolicy>] -EndpointHostname <Uri>
- [-WhatIf] [-Confirm]
- [<CommonParameters>]
-```
-
 ### CustomAccount
 
 ```powershell
@@ -47,11 +38,28 @@ New-CosmosDbContext -Account <String> [-Database <String>] -ResourceGroupName <S
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
+### CustomAzureAccount
+
+```powershell
+New-CosmosDbContext -Account <String> [-Database <String>] -ResourceGroupName <String>
+ [-MasterKeyType <String>] [-BackoffPolicy <BackoffPolicy>] -EndpointHostname <Uri>
+ [-WhatIf] [-Confirm]
+ [<CommonParameters>]
+```
+
 ### EntraIdToken
 
 ```powershell
 New-CosmosDbContext -Account <String> [-Database <String>] -EntraIdToken <SecureString>
  [-BackoffPolicy <BackoffPolicy>] [-Environment <Environment>]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+### CustomEntraIdToken
+
+```powershell
+New-CosmosDbContext -Account <String> [-Database <String>] -EntraIdToken <SecureString>
+ [-BackoffPolicy <BackoffPolicy>] -EndpointHostname <Uri>
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
@@ -63,11 +71,27 @@ New-CosmosDbContext -Account <String> [-Database <String>] -AutoGenerateEntraIdT
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
+### CustomEntraIdTokenAutogen
+
+```powershell
+New-CosmosDbContext -Account <String> [-Database <String>] -AutoGenerateEntraIdToken
+ [-BackoffPolicy <BackoffPolicy>] -EndpointHostname <Uri>
+ [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
 ### Token
 
 ```powershell
 New-CosmosDbContext -Account <String> [-Database <String>] -Token <ContextToken[]>
  [-BackoffPolicy <BackoffPolicy>] [-Environment <Environment>]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+### CustomToken
+
+```powershell
+New-CosmosDbContext -Account <String> [-Database <String>] -Token <ContextToken[]>
+ [-BackoffPolicy <BackoffPolicy>] -EndpointHostname <Uri>
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
@@ -212,6 +236,30 @@ Creates a CosmosDB context with an Entra ID OAuth2 token generated automatically
 Get-CosmosDbEntraIdToken function to generate the token using the Base URI for the context as the
 resource URL. This function requires that the Az.Account module is installed and that the user or
 principle is logged in and has the appropriate RBAC permissions to access the Cosmos DB account.
+
+### Example 12
+
+```powershell
+PS C:\> $entraIdToken = Get-CosmosDbEntraIdToken -Endpoint 'https://MyAzureCosmosDB.documents.eassov.com/'
+PS C:\> $cosmosDbContext = New-CosmosDbContext -Account 'MyAzureCosmosDB' -EntraIdToken $entraIdToken -EndpointHostname 'documents.eassov.com'
+```
+Creates a CosmosDB context specifying the an Entra ID OAuth2 token generated
+by the Entra ID service for the endpoint 'https://MyAzureCosmosDB.documents.eassov.com/'. The
+identity it represents should have the appropriate RBAC permissions to access the Cosmos DB
+account. It will use the alternative Azure cloud endpoint 'documents.eassov.com' to access the
+Cosmos DB account.
+
+### Example 13
+
+```powershell
+PS C:\> $cosmosDbContext = New-CosmosDbContext -Account 'MyAzureCosmosDB' -AutoGenerateEntraIdToken -EndpointHostname 'documents.eassov.com'
+```
+Creates a CosmosDB context with an Entra ID OAuth2 token generated automatically. This will use the
+Get-CosmosDbEntraIdToken function to generate the token using the Base URI for the context as the
+resource URL. This function requires that the Az.Account module is installed and that the user or
+principle is logged in and has the appropriate RBAC permissions to access the Cosmos DB account.
+It will use the alternative Azure cloud endpoint 'documents.eassov.com' to access the
+Cosmos DB account.
 
 ## PARAMETERS
 

--- a/source/Public/utils/New-CosmosDbContext.ps1
+++ b/source/Public/utils/New-CosmosDbContext.ps1
@@ -9,12 +9,15 @@ function New-CosmosDbContext
     param
     (
         [Parameter(Mandatory = $true, ParameterSetName = 'Account')]
-        [Parameter(Mandatory = $true, ParameterSetName = 'AzureAccount')]
         [Parameter(Mandatory = $true, ParameterSetName = 'CustomAccount')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'AzureAccount')]
         [Parameter(Mandatory = $true, ParameterSetName = 'CustomAzureAccount')]
         [Parameter(Mandatory = $true, ParameterSetName = 'EntraIdToken')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'CustomEntraIdToken')]
         [Parameter(Mandatory = $true, ParameterSetName = 'EntraIdTokenAutogen')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'CustomEntraIdTokenAutogen')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Token')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'CustomToken')]
         [ValidateScript({ Assert-CosmosDbAccountNameValid -Name $_ })]
         [System.String]
         $Account,
@@ -69,17 +72,20 @@ function New-CosmosDbContext
         $Uri,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Token')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'CustomToken')]
         [Parameter(ParameterSetName = 'Emulator')]
         [ValidateNotNullOrEmpty()]
         [CosmosDB.ContextToken[]]
         $Token,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'EntraIdToken')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'CustomEntraIdToken')]
         [ValidateNotNullOrEmpty()]
         [System.Security.SecureString]
         $EntraIdToken,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'EntraIdTokenAutogen')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'CustomEntraIdTokenAutogen')]
         [ValidateNotNullOrEmpty()]
         [Switch]
         $AutoGenerateEntraIdToken,
@@ -98,8 +104,12 @@ function New-CosmosDbContext
         [CosmosDB.Environment]
         $Environment = [CosmosDB.Environment]::AzureCloud,
 
+        [Alias("BaseUri")]
         [Parameter(Mandatory = $true, ParameterSetName = 'CustomAccount')]
         [Parameter(Mandatory = $true, ParameterSetName = 'CustomAzureAccount')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'CustomEntraIdToken')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'CustomEntraIdTokenAutogen')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'CustomToken')]
         [System.Uri]
         $EndpointHostname
     )
@@ -109,6 +119,11 @@ function New-CosmosDbContext
         'Account'
         {
             $BaseUri = Get-CosmosDbUri -Account $Account -Environment $Environment
+        }
+
+        'CustomAccount'
+        {
+            $BaseUri = Get-CosmosDbUri -Account $Account -BaseHostname $EndpointHostname
         }
 
         'AzureAccount'
@@ -149,6 +164,38 @@ function New-CosmosDbContext
             $BaseUri = Get-CosmosDbUri -Account $Account -BaseHostname $EndpointHostname
         }
 
+        'EntraIdToken'
+        {
+            $BaseUri = Get-CosmosDbUri -Account $Account -Environment $Environment
+        }
+
+        'CustomEntraIdToken'
+        {
+            $BaseUri = Get-CosmosDbUri -Account $Account -BaseHostname $EndpointHostname
+        }
+
+        'EntraIdTokenAutogen'
+        {
+            $BaseUri = Get-CosmosDbUri -Account $Account -Environment $Environment
+            $EntraIdToken = Get-CosmosDbEntraIdToken -Endpoint $BaseUri
+        }
+
+        'CustomEntraIdTokenAutogen'
+        {
+            $BaseUri = Get-CosmosDbUri -Account $Account -BaseHostname $EndpointHostname
+            $EntraIdToken = Get-CosmosDbEntraIdToken -Endpoint $BaseUri
+        }
+
+        'Token'
+        {
+            $BaseUri = Get-CosmosDbUri -Account $Account -Environment $Environment
+        }
+
+        'CustomToken'
+        {
+            $BaseUri = Get-CosmosDbUri -Account $Account -BaseHostname $EndpointHostname
+        }
+
         'ConnectionString'
         {
             $decryptedConnectionString = $ConnectionString | Convert-CosmosDbSecureStringToString
@@ -156,11 +203,6 @@ function New-CosmosDbContext
             $BaseUri = [System.Uri]::new($connectionStringParts.AccountEndpoint)
             $Account = $BaseUri.Host.Split('.')[0]
             $Key = $connectionStringParts.AccountKey | ConvertTo-SecureString -AsPlainText -Force
-        }
-
-        'CustomAccount'
-        {
-            $BaseUri = Get-CosmosDbUri -Account $Account -BaseHostname $EndpointHostname
         }
 
         'Emulator'
@@ -201,22 +243,6 @@ function New-CosmosDbContext
             }
 
             $BaseUri = [System.Uri]::new($Uri)
-        }
-
-        'EntraIdToken'
-        {
-            $BaseUri = Get-CosmosDbUri -Account $Account -Environment $Environment
-        }
-
-        'EntraIdTokenAutogen'
-        {
-            $BaseUri = Get-CosmosDbUri -Account $Account -Environment $Environment
-            $EntraIdToken = Get-CosmosDbEntraIdToken -Endpoint $BaseUri
-        }
-
-        'Token'
-        {
-            $BaseUri = Get-CosmosDbUri -Account $Account -Environment $Environment
         }
     }
 

--- a/tests/Unit/CosmosDB.utils.Tests.ps1
+++ b/tests/Unit/CosmosDB.utils.Tests.ps1
@@ -958,7 +958,7 @@ console.log("done");
                 $newCosmosDbContextParameters = @{
                     Account  = $script:testAccount
                     Database = $script:testDatabase
-                    Token    = $script:testCustomToken
+                    Token    = $script:testContextToken
                     EndpointHostname = $script:testBaseHostnameAzureCustomEndpoint
                     Verbose  = $true
                 }


### PR DESCRIPTION
Adds support to `New-CosmosDbContext` for setting the `EndpointHostname` parameter when using EntraID or Token authentication.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/PlagueHO/CosmosDB/505)
<!-- Reviewable:end -->
