### PR TITLE
BREAKING CHANGE: Remove all legacy non-partitioned collection support (#528)

### DIFF
--- a/.build-local.ps1
+++ b/.build-local.ps1
@@ -12,8 +12,18 @@ function global:gitversion
         $obj = ($raw -join "`n") | ConvertFrom-Json
         if ($obj -and [string]::IsNullOrEmpty($obj.NuGetVersionV2) -and $obj.SemVer)
         {
-            $obj | Add-Member -MemberType NoteProperty -Name 'NuGetVersionV2' -Value $obj.SemVer -Force
-            $obj | Add-Member -MemberType NoteProperty -Name 'NuGetVersion' -Value $obj.SemVer -Force
+            # GitVersion 6.x removed NuGetVersionV2; construct a NuGet-compatible version
+            # from SemVer by replacing dots in the pre-release segment with hyphens.
+            # NuGet only allows [A-Za-z0-9-] in pre-release identifiers.
+            $semVer = $obj.SemVer -replace '\+.*$', ''
+            $parts = $semVer -split '-', 2
+            $nuGetVersion = if ($parts.Length -eq 2) {
+                "$($parts[0])-$($parts[1] -replace '\.', '-')"
+            } else {
+                $semVer
+            }
+            $obj | Add-Member -MemberType NoteProperty -Name 'NuGetVersionV2' -Value $nuGetVersion -Force
+            $obj | Add-Member -MemberType NoteProperty -Name 'NuGetVersion' -Value $nuGetVersion -Force
         }
         return $obj | ConvertTo-Json -Compress
     }

--- a/.build-local.ps1
+++ b/.build-local.ps1
@@ -1,0 +1,26 @@
+param([string[]] $Tasks = @('build'))
+
+Set-Location $PSScriptRoot
+
+function global:gitversion
+{
+    $exe = (Get-Command gitversion -CommandType Application).Source
+    $raw = & $exe @args | Where-Object { $_ -notmatch '^\s*(INFO|WARN|VERBOSE|DEBUG) \[' }
+
+    try
+    {
+        $obj = ($raw -join "`n") | ConvertFrom-Json
+        if ($obj -and [string]::IsNullOrEmpty($obj.NuGetVersionV2) -and $obj.SemVer)
+        {
+            $obj | Add-Member -MemberType NoteProperty -Name 'NuGetVersionV2' -Value $obj.SemVer -Force
+            $obj | Add-Member -MemberType NoteProperty -Name 'NuGetVersion' -Value $obj.SemVer -Force
+        }
+        return $obj | ConvertTo-Json -Compress
+    }
+    catch
+    {
+        return $raw
+    }
+}
+
+& ./build.ps1 -Tasks $Tasks

--- a/.build-local.ps1
+++ b/.build-local.ps1
@@ -4,8 +4,13 @@ Set-Location $PSScriptRoot
 
 function global:gitversion
 {
-    $exe = (Get-Command gitversion -CommandType Application).Source
-    $raw = & $exe @args | Where-Object { $_ -notmatch '^\s*(INFO|WARN|VERBOSE|DEBUG) \[' }
+    $cmd = Get-Command -Name dotnet-gitversion -CommandType Application -ErrorAction SilentlyContinue
+    if (-not $cmd)
+    {
+        $cmd = Get-Command -Name gitversion -CommandType Application -ErrorAction Stop
+    }
+
+    $raw = & $cmd.Source @args | Where-Object { $_ -notmatch '^\s*(INFO|WARN|VERBOSE|DEBUG) \[' }
 
     try
     {

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -57,6 +57,7 @@ Built with Sampler/ModuleBuilder; C# types in `source/classes/CosmosDB/`.
 - Mock `Invoke-CosmosDbRequest` to isolate from REST calls
 - Use `$script:` variables for shared test fixtures (accounts, keys, contexts)
 - `ConvertTo-SecureString -AsPlainText -Force` is acceptable **only** in test files
+- Use `.build-local.ps1` for all local builds and test runs (see `AGENTS.md`)
 
 ## Security
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
           path: output
 
       - name: Sign in to Azure with OIDC
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,13 +50,15 @@ jobs:
       - name: Install GitVersion
         shell: pwsh
         run: |
-          dotnet tool install --global GitVersion.Tool --version 5.*
+          dotnet tool install --global GitVersion.Tool --version 6.*
 
       - name: Calculate module version
         shell: pwsh
         run: |
-          $gitVersionObject = dotnet-gitversion | ConvertFrom-Json
-          $moduleVersion = $gitVersionObject.NuGetVersionV2
+          $rawOutput = dotnet-gitversion
+          $filteredOutput = $rawOutput | Where-Object { $_ -notmatch '^\s*(INFO|WARN|VERBOSE|DEBUG) \[' }
+          $gitVersionObject = ($filteredOutput -join "`n") | ConvertFrom-Json
+          $moduleVersion = if (-not [string]::IsNullOrEmpty($gitVersionObject.NuGetVersionV2)) { $gitVersionObject.NuGetVersionV2 } else { $gitVersionObject.SemVer }
           "ModuleVersion=$moduleVersion" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Build and package module

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,12 +38,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up .NET SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.0.x
 
@@ -77,7 +77,7 @@ jobs:
         run: ./build.ps1 -ResolveDependency -Tasks pack -Verbose
 
       - name: Upload module artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: module-output
           path: output/
@@ -120,12 +120,12 @@ jobs:
         shell: ${{ matrix.shell }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Download module artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: module-output
           path: output
@@ -135,7 +135,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: unit-test-results-${{ matrix.name }}
           path: output/testResults/
@@ -190,12 +190,12 @@ jobs:
       azureTenantId: ${{ secrets.AZURE_TENANT_ID }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Download module artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: module-output
           path: output

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,16 @@ jobs:
           $rawOutput = dotnet-gitversion
           $filteredOutput = $rawOutput | Where-Object { $_ -notmatch '^\s*(INFO|WARN|VERBOSE|DEBUG) \[' }
           $gitVersionObject = ($filteredOutput -join "`n") | ConvertFrom-Json
-          $moduleVersion = if (-not [string]::IsNullOrEmpty($gitVersionObject.NuGetVersionV2)) { $gitVersionObject.NuGetVersionV2 } else { $gitVersionObject.SemVer }
+          # GitVersion 6.x removed NuGetVersionV2; construct a NuGet-compatible version
+          # from SemVer by replacing dots in the pre-release segment with hyphens.
+          # NuGet only allows [A-Za-z0-9-] in pre-release identifiers.
+          $semVer = $gitVersionObject.SemVer -replace '\+.*$', ''
+          $versionParts = $semVer -split '-', 2
+          $moduleVersion = if ($versionParts.Length -eq 2) {
+              "$($versionParts[0])-$($versionParts[1] -replace '\.', '-')"
+          } else {
+              $semVer
+          }
           "ModuleVersion=$moduleVersion" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Build and package module

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install GitVersion
         shell: pwsh
         run: |
-          dotnet tool install --global GitVersion.Tool --version 5.*
+          dotnet tool install --global GitVersion.Tool --version 6.*
 
       - name: Build and package module
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
         run: ./build.ps1 -ResolveDependency -Tasks pack -Verbose
 
       - name: Sign in to Azure with OIDC
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,12 +20,12 @@ jobs:
     environment: test
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up .NET SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.0.x
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ output/CosmosDB/<version>/     # Build output (versioned)
 > default `build.ps1` invocation. Use `.build-local.ps1` instead — it wraps
 > `gitversion` to strip log noise and remap `NuGetVersionV2` for Sampler compatibility.
 > After running unit tests, `CosmosDB.dll` is locked in the current session; subsequent
-> builds must use a new process (`.build-local.ps1` spawns `pwsh -NoProfile -File`).
+> builds should be run in a new PowerShell process (for example, restart your `pwsh` session) to avoid file locking.
 
 ```powershell
 # Bootstrap (first time or after clean)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,21 +23,27 @@ output/CosmosDB/<version>/     # Build output (versioned)
 
 ## Commands
 
+> **Local builds:** GitVersion 6.x outputs INFO lines to stdout, which breaks the
+> default `build.ps1` invocation. Use `.build-local.ps1` instead — it wraps
+> `gitversion` to strip log noise and remap `NuGetVersionV2` for Sampler compatibility.
+> After running unit tests, `CosmosDB.dll` is locked in the current session; subsequent
+> builds must use a new process (`.build-local.ps1` spawns `pwsh -NoProfile -File`).
+
 ```powershell
 # Bootstrap (first time or after clean)
 ./build.ps1 -ResolveDependency -Tasks noop
 
 # Build (compile C#, assemble module, generate help)
-./build.ps1 -Tasks build
+./.build-local.ps1 -Tasks build
 
 # Unit tests only (no Azure required)
-./build.ps1 -Tasks test -PesterScript tests/Unit
+./.build-local.ps1 -Tasks test -PesterScript tests/Unit
 
 # All tests (unit + integration — requires Azure credentials)
-./build.ps1 -Tasks test
+./.build-local.ps1 -Tasks test
 
 # Package for publishing
-./build.ps1 -Tasks pack
+./.build-local.ps1 -Tasks pack
 ```
 
 **C# classes only:**
@@ -53,8 +59,8 @@ dotnet build source/classes/CosmosDB/CosmosDB.csproj /p:Configuration=Release
 1. Add unit test in `tests/Unit/CosmosDB.<resource-type>.Tests.ps1`
 1. Add integration test if the cmdlet hits the live API
 1. Create/update `docs/Verb-CosmosDb<Noun>.md` (PlatyPS format)
-1. Run `./build.ps1 -Tasks build` — must succeed
-1. Run `./build.ps1 -Tasks test -PesterScript tests/Unit` — must pass
+1. Run `./.build-local.ps1 -Tasks build` — must succeed
+1. Run `./.build-local.ps1 -Tasks test -PesterScript tests/Unit` — must pass
 
 ## CI Pipeline (Azure Pipelines)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- BREAKING CHANGE: Removed support for creating collections without a
+  partition key. `New-CosmosDbCollection` now requires the `-PartitionKey`
+  parameter. Collections created without a partition key (legacy
+  non-partitioned collections) are no longer supported by this module.
+  Pin to the previous major version if you still require non-partitioned
+  collection support.
+- BREAKING CHANGE: Removed the `-PartitionKeyRangeId` parameter from
+  `Get-CosmosDbDocument` and `Get-CosmosDbDocumentJson`. This parameter
+  only applied to legacy non-partitioned collection scenarios.
+- BREAKING CHANGE: Removed the `-ApiVersion` parameter from
+  `Invoke-CosmosDbRequest`. The Cosmos DB REST API version is now
+  pinned internally to `2020-07-15` and cannot be overridden.
+- Updated module to default to Cosmos DB REST API version `2020-07-15`.
+
+
 ### Operational Changes
 
 - Added `AGENTS.md` and `copilot-instructions.md` to optimize the
@@ -20,10 +37,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   governing principles and development standards.
 - Added `Configuration` to `RequiredModules.psd1` to satisfy
   `ModuleBuilder` required module loading in newer releases.
-
-### Changes
-
-- Updated module to default to Cosmos DB REST API version `2020-07-15`.
 
 ### Added
 

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,10 +1,10 @@
 mode: ContinuousDelivery
+verbosity: None
 next-version: 3.0.0
 major-version-bump-message: '\s?(breaking|major|breaking\schange)'
 minor-version-bump-message: '\s?(add|feature|minor)'
 patch-version-bump-message: '\s?(fix|patch)'
 no-bump-message: '\+semver:\s?(none|skip)'
-assembly-informational-format: '{NuGetVersionV2}+Sha.{Sha}.Date.{CommitDate}'
 branches:
   master:
     tag: preview

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,5 @@
 mode: ContinuousDelivery
-verbosity: None
+verbosity: Quiet
 next-version: 3.0.0
 major-version-bump-message: '\s?(breaking|major|breaking\schange)'
 minor-version-bump-message: '\s?(add|feature|minor)'

--- a/docs/Get-CosmosDbDocument.md
+++ b/docs/Get-CosmosDbDocument.md
@@ -20,7 +20,7 @@ Get-CosmosDbDocument -Context <Context> [-Key <SecureString>] [-KeyType <String>
  [-Database <String>] -CollectionId <String> [-Id <String>]
  [-PartitionKey <Object[]>] [-MaxItemCount <Int32>] [-ContinuationToken <String>]
  [-ConsistencyLevel <String>] [-SessionToken <String>]
- [-PartitionKeyRangeId <String>] [-Query <String>] [-QueryParameters <Hashtable[]>]
+ [-Query <String>] [-QueryParameters <Hashtable[]>]
  [-QueryEnableCrossPartition <Boolean>] [-ResponseHeader <PSReference>]
  [-ReturnJson <switch>] [<CommonParameters>]
 ```
@@ -32,7 +32,7 @@ Get-CosmosDbDocument -Account <String> [-Key <SecureString>] [-KeyType <String>]
  [-Database <String>] -CollectionId <String> [-Id <String>]
  [-PartitionKey <Object[]>] [-MaxItemCount <Int32>] [-ContinuationToken <String>]
  [-ConsistencyLevel <String>] [-SessionToken <String>]
- [-PartitionKeyRangeId <String>] [-Query <String>] [-QueryParameters <Hashtable[]>]
+ [-Query <String>] [-QueryParameters <Hashtable[]>]
  [-QueryEnableCrossPartition <Boolean>] [-ResponseHeader <PSReference>]
  [-ReturnJson <switch>] [<CommonParameters>]
 ```
@@ -287,23 +287,6 @@ with a partitionKey definition.
 
 ```yaml
 Type: String[]
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -PartitionKeyRangeId
-
-The partition key range Id for reading data.
-Should not be set if Id is set.
-
-```yaml
-Type: String
 Parameter Sets: (All)
 Aliases:
 

--- a/docs/Get-CosmosDbDocumentJson.md
+++ b/docs/Get-CosmosDbDocumentJson.md
@@ -20,7 +20,7 @@ Get-CosmosDbDocumentJson -Context <Context> [-Key <SecureString>] [-KeyType <Str
  [-Database <String>] -CollectionId <String> [-Id <String>]
  [-PartitionKey <Object[]>] [-MaxItemCount <Int32>] [-ContinuationToken <String>]
  [-ConsistencyLevel <String>] [-SessionToken <String>]
- [-PartitionKeyRangeId <String>] [-Query <String>] [-QueryParameters <Hashtable[]>]
+ [-Query <String>] [-QueryParameters <Hashtable[]>]
  [-QueryEnableCrossPartition <Boolean>] [-ResponseHeader <PSReference>] [<CommonParameters>]
 ```
 
@@ -31,7 +31,7 @@ Get-CosmosDbDocumentJson -Account <String> [-Key <SecureString>] [-KeyType <Stri
  [-Database <String>] -CollectionId <String> [-Id <String>]
  [-PartitionKey <Object[]>] [-MaxItemCount <Int32>] [-ContinuationToken <String>]
  [-ConsistencyLevel <String>] [-SessionToken <String>]
- [-PartitionKeyRangeId <String>] [-Query <String>] [-QueryParameters <Hashtable[]>]
+ [-Query <String>] [-QueryParameters <Hashtable[]>]
  [-QueryEnableCrossPartition <Boolean>] [-ResponseHeader <PSReference>] [<CommonParameters>]
 ```
 
@@ -275,23 +275,6 @@ with a partitionKey definition.
 
 ```yaml
 Type: String[]
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -PartitionKeyRangeId
-
-The partition key range Id for reading data.
-Should not be set if Id is set.
-
-```yaml
-Type: String
 Parameter Sets: (All)
 Aliases:
 

--- a/docs/Get-CosmosDbEntraIdToken.md
+++ b/docs/Get-CosmosDbEntraIdToken.md
@@ -15,7 +15,8 @@ calling the Entra ID service using the Get-AzAccessToken cmdlet.
 ## SYNTAX
 
 ```powershell
-Get-CosmosDbEntraIdToken [[-Endpoint] <String>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Get-CosmosDbEntraIdToken [[-Environment] <Environment>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Get-CosmosDbEntraIdToken [-Endpoint <String>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -26,6 +27,10 @@ This requires that a user or service principal has been authenticated
 using the Connect-AzAccount cmdlet. If the user is not authenticated,
 the cmdlet will return null but display an error message.
 
+The `Environment` parameter set resolves the correct Azure AD resource URL
+for the specified cloud environment. The `Endpoint` parameter set allows an
+explicit resource URL to be provided for custom or non-standard scenarios.
+
 ## EXAMPLES
 
 ### Example 1
@@ -33,23 +38,62 @@ the cmdlet will return null but display an error message.
 PS C:\> Get-CosmosDbEntraIdToken
 ```
 
-This will return a secure string token that can be used with Azure Cosmos DB.
-The token will use the default resource URI of https://cosmos.azure.com.
+This will return a secure string token using the default AzureCloud environment
+resource URI of https://cosmos.azure.com.
+
+### Example 2
+```powershell
+PS C:\> Get-CosmosDbEntraIdToken -Environment AzureUSGovernment
+```
+
+This will return a secure string token using the Azure US Government resource
+URI of https://cosmos.azure.us.
+
+### Example 3
+```powershell
+PS C:\> Get-CosmosDbEntraIdToken -Endpoint 'https://cosmos.azure.com'
+```
+
+This will return a secure string token using the explicitly specified resource URI.
 
 ## PARAMETERS
 
-### -Endpoint
+### -Environment
 
-This parameter allows the resource URI of the token to be specified. The default
-value is https://cosmos.azure.com.
+Specifies the Azure cloud environment. The cmdlet resolves the correct Azure AD
+resource URL for the environment:
+- AzureCloud: https://cosmos.azure.com
+- AzureUSGovernment: https://cosmos.azure.us
+- AzureChinaCloud: https://cosmos.azure.cn
+
+This parameter cannot be used together with `-Endpoint`.
 
 ```yaml
-Type: String
-Parameter Sets: (All)
+Type: CosmosDB.Environment
+Parameter Sets: Environment
 Aliases:
 
 Required: False
 Position: 0
+Default value: AzureCloud
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Endpoint
+
+This parameter allows the Azure AD resource URI of the token to be specified
+explicitly. Use this for custom or non-standard cloud deployments.
+
+This parameter cannot be used together with `-Environment`.
+
+```yaml
+Type: String
+Parameter Sets: Endpoint
+Aliases:
+
+Required: False
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/Invoke-CosmosDbRequest.md
+++ b/docs/Invoke-CosmosDbRequest.md
@@ -17,7 +17,7 @@ Execute a new request to a Cosmos DB REST endpoint.
 
 ```powershell
 Invoke-CosmosDbRequest -Context <Context> [-Database <String>] [-Key <SecureString>] [-KeyType <String>]
- [-Method <String>] -ResourceType <String> [-ResourcePath <String>] [-Body <String>] [-ApiVersion <String>]
+ [-Method <String>] -ResourceType <String> [-ResourcePath <String>] [-Body <String>]
  [-Headers <Hashtable>] [-ContentType <String>] [-Encoding <String>] [<CommonParameters>]
 ```
 
@@ -25,7 +25,7 @@ Invoke-CosmosDbRequest -Context <Context> [-Database <String>] [-Key <SecureStri
 
 ```powershell
 Invoke-CosmosDbRequest -Account <String> [-Database <String>] [-Key <SecureString>] [-KeyType <String>]
- [-Method <String>] -ResourceType <String> [-ResourcePath <String>] [-Body <String>] [-ApiVersion <String>]
+ [-Method <String>] -ResourceType <String> [-ResourcePath <String>] [-Body <String>]
  [-Headers <Hashtable>] [-ContentType <String>] [-Encoding <String>] [<CommonParameters>]
 ```
 
@@ -206,22 +206,6 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -ApiVersion
-
-This is the version of the Rest API that will be called.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: 2020-07-15
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/New-CosmosDbCollection.md
+++ b/docs/New-CosmosDbCollection.md
@@ -18,7 +18,7 @@ Create a new collection in a Cosmos DB database.
 ```powershell
 New-CosmosDbCollection -Context <Context> [-Key <SecureString>] [-KeyType <String>]
  [-Database <String>] -Id <String> [-OfferThroughput <Int32>] [-OfferType <String>]
- [-PartitionKey <String>] [-IndexingPolicy <Policy>] [-DefaultTimeToLive <Int32>]
+ -PartitionKey <String> [-IndexingPolicy <Policy>] [-DefaultTimeToLive <Int32>]
  [-UniqueKeyPolicy <Policy>] [-AutoscaleThroughput <Int32>] [<CommonParameters>]
 ```
 
@@ -27,7 +27,7 @@ New-CosmosDbCollection -Context <Context> [-Key <SecureString>] [-KeyType <Strin
 ```powershell
 New-CosmosDbCollection -Context <Context> [-Key <SecureString>] [-KeyType <String>]
  [-Database <String>] -Id <String> [-OfferThroughput <Int32>] [-OfferType <String>]
- [-PartitionKey <String>] [-IndexingPolicyJson <String>] [-DefaultTimeToLive <Int32>]
+ -PartitionKey <String> [-IndexingPolicyJson <String>] [-DefaultTimeToLive <Int32>]
  [-UniqueKeyPolicy <Policy>] [-AutoscaleThroughput <Int32>] [<CommonParameters>]
 ```
 
@@ -36,7 +36,7 @@ New-CosmosDbCollection -Context <Context> [-Key <SecureString>] [-KeyType <Strin
 ```powershell
 New-CosmosDbCollection -Account <String> [-Key <SecureString>] [-KeyType <String>]
  [-Database <String>] -Id <String> [-OfferThroughput <Int32>] [-OfferType <String>]
- [-PartitionKey <String>] [-IndexingPolicyJson <String>] [-DefaultTimeToLive <Int32>]
+ -PartitionKey <String> [-IndexingPolicyJson <String>] [-DefaultTimeToLive <Int32>]
  [-UniqueKeyPolicy <Policy>] [-AutoscaleThroughput <Int32>] [<CommonParameters>]
 ```
 
@@ -45,7 +45,7 @@ New-CosmosDbCollection -Account <String> [-Key <SecureString>] [-KeyType <String
 ```powershell
 New-CosmosDbCollection -Account <String> [-Key <SecureString>] [-KeyType <String>]
  [-Database <String>] -Id <String> [-OfferThroughput <Int32>] [-OfferType <String>]
- [-PartitionKey <String>] [-IndexingPolicy <Policy>] [-DefaultTimeToLive <Int32>]
+ -PartitionKey <String> [-IndexingPolicy <Policy>] [-DefaultTimeToLive <Int32>]
  [-UniqueKeyPolicy <Policy>] [-AutoscaleThroughput <Int32>] [<CommonParameters>]
 ```
 
@@ -58,10 +58,11 @@ This cmdlet will create a collection in a Cosmos DB.
 ### Example 1
 
 ```powershell
-PS C:\> New-CosmosDbCollection -Context $cosmosDbContext -Id 'MyNewCollection' -OfferThroughput 2500
+PS C:\> New-CosmosDbCollection -Context $cosmosDbContext -Id 'MyNewCollection' -PartitionKey 'id' -OfferThroughput 2500
 ```
 
-Create a collection in the database with the offer throughput of 2500 RU/s.
+Create a collection in the database with the partition key 'id' and
+the offer throughput of 2500 RU/s.
 
 ### Example 2
 
@@ -75,11 +76,11 @@ the offer throughput of 50,000 RU/s.
 ### Example 3
 
 ```powershell
-PS C:\> New-CosmosDbCollection -Context $cosmosDbContext -Id 'PartitionedCollection' -DefaultTimeToLive 3600
+PS C:\> New-CosmosDbCollection -Context $cosmosDbContext -Id 'PartitionedCollection' -PartitionKey 'id' -DefaultTimeToLive 3600
 ```
 
-Create a collection in the database with the a default time to live of 3600
-seconds.
+Create a collection in the database with the partition key 'id' and
+a default time to live of 3600 seconds.
 
 ### Example 4
 
@@ -287,15 +288,16 @@ Accept wildcard characters: False
 
 ### -PartitionKey
 
-This value is used to configure the partition keys to be used
+This value is used to configure the partition key to be used
 for partitioning data into multiple partitions.
+All collections must define a partition key.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: False
+Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/source/Private/utils/Get-CosmosDbEntraIdEndpoint.ps1
+++ b/source/Private/utils/Get-CosmosDbEntraIdEndpoint.ps1
@@ -1,0 +1,37 @@
+function Get-CosmosDbEntraIdEndpoint
+{
+    [CmdletBinding(DefaultParameterSetName = 'Environment')]
+    [OutputType([System.String])]
+    param
+    (
+        [Parameter(ParameterSetName = 'Environment')]
+        [CosmosDB.Environment]
+        $Environment = [CosmosDB.Environment]::AzureCloud,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'Hostname')]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $BaseHostname
+    )
+
+    if ($PSCmdlet.ParameterSetName -eq 'Hostname')
+    {
+        $endpoint = switch -Wildcard ($BaseHostname)
+        {
+            '*.azure.us' { 'https://cosmos.azure.us' }
+            '*.azure.cn' { 'https://cosmos.azure.cn' }
+            default      { 'https://cosmos.azure.com' }
+        }
+    }
+    else
+    {
+        $endpoint = switch ($Environment)
+        {
+            'AzureUSGovernment' { 'https://cosmos.azure.us' }
+            'AzureChinaCloud'   { 'https://cosmos.azure.cn' }
+            default             { 'https://cosmos.azure.com' }
+        }
+    }
+
+    return $endpoint
+}

--- a/source/Private/utils/Invoke-CosmosDbRequest.ps1
+++ b/source/Private/utils/Invoke-CosmosDbRequest.ps1
@@ -49,11 +49,6 @@ function Invoke-CosmosDbRequest
         $Body = '',
 
         [Parameter()]
-        [ValidateSet('2014-08-21', '2015-04-08', '2015-06-03', '2015-08-06', '2015-12-16', '2016-07-11', '2017-01-19', '2017-02-22', '2017-05-03', '2017-11-15', '2018-06-18', '2018-08-31', '2018-09-17', '2018-12-31', '2020-07-15')]
-        [System.String]
-        $ApiVersion = '2020-07-15',
-
-        [Parameter()]
         [System.Collections.Hashtable]
         $Headers = @{ },
 
@@ -197,7 +192,7 @@ function Invoke-CosmosDbRequest
     }
 
     $Headers += $authorizationHeaders
-    $Headers.Add('x-ms-version', $ApiVersion)
+    $Headers.Add('x-ms-version', '2020-07-15')
 
     $invokeWebRequestParameters = @{
         Uri             = $uri

--- a/source/Private/utils/Invoke-CosmosDbRequest.ps1
+++ b/source/Private/utils/Invoke-CosmosDbRequest.ps1
@@ -192,7 +192,7 @@ function Invoke-CosmosDbRequest
     }
 
     $Headers += $authorizationHeaders
-    $Headers.Add('x-ms-version', '2020-07-15')
+    $Headers['x-ms-version'] = '2020-07-15'
 
     $invokeWebRequestParameters = @{
         Uri             = $uri

--- a/source/Public/attachments/Remove-CosmosDbAttachment.ps1
+++ b/source/Public/attachments/Remove-CosmosDbAttachment.ps1
@@ -73,5 +73,5 @@ function Remove-CosmosDbAttachment
         -Method 'Delete' `
         -ResourceType 'attachments' `
         -ResourcePath $resourcePath `
-        -Header $headers
+        -Headers $headers
 }

--- a/source/Public/collections/New-CosmosDbCollection.ps1
+++ b/source/Public/collections/New-CosmosDbCollection.ps1
@@ -49,7 +49,7 @@ function New-CosmosDbCollection
         [System.String]
         $OfferType,
 
-        [Parameter()]
+        [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
         $PartitionKey,
@@ -93,11 +93,6 @@ function New-CosmosDbCollection
 
     if ($PSBoundParameters.ContainsKey('OfferThroughput'))
     {
-        if ($OfferThroughput -gt 10000 -and -not ($PSBoundParameters.ContainsKey('PartitionKey')))
-        {
-            New-CosmosDbInvalidOperationException -Message $($LocalizedData.ErrorNewCollectionParitionKeyOfferRequired)
-        }
-
         $headers += @{
             'x-ms-offer-throughput' = $OfferThroughput
         }
@@ -115,11 +110,6 @@ function New-CosmosDbCollection
 
     if ($PSBoundParameters.ContainsKey('AutoscaleThroughput'))
     {
-        if (-not ($PSBoundParameters.ContainsKey('PartitionKey')))
-        {
-            New-CosmosDbInvalidOperationException -Message $($LocalizedData.ErrorNewCollectionParitionKeyAutoscaleRequired)
-        }
-
         $headers += @{
             'x-ms-cosmos-offer-autopilot-settings' = ConvertTo-Json -InputObject @{
                 maxThroughput = $AutoscaleThroughput
@@ -134,20 +124,13 @@ function New-CosmosDbCollection
         id = $id
     }
 
-    if ($PSBoundParameters.ContainsKey('PartitionKey'))
-    {
-        $bodyObject += @{
-            partitionKey = @{
-                paths = @('/{0}' -f $PartitionKey.TrimStart('/'))
-                kind  = 'Hash'
-            }
+    $bodyObject += @{
+        partitionKey = @{
+            paths = @('/{0}' -f $PartitionKey.TrimStart('/'))
+            kind  = 'Hash'
         }
-        $null = $PSBoundParameters.Remove('PartitionKey')
     }
-    else
-    {
-        Write-Warning -Message $($LocalizedData.NonPartitionedCollectionWarning)
-    }
+    $null = $PSBoundParameters.Remove('PartitionKey')
 
     if ($PSBoundParameters.ContainsKey('IndexingPolicy'))
     {

--- a/source/Public/documents/Get-CosmosDbDocument.ps1
+++ b/source/Public/documents/Get-CosmosDbDocument.ps1
@@ -69,11 +69,6 @@ function Get-CosmosDbDocument
         [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $PartitionKeyRangeId,
-
-        [Parameter()]
-        [ValidateNotNullOrEmpty()]
-        [System.String]
         $Query,
 
         [Parameter()]

--- a/source/Public/documents/Get-CosmosDbDocumentJson.ps1
+++ b/source/Public/documents/Get-CosmosDbDocumentJson.ps1
@@ -69,11 +69,6 @@ function Get-CosmosDbDocumentJson
         [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $PartitionKeyRangeId,
-
-        [Parameter()]
-        [ValidateNotNullOrEmpty()]
-        [System.String]
         $Query,
 
         [Parameter()]
@@ -98,7 +93,6 @@ function Get-CosmosDbDocumentJson
     $null = $PSBoundParameters.Remove('ContinuationToken')
     $null = $PSBoundParameters.Remove('ConsistencyLevel')
     $null = $PSBoundParameters.Remove('SessionToken')
-    $null = $PSBoundParameters.Remove('PartitionKeyRangeId')
     $null = $PSBoundParameters.Remove('Query')
     $null = $PSBoundParameters.Remove('QueryParameters')
     $null = $PSBoundParameters.Remove('QueryEnableCrossPartition')
@@ -147,15 +141,6 @@ function Get-CosmosDbDocumentJson
             }
 
             $body = ConvertTo-Json -InputObject $bodyObject
-        }
-        else
-        {
-            if (-not [System.String]::IsNullOrEmpty($PartitionKeyRangeId))
-            {
-                $headers += @{
-                    'x-ms-documentdb-partitionkeyrangeid' = $PartitionKeyRangeId
-                }
-            }
         }
 
         # The following headers apply when querying documents or just getting a list

--- a/source/Public/utils/Get-CosmosDbEntraIdToken.ps1
+++ b/source/Public/utils/Get-CosmosDbEntraIdToken.ps1
@@ -1,17 +1,28 @@
 function Get-CosmosDbEntraIdToken {
     [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'Environment')]
     [OutputType([System.Security.SecureString])]
     param
     (
-        [Parameter()]
+        [Parameter(ParameterSetName = 'Environment')]
+        [CosmosDB.Environment]
+        $Environment = [CosmosDB.Environment]::AzureCloud,
+
+        [Parameter(ParameterSetName = 'Endpoint')]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $Endpoint = 'https://cosmos.azure.com'
+        $Endpoint
     )
 
-    # Remove any trailing slash as Cosmos DB RBAC does not expect the resource URL to have a trailing slash
-    $Endpoint = $Endpoint.TrimEnd('/')
+    if ($PSCmdlet.ParameterSetName -eq 'Endpoint')
+    {
+        # Remove any trailing slash as Cosmos DB RBAC does not expect the resource URL to have a trailing slash
+        $Endpoint = $Endpoint.TrimEnd('/')
+    }
+    else
+    {
+        $Endpoint = Get-CosmosDbEntraIdEndpoint -Environment $Environment
+    }
 
     <#
         `-AsSecureString` is not required here because the `Get-AzAccessToken` cmdlet always

--- a/source/Public/utils/New-CosmosDbContext.ps1
+++ b/source/Public/utils/New-CosmosDbContext.ps1
@@ -178,13 +178,13 @@ function New-CosmosDbContext
         'EntraIdTokenAutogen'
         {
             $BaseUri = Get-CosmosDbUri -Account $Account -Environment $Environment
-            $EntraIdToken = Get-CosmosDbEntraIdToken -Endpoint $BaseUri
+            $EntraIdToken = Get-CosmosDbEntraIdToken -Environment $Environment
         }
 
         'CustomEntraIdTokenAutogen'
         {
             $BaseUri = Get-CosmosDbUri -Account $Account -BaseHostname $EndpointHostname
-            $EntraIdToken = Get-CosmosDbEntraIdToken -Endpoint $BaseUri
+            $EntraIdToken = Get-CosmosDbEntraIdToken -Endpoint (Get-CosmosDbEntraIdEndpoint -BaseHostname $EndpointHostname)
         }
 
         'Token'

--- a/source/en-US/CosmosDB.strings.psd1
+++ b/source/en-US/CosmosDB.strings.psd1
@@ -20,7 +20,6 @@ ConvertFrom-StringData -StringData @'
     RemovingAzureCosmosDBAccount = Removing Azure Cosmos DB account '{0}' in resource group '{1}'.
     StoredProcedureScriptLogResults = Stored Procedure '{0}' script log results:\n{1}
     RequestChargeResults = Request charge for {0} to '{1}' was {2} RUs.
-    NonPartitionedCollectionWarning = It is not recommended to create a collection without a partition key. It may result in reduced performance and increased cost. This functionality is included for backwards compatibility only and will be removed in a future version.
     CollectionProvisionedThroughputExceededWithBackoffPolicy = The collection has exceeded the provisioned throughput limit but a back-off policy is specified.
     CollectionProvisionedThroughputExceededNoBackoffPolicy = The collection has exceeded the provisioned throughput limit but there is no back-off policy.
     CollectionProvisionedThroughputExceededMaxRetriesHit = The maximum back-off policy retries {0} has been exceeded.
@@ -30,8 +29,6 @@ ConvertFrom-StringData -StringData @'
     ErrorAuthorizationKeyEmpty = The authorization key is empty. It must be passed in the context or a valid token context for the resource being accessed must be supplied.
     WarningNewCollectionOfferTypeDeprecated = The 'OfferType' parameter is a legacy parameter and is only supported for backwards compatibility and may be removed in future. It is recommended to use 'OfferThroughput' or 'AutopilotThroughput' instead.
     ErrorNewCollectionOfferParameterConflict = Only one of 'OfferType', OfferThroughput' or 'AutoscaleThroughput' should be specified when creating a new collection.
-    ErrorNewCollectionParitionKeyOfferRequired = A 'PartitionKey' is required when the 'OfferThroughput' is greater than 10000.
-    ErrorNewCollectionParitionKeyAutoscaleRequired = A 'PartitionKey' is required when the 'AutoscaleThroughput' is used.
     ErrorNewCollectionIncludedPathIndexInvalidDataType = The DataType '{1}' is invalid for the included path index Kind '{0}'. Please use one of: {2}.
     ErrorNewCollectionIncludedPathIndexPrecisionNotSupported = A Precision value should not be provided for the index Kind '{0}'.
     WarningNewCollectionIncludedPathIndexHashDeprecated = The 'Hash' index Kind has been deprecated. Default String and Number 'Range' index Kinds will be used instead. The 'Hash' index Kind will be removed in a future breaking release. See https://docs.microsoft.com/en-us/azure/cosmos-db/index-types#index-kind.

--- a/tests/Integration/CosmosDB.integration.Tests.ps1
+++ b/tests/Integration/CosmosDB.integration.Tests.ps1
@@ -1692,6 +1692,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
             $script:result = New-CosmosDbCollection `
                 -Context $script:testContext `
                 -Id $script:testCollection `
+                -PartitionKey $script:testPartitionKey `
                 -OfferThroughput 400 `
                 -IndexingPolicy $script:indexingPolicyNone `
                 -Verbose
@@ -1716,6 +1717,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
             $script:result = New-CosmosDbCollection `
                 -Context $script:testContext `
                 -Id $script:testCollection `
+                -PartitionKey $script:testPartitionKey `
                 -DefaultTimeToLive $script:testDefaultTimeToLive `
                 -Verbose
         }
@@ -1809,11 +1811,13 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
             $null = New-CosmosDbCollection `
                 -Context $script:testContext `
                 -Id "$($script:testCollection)1" `
+                -PartitionKey $script:testPartitionKey `
                 -Verbose
 
             $null = New-CosmosDbCollection `
                 -Context $script:testContext `
                 -Id "$($script:testCollection)2" `
+                -PartitionKey $script:testPartitionKey `
                 -Verbose
         }
     }

--- a/tests/Integration/CosmosDB.integration.Tests.ps1
+++ b/tests/Integration/CosmosDB.integration.Tests.ps1
@@ -1419,6 +1419,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
                 -Context $script:testContext `
                 -CollectionId $script:testCollection `
                 -Query "SELECT * FROM docs c" `
+                -QueryEnableCrossPartition $True `
                 -Verbose
         }
 
@@ -1435,6 +1436,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
                 -Context $script:testContext `
                 -CollectionId $script:testCollection `
                 -Query "SELECT * FROM docs c WHERE (c.id = '$testDocumentUTF8Id')" `
+                -QueryEnableCrossPartition $True `
                 -Verbose
         }
 
@@ -1451,6 +1453,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
                 -Context $script:testContext `
                 -CollectionId $script:testCollection `
                 -Query 'SELECT * FROM docs c WHERE (c.id = @id)' `
+                -QueryEnableCrossPartition $True `
                 -QueryParameters @{
                     name = '@id'
                     value = $testDocumentUTF8Id

--- a/tests/Integration/CosmosDB.integration.Tests.ps1
+++ b/tests/Integration/CosmosDB.integration.Tests.ps1
@@ -848,117 +848,6 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
         }
     }
 
-    Context 'When adding a read collection permission for a user' {
-        It 'Should not throw an exception' {
-            $script:collectionResourcePath = Get-CosmosDbCollectionResourcePath `
-                -Database $script:testDatabase `
-                -Id $script:testCollection
-            $script:result = New-CosmosDbPermission `
-                -Context $script:testContext `
-                -UserId $script:testUser `
-                -Id $script:testCollectionPermission `
-                -Resource $script:collectionResourcePath `
-                -PermissionMode Read `
-                -Verbose
-        }
-
-        It 'Should return expected object' {
-            Test-GenericResult -GenericResult $script:result
-            $script:result.Id | Should -Be $script:testCollectionPermission
-            $script:result.permissionMode | Should -Be 'Read'
-            $script:result.resource | Should -Be $script:collectionResourcePath
-            $script:result.Token | Should -BeOfType [System.String]
-        }
-    }
-
-    Context 'When getting the read collection permission for the user' {
-        It 'Should not throw an exception' {
-            $script:collectionResourcePath = Get-CosmosDbCollectionResourcePath `
-                -Database $script:testDatabase `
-                -Id $script:testCollection
-            $script:result = Get-CosmosDbPermission `
-                -Context $script:testContext `
-                -UserId $script:testUser `
-                -Id $script:testCollectionPermission `
-                -Verbose
-        }
-
-        It 'Should return expected object' {
-            Test-GenericResult -GenericResult $script:result
-            $script:result.Id | Should -Be $script:testCollectionPermission
-            $script:result.permissionMode | Should -Be 'Read'
-            $script:result.resource | Should -Be $script:collectionResourcePath
-            $script:result.Token | Should -BeOfType [System.String]
-        }
-    }
-
-    Context 'When getting existing collection using resource token for user permission as context' {
-        It 'Should not throw an exception' {
-            $script:collectionResourcePath = Get-CosmosDbCollectionResourcePath `
-                -Database $script:testDatabase `
-                -Id $script:testCollection `
-                -Verbose
-            $permission = Get-CosmosDbPermission `
-                -Context $script:testContext `
-                -UserId $script:testUser `
-                -Id $script:testCollectionPermission `
-                -Verbose
-            $contextToken = New-CosmosDbContextToken `
-                -Resource $script:collectionResourcePath `
-                -TimeStamp $permission[0].Timestamp `
-                -Token (ConvertTo-SecureString -String $permission[0].Token -AsPlainText -Force) `
-                -Verbose
-            $resourceContext = New-CosmosDbContext `
-                -Account $script:testAccountName `
-                -Database $script:testDatabase `
-                -Token $contextToken `
-                -Verbose
-            $script:result = Get-CosmosDbCollection `
-                -Context $resourceContext `
-                -Id $script:testCollection `
-                -Verbose
-        }
-
-        It 'Should return expected object' {
-            Test-CollectionResultComplexAutomaticIndexingPolicy -CollectionResult $script:Result
-            $script:result.Id | Should -Be $script:testCollection
-        }
-    }
-
-    Context 'When getting existing offers' {
-        It 'Should not throw an exception' {
-            $script:result = Get-CosmosDbOffer -Context $script:testContext -Verbose
-        }
-
-        It 'Should return expected object' {
-            Test-GenericResult -GenericResult $script:result
-            $script:result.OfferVersion | Should -BeOfType [System.String]
-            $script:result.OfferType | Should -BeOfType [System.String]
-            $script:result.OfferResourceId | Should -BeOfType [System.String]
-            $script:result.Id | Should -BeOfType [System.String]
-            $script:result.content.offerThroughput | Should -Be 400
-            $script:result.content.offerIsRUPerMinuteThroughputEnabled | Should -Be $false
-        }
-    }
-
-    Context 'When updating existing offer throughput' {
-        It 'Should not throw an exception' {
-            $script:result = `
-                Get-CosmosDbOffer -Context $script:testContext -Verbose |
-                Set-CosmosDbOffer -Context $script:testContext -OfferThroughput 800 -Verbose
-        }
-
-        It 'Should return expected object' {
-            Test-GenericResult -GenericResult $script:result
-            $script:result.OfferVersion | Should -BeOfType [System.String]
-            $script:result.OfferType | Should -BeOfType [System.String]
-            $script:result.OfferResourceId | Should -BeOfType [System.String]
-            $script:result.Id | Should -BeOfType [System.String]
-            $script:result.content.offerThroughput | Should -Be 800
-            $script:result.content.offerIsRUPerMinuteThroughputEnabled | Should -Be $false
-        }
-    }
-
     Context 'When testing RBAC access using an Entra ID token' {
         Context 'When assigning an RBAC contributor role to the account for the principal' {
             It 'Should not throw an exception' {
@@ -1122,6 +1011,117 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
                     $script:cosmosDbResponseException.Message | Should -Be 'The remote server returned an error: (404) Not Found.'
                 }
             }
+        }
+    }
+
+    Context 'When adding a read collection permission for a user' {
+        It 'Should not throw an exception' {
+            $script:collectionResourcePath = Get-CosmosDbCollectionResourcePath `
+                -Database $script:testDatabase `
+                -Id $script:testCollection
+            $script:result = New-CosmosDbPermission `
+                -Context $script:testContext `
+                -UserId $script:testUser `
+                -Id $script:testCollectionPermission `
+                -Resource $script:collectionResourcePath `
+                -PermissionMode Read `
+                -Verbose
+        }
+
+        It 'Should return expected object' {
+            Test-GenericResult -GenericResult $script:result
+            $script:result.Id | Should -Be $script:testCollectionPermission
+            $script:result.permissionMode | Should -Be 'Read'
+            $script:result.resource | Should -Be $script:collectionResourcePath
+            $script:result.Token | Should -BeOfType [System.String]
+        }
+    }
+
+    Context 'When getting the read collection permission for the user' {
+        It 'Should not throw an exception' {
+            $script:collectionResourcePath = Get-CosmosDbCollectionResourcePath `
+                -Database $script:testDatabase `
+                -Id $script:testCollection
+            $script:result = Get-CosmosDbPermission `
+                -Context $script:testContext `
+                -UserId $script:testUser `
+                -Id $script:testCollectionPermission `
+                -Verbose
+        }
+
+        It 'Should return expected object' {
+            Test-GenericResult -GenericResult $script:result
+            $script:result.Id | Should -Be $script:testCollectionPermission
+            $script:result.permissionMode | Should -Be 'Read'
+            $script:result.resource | Should -Be $script:collectionResourcePath
+            $script:result.Token | Should -BeOfType [System.String]
+        }
+    }
+
+    Context 'When getting existing collection using resource token for user permission as context' {
+        It 'Should not throw an exception' {
+            $script:collectionResourcePath = Get-CosmosDbCollectionResourcePath `
+                -Database $script:testDatabase `
+                -Id $script:testCollection `
+                -Verbose
+            $permission = Get-CosmosDbPermission `
+                -Context $script:testContext `
+                -UserId $script:testUser `
+                -Id $script:testCollectionPermission `
+                -Verbose
+            $contextToken = New-CosmosDbContextToken `
+                -Resource $script:collectionResourcePath `
+                -TimeStamp $permission[0].Timestamp `
+                -Token (ConvertTo-SecureString -String $permission[0].Token -AsPlainText -Force) `
+                -Verbose
+            $resourceContext = New-CosmosDbContext `
+                -Account $script:testAccountName `
+                -Database $script:testDatabase `
+                -Token $contextToken `
+                -Verbose
+            $script:result = Get-CosmosDbCollection `
+                -Context $resourceContext `
+                -Id $script:testCollection `
+                -Verbose
+        }
+
+        It 'Should return expected object' {
+            Test-CollectionResultComplexAutomaticIndexingPolicy -CollectionResult $script:Result
+            $script:result.Id | Should -Be $script:testCollection
+        }
+    }
+
+    Context 'When getting existing offers' {
+        It 'Should not throw an exception' {
+            $script:result = Get-CosmosDbOffer -Context $script:testContext -Verbose
+        }
+
+        It 'Should return expected object' {
+            Test-GenericResult -GenericResult $script:result
+            $script:result.OfferVersion | Should -BeOfType [System.String]
+            $script:result.OfferType | Should -BeOfType [System.String]
+            $script:result.OfferResourceId | Should -BeOfType [System.String]
+            $script:result.Id | Should -BeOfType [System.String]
+            $script:result.content.offerThroughput | Should -Be 400
+            $script:result.content.offerIsRUPerMinuteThroughputEnabled | Should -Be $false
+        }
+    }
+
+    Context 'When updating existing offer throughput' {
+        It 'Should not throw an exception' {
+            $script:result = `
+                Get-CosmosDbOffer -Context $script:testContext -Verbose |
+                Set-CosmosDbOffer -Context $script:testContext -OfferThroughput 800 -Verbose
+        }
+
+        It 'Should return expected object' {
+            Test-GenericResult -GenericResult $script:result
+            $script:result.OfferVersion | Should -BeOfType [System.String]
+            $script:result.OfferType | Should -BeOfType [System.String]
+            $script:result.OfferResourceId | Should -BeOfType [System.String]
+            $script:result.Id | Should -BeOfType [System.String]
+            $script:result.content.offerThroughput | Should -Be 800
+            $script:result.content.offerIsRUPerMinuteThroughputEnabled | Should -Be $false
         }
     }
 

--- a/tests/Integration/CosmosDB.integration.Tests.ps1
+++ b/tests/Integration/CosmosDB.integration.Tests.ps1
@@ -61,6 +61,9 @@ if ([System.String]::IsNullOrEmpty($script:testBuildSystem))
     }
 }
 
+# Sanitize branch name: Azure resource group names only allow [-\w\._\(\)]
+$script:testBuildBranch = $script:testBuildBranch -replace '[^\w\-\._\(\)]', '-'
+
 $script:testResourceGroupName = ('cdbtestrgp-{0}-{1}-{2}' -f $script:testRandomName,$script:testBuildSystem,$script:testBuildBranch)
 $script:testAccountName = ('cdbtest{0}' -f $script:testRandomName)
 $script:testLocation = 'Australia East'

--- a/tests/Integration/CosmosDB.integration.Tests.ps1
+++ b/tests/Integration/CosmosDB.integration.Tests.ps1
@@ -1419,7 +1419,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
                 -Context $script:testContext `
                 -CollectionId $script:testCollection `
                 -Query "SELECT * FROM docs c" `
-                -QueryEnableCrossPartition $True `
+                -QueryEnableCrossPartition $true `
                 -Verbose
         }
 
@@ -1436,7 +1436,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
                 -Context $script:testContext `
                 -CollectionId $script:testCollection `
                 -Query "SELECT * FROM docs c WHERE (c.id = '$testDocumentUTF8Id')" `
-                -QueryEnableCrossPartition $True `
+                -QueryEnableCrossPartition $true `
                 -Verbose
         }
 
@@ -1453,7 +1453,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
                 -Context $script:testContext `
                 -CollectionId $script:testCollection `
                 -Query 'SELECT * FROM docs c WHERE (c.id = @id)' `
-                -QueryEnableCrossPartition $True `
+                -QueryEnableCrossPartition $true `
                 -QueryParameters @{
                     name = '@id'
                     value = $testDocumentUTF8Id

--- a/tests/Integration/CosmosDB.integration.Tests.ps1
+++ b/tests/Integration/CosmosDB.integration.Tests.ps1
@@ -670,6 +670,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
             $script:result = New-CosmosDbCollection `
                 -Context $script:testContext `
                 -Id $script:testCollection `
+                -PartitionKey $script:testPartitionKey `
                 -OfferThroughput 400 `
                 -Verbose
         }
@@ -697,6 +698,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
             $script:result = New-CosmosDbCollection `
                 -Context $script:testContext `
                 -Id $script:testCollection `
+                -PartitionKey $script:testPartitionKey `
                 -OfferThroughput 400 `
                 -IndexingPolicy $script:indexingPolicySimpleAutomatic `
                 -Verbose
@@ -719,6 +721,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
             $script:result = New-CosmosDbCollection `
                 -Context $script:testContext `
                 -Id $script:testCollection `
+                -PartitionKey $script:testPartitionKey `
                 -OfferThroughput 400 `
                 -IndexingPolicyJson (ConvertTo-Json -InputObject $script:indexingPolicySimpleAutomatic -Depth 10) `
                 -Verbose
@@ -758,6 +761,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
             $script:result = New-CosmosDbCollection `
                 -Context $script:testContext `
                 -Id $script:testCollection `
+                -PartitionKey $script:testPartitionKey `
                 -OfferThroughput 400 `
                 -IndexingPolicy $script:indexingPolicyComposite `
                 -Verbose
@@ -798,6 +802,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
             $script:result = New-CosmosDbCollection `
                 -Context $script:testContext `
                 -Id $script:testCollection `
+                -PartitionKey $script:testPartitionKey `
                 -OfferThroughput 400 `
                 -IndexingPolicy $script:indexingPolicyComplexAutomatic `
                 -UniqueKeyPolicy $script:uniqueKeyPolicy `

--- a/tests/Integration/CosmosDB.integration.Tests.ps1
+++ b/tests/Integration/CosmosDB.integration.Tests.ps1
@@ -1004,6 +1004,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
                     -Context $script:testEntraIdContext `
                     -CollectionId $script:testCollection `
                     -DocumentBody $script:testDocumentBody `
+                    -PartitionKey $script:testDocumentId `
                     -Verbose
             }
 
@@ -1021,6 +1022,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
                     -Context $script:testEntraIdContext `
                     -CollectionId $script:testCollection `
                     -Id $script:testDocumentId `
+                    -PartitionKey $script:testDocumentId `
                     -Verbose
             }
         }
@@ -1041,6 +1043,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
                     -Context $script:testEntraIdContext `
                     -CollectionId $script:testCollection `
                     -DocumentBody $script:testDocumentBody `
+                    -PartitionKey $script:testDocumentId `
                     -Verbose
             }
 
@@ -1058,6 +1061,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
                     -Context $script:testEntraIdContext `
                     -CollectionId $script:testCollection `
                     -Id $script:testDocumentId `
+                    -PartitionKey $script:testDocumentId `
                     -Verbose
             }
 
@@ -1075,6 +1079,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
                     -Context $script:testEntraIdContext `
                     -CollectionId $script:testCollection `
                     -Id $script:testDocumentId `
+                    -PartitionKey $script:testDocumentId `
                     -Verbose
             }
         }
@@ -1096,6 +1101,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
                             -Context $script:testEntraIdContext `
                             -CollectionId $script:testCollection `
                             -Id $script:testDocumentId `
+                            -PartitionKey $script:testDocumentId `
                             -Verbose
                     }
                     catch [CosmosDb.ResponseException]
@@ -1125,6 +1131,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
                 -Context $script:testContext `
                 -CollectionId $script:testCollection `
                 -DocumentBody $script:testDocumentBody `
+                -PartitionKey $script:testDocumentId `
                 -Verbose
         }
 
@@ -1207,6 +1214,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
                 -Context $resourceContext `
                 -CollectionId $script:testCollection `
                 -Id $script:testDocumentId `
+                -PartitionKey $script:testDocumentId `
                 -Verbose
         }
     }
@@ -1227,6 +1235,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
                 -Context $connectionStringContext `
                 -CollectionId $script:testCollection `
                 -Id $script:testDocumentId `
+                -PartitionKey $script:testDocumentId `
                 -Verbose
         }
     }
@@ -1379,6 +1388,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
                 -Context $script:testContext `
                 -CollectionId $script:testCollection `
                 -Id $script:testDocumentId `
+                -PartitionKey $script:testDocumentId `
                 -Verbose
         }
     }
@@ -1390,6 +1400,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
                 -CollectionId $script:testCollection `
                 -DocumentBody $script:testDocumentUTF8Body `
                 -Encoding 'UTF-8' `
+                -PartitionKey $script:testDocumentUTF8Id `
                 -Verbose
         }
 
@@ -1457,6 +1468,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
                 -Context $script:testContext `
                 -CollectionId $script:testCollection `
                 -Id $script:testDocumentUTF8Id `
+                -PartitionKey $script:testDocumentUTF8Id `
                 -Verbose
         }
 
@@ -1475,6 +1487,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
                 -Id $script:testDocumentUTF8Id `
                 -DocumentBody $script:testDocumentUTF8UpdateBody `
                 -Encoding 'UTF-8' `
+                -PartitionKey $script:testDocumentUTF8Id `
                 -Verbose
         }
 
@@ -1490,6 +1503,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
                 -Context $script:testContext `
                 -CollectionId $script:testCollection `
                 -Id $script:testDocumentUTF8Id `
+                -PartitionKey $script:testDocumentUTF8Id `
                 -Verbose
         }
 
@@ -1506,6 +1520,7 @@ Describe 'Cosmos DB Module' -Tag 'Integration' {
                 -Context $script:testContext `
                 -CollectionId $script:testCollection `
                 -Id $script:testDocumentUTF8Id `
+                -PartitionKey $script:testDocumentUTF8Id `
                 -Verbose
         }
     }

--- a/tests/Unit/CosmosDB.collections.Tests.ps1
+++ b/tests/Unit/CosmosDB.collections.Tests.ps1
@@ -766,9 +766,10 @@ InModuleScope $ProjectName {
 
             It 'Should not throw an exception' {
                 $newCosmosDbCollectionParameters = @{
-                    Context = $script:testContext
-                    Id      = $script:testCollection1
-                    Verbose = $true
+                    Context      = $script:testContext
+                    Id           = $script:testCollection1
+                    PartitionKey = 'partitionkey'
+                    Verbose      = $true
                 }
 
                 {
@@ -807,6 +808,7 @@ InModuleScope $ProjectName {
                     Context           = $script:testContext
                     Id                = $script:testCollection1
                     DefaultTimeToLive = $script:testDefaultTimeToLive
+                    PartitionKey      = 'partitionkey'
                     Verbose           = $true
                 }
 
@@ -846,6 +848,7 @@ InModuleScope $ProjectName {
                     Context         = $script:testContext
                     Id              = $script:testCollection1
                     OfferThroughput = 400
+                    PartitionKey    = 'partitionkey'
                     Verbose         = $true
                 }
 
@@ -866,26 +869,6 @@ InModuleScope $ProjectName {
             }
         }
 
-        Context 'When called with context parameter and an Id parameter and OfferThroughput is greater than 10000 but PartitionKey is not specified' {
-            $script:result = $null
-
-            It 'Should not throw an exception' {
-                $newCosmosDbCollectionParameters = @{
-                    Context         = $script:testContext
-                    Id              = $script:testCollection1
-                    OfferThroughput = 20000
-                    Verbose         = $true
-                }
-
-                $errorRecord = Get-InvalidOperationRecord `
-                    -Message $LocalizedData.ErrorNewCollectionParitionKeyOfferRequired
-
-                {
-                    $script:result = New-CosmosDbCollection @newCosmosDbCollectionParameters
-                } | Should -Throw $errorRecord
-            }
-        }
-
         Context 'When called with context parameter and an Id and OfferType parameter' {
             $script:result = $null
             $invokecosmosdbrequest_parameterfilter = {
@@ -902,10 +885,11 @@ InModuleScope $ProjectName {
 
             It 'Should not throw an exception' {
                 $newCosmosDbCollectionParameters = @{
-                    Context   = $script:testContext
-                    Id        = $script:testCollection1
-                    OfferType = 'S2'
-                    Verbose   = $true
+                    Context      = $script:testContext
+                    Id           = $script:testCollection1
+                    OfferType    = 'S2'
+                    PartitionKey = 'partitionkey'
+                    Verbose      = $true
                 }
 
                 {
@@ -965,26 +949,6 @@ InModuleScope $ProjectName {
             }
         }
 
-        Context 'When called with context parameter and an Id and AutoscaleThroughput but without a PartitionKey parameter' {
-            $script:result = $null
-
-            It 'Should throw expected exception' {
-                $newCosmosDbCollectionParameters = @{
-                    Context             = $script:testContext
-                    Id                  = $script:testCollection1
-                    AutoscaleThroughput = 1000
-                    Verbose             = $true
-                }
-
-                $errorRecord = Get-InvalidOperationRecord `
-                    -Message $LocalizedData.ErrorNewCollectionParitionKeyAutoscaleRequired
-
-                {
-                    $script:result = New-CosmosDbCollection @newCosmosDbCollectionParameters
-                } | Should -Throw $errorRecord
-            }
-        }
-
         Context 'When called with context parameter and an Id and AutoscaleThroughput and OfferThroughput parameter' {
             $script:result = $null
 
@@ -994,6 +958,7 @@ InModuleScope $ProjectName {
                     Id                  = $script:testCollection1
                     OfferThroughput     = 400
                     AutoscaleThroughput = 1000
+                    PartitionKey        = 'partitionkey'
                     Verbose             = $true
                 }
 
@@ -1015,6 +980,7 @@ InModuleScope $ProjectName {
                     Id                  = $script:testCollection1
                     OfferType           = 'S1'
                     AutoscaleThroughput = 1000
+                    PartitionKey        = 'partitionkey'
                     Verbose             = $true
                 }
 
@@ -1036,6 +1002,7 @@ InModuleScope $ProjectName {
                     Id                  = $script:testCollection1
                     OfferType           = 'S1'
                     OfferThroughput     = 400
+                    PartitionKey        = 'partitionkey'
                     Verbose             = $true
                 }
 
@@ -1068,6 +1035,7 @@ InModuleScope $ProjectName {
                     Context        = $script:testContext
                     Id             = $script:testCollection1
                     IndexingPolicy = $script:testIndexingPolicy
+                    PartitionKey   = 'partitionkey'
                     Verbose        = $true
                 }
 
@@ -1108,6 +1076,7 @@ InModuleScope $ProjectName {
                     Context            = $script:testContext
                     Id                 = $script:testCollection1
                     IndexingPolicyJson = $script:testIndexingPolicyJson
+                    PartitionKey       = 'partitionkey'
                     Verbose            = $true
                 }
 
@@ -1149,6 +1118,7 @@ InModuleScope $ProjectName {
                     Context         = $script:testContext
                     Id              = $script:testCollection1
                     UniqueKeyPolicy = $script:testUniqueKeyPolicy
+                    PartitionKey    = 'partitionkey'
                     Verbose         = $true
                 }
 
@@ -1262,6 +1232,7 @@ InModuleScope $ProjectName {
                     Id              = $script:testCollection1
                     OfferThroughput = 400
                     OfferType       = 'S1'
+                    PartitionKey    = 'partitionkey'
                     Verbose         = $true
                 }
 

--- a/tests/Unit/CosmosDB.documents.Tests.ps1
+++ b/tests/Unit/CosmosDB.documents.Tests.ps1
@@ -267,14 +267,13 @@ InModuleScope $ProjectName {
 
             It 'Should not throw exception' {
                 $getCosmosDbDocumentParameters = @{
-                    Context             = $script:testContext
-                    CollectionId        = $script:testCollection
-                    MaxItemCount        = 5
-                    ContinuationToken   = 'token'
-                    ConsistencyLevel    = 'Strong'
-                    SessionToken        = 'session'
-                    PartitionKeyRangeId = 'partition'
-                    Verbose             = $true
+                    Context           = $script:testContext
+                    CollectionId      = $script:testCollection
+                    MaxItemCount      = 5
+                    ContinuationToken = 'token'
+                    ConsistencyLevel  = 'Strong'
+                    SessionToken      = 'session'
+                    Verbose           = $true
                 }
 
                 { $script:result = Get-CosmosDbDocument @getCosmosDbDocumentParameters } | Should -Not -Throw
@@ -665,14 +664,13 @@ InModuleScope $ProjectName {
 
             It 'Should not throw exception' {
                 $getCosmosDbDocumentJsonParameters = @{
-                    Context             = $script:testContext
-                    CollectionId        = $script:testCollection
-                    MaxItemCount        = 5
-                    ContinuationToken   = 'token'
-                    ConsistencyLevel    = 'Strong'
-                    SessionToken        = 'session'
-                    PartitionKeyRangeId = 'partition'
-                    Verbose             = $true
+                    Context           = $script:testContext
+                    CollectionId      = $script:testCollection
+                    MaxItemCount      = 5
+                    ContinuationToken = 'token'
+                    ConsistencyLevel  = 'Strong'
+                    SessionToken      = 'session'
+                    Verbose           = $true
                 }
 
                 { $script:result = Get-CosmosDbDocumentJson @getCosmosDbDocumentJsonParameters } | Should -Not -Throw

--- a/tests/Unit/CosmosDB.utils.Tests.ps1
+++ b/tests/Unit/CosmosDB.utils.Tests.ps1
@@ -1076,7 +1076,7 @@ console.log("done");
                 Assert-MockCalled -CommandName Get-AzAccessToken -Exactly -Times 1 `
                     -ParameterFilter {
                         $AsSecureString -and `
-                        $ResourceUrl -eq ('https://{0}.{1}' -f $script:testAccount, $script:testBaseHostnameAzureCustomEndpoint)
+                        $ResourceUrl -eq 'https://cosmos.azure.com'
                     }
             }
         }
@@ -1114,7 +1114,7 @@ console.log("done");
                 Assert-MockCalled -CommandName Get-AzAccessToken -Exactly -Times 1 `
                     -ParameterFilter {
                         $AsSecureString -and `
-                        $ResourceUrl -eq ('https://{0}.documents.azure.com' -f $script:testAccount)
+                        $ResourceUrl -eq 'https://cosmos.azure.com'
                     }
             }
         }
@@ -1227,6 +1227,108 @@ console.log("done");
             It 'Should return expected result' {
                 $script:result | Should -BeOfType uri
                 $script:result.ToString() | Should -Be ('https://{0}.{1}/' -f $script:testAccount, $script:testBaseHostnameAzureChinaCloud)
+            }
+        }
+    }
+
+    Describe 'Get-CosmosDbEntraIdEndpoint' -Tag 'Unit' {
+        It 'Should exist' {
+            { Get-Command -Name Get-CosmosDbEntraIdEndpoint -ErrorAction Stop } | Should -Not -Throw
+        }
+
+        Context 'When called without parameters' {
+            $script:result = $null
+
+            It 'Should not throw exception' {
+                { $script:result = Get-CosmosDbEntraIdEndpoint } | Should -Not -Throw
+            }
+
+            It 'Should return the AzureCloud endpoint' {
+                $script:result | Should -Be 'https://cosmos.azure.com'
+            }
+        }
+
+        Context 'When called with Environment set to AzureCloud' {
+            $script:result = $null
+
+            It 'Should not throw exception' {
+                { $script:result = Get-CosmosDbEntraIdEndpoint -Environment 'AzureCloud' } | Should -Not -Throw
+            }
+
+            It 'Should return the AzureCloud endpoint' {
+                $script:result | Should -Be 'https://cosmos.azure.com'
+            }
+        }
+
+        Context 'When called with Environment set to AzureUSGovernment' {
+            $script:result = $null
+
+            It 'Should not throw exception' {
+                { $script:result = Get-CosmosDbEntraIdEndpoint -Environment 'AzureUSGovernment' } | Should -Not -Throw
+            }
+
+            It 'Should return the AzureUSGovernment endpoint' {
+                $script:result | Should -Be 'https://cosmos.azure.us'
+            }
+        }
+
+        Context 'When called with Environment set to AzureChinaCloud' {
+            $script:result = $null
+
+            It 'Should not throw exception' {
+                { $script:result = Get-CosmosDbEntraIdEndpoint -Environment 'AzureChinaCloud' } | Should -Not -Throw
+            }
+
+            It 'Should return the AzureChinaCloud endpoint' {
+                $script:result | Should -Be 'https://cosmos.azure.cn'
+            }
+        }
+
+        Context 'When called with BaseHostname matching AzureCloud pattern' {
+            $script:result = $null
+
+            It 'Should not throw exception' {
+                { $script:result = Get-CosmosDbEntraIdEndpoint -BaseHostname 'documents.azure.com' } | Should -Not -Throw
+            }
+
+            It 'Should return the AzureCloud endpoint' {
+                $script:result | Should -Be 'https://cosmos.azure.com'
+            }
+        }
+
+        Context 'When called with BaseHostname matching AzureUSGovernment pattern' {
+            $script:result = $null
+
+            It 'Should not throw exception' {
+                { $script:result = Get-CosmosDbEntraIdEndpoint -BaseHostname 'documents.azure.us' } | Should -Not -Throw
+            }
+
+            It 'Should return the AzureUSGovernment endpoint' {
+                $script:result | Should -Be 'https://cosmos.azure.us'
+            }
+        }
+
+        Context 'When called with BaseHostname matching AzureChinaCloud pattern' {
+            $script:result = $null
+
+            It 'Should not throw exception' {
+                { $script:result = Get-CosmosDbEntraIdEndpoint -BaseHostname 'documents.azure.cn' } | Should -Not -Throw
+            }
+
+            It 'Should return the AzureChinaCloud endpoint' {
+                $script:result | Should -Be 'https://cosmos.azure.cn'
+            }
+        }
+
+        Context 'When called with an unrecognised BaseHostname' {
+            $script:result = $null
+
+            It 'Should not throw exception' {
+                { $script:result = Get-CosmosDbEntraIdEndpoint -BaseHostname 'documents.somecloud.zzz' } | Should -Not -Throw
+            }
+
+            It 'Should return the AzureCloud endpoint as the default' {
+                $script:result | Should -Be 'https://cosmos.azure.com'
             }
         }
     }
@@ -2402,6 +2504,72 @@ console.log("done");
             It 'Should call expected mocks' {
                 Assert-MockCalled -CommandName Get-AzAccessToken -Exactly -Times 1 `
                     -ParameterFilter { $ResourceUrl -eq 'https://cosmos.azure.com' }
+            }
+        }
+
+        Context 'When called with Environment set to AzureUSGovernment' {
+            $script:result = $null
+
+            Mock Get-AzAccessToken -MockWith {
+                return @{
+                    Token = $script:testEntraIdTokenSecureString
+                }
+            }
+
+            It 'Should not throw exception' {
+                $getCosmosDbEntraIdTokenParameters = @{
+                    Environment = 'AzureUSGovernment'
+                }
+                { $script:result = Get-CosmosDbEntraIdToken @getCosmosDbEntraIdTokenParameters } | Should -Not -Throw
+            }
+
+            It 'Should return a secure string' {
+                $script:result | Should -BeOfType [System.Security.SecureString]
+            }
+
+            It 'Should return secure string containing the expected token' {
+                $script:result | Convert-CosmosDbSecureStringToString | Should -Be $script:testEntraIdToken
+            }
+
+            It 'Should call expected mocks' {
+                Assert-MockCalled -CommandName Get-AzAccessToken -Exactly -Times 1 `
+                    -ParameterFilter {
+                        $AsSecureString -and
+                        $ResourceUrl -eq 'https://cosmos.azure.us'
+                    }
+            }
+        }
+
+        Context 'When called with Environment set to AzureChinaCloud' {
+            $script:result = $null
+
+            Mock Get-AzAccessToken -MockWith {
+                return @{
+                    Token = $script:testEntraIdTokenSecureString
+                }
+            }
+
+            It 'Should not throw exception' {
+                $getCosmosDbEntraIdTokenParameters = @{
+                    Environment = 'AzureChinaCloud'
+                }
+                { $script:result = Get-CosmosDbEntraIdToken @getCosmosDbEntraIdTokenParameters } | Should -Not -Throw
+            }
+
+            It 'Should return a secure string' {
+                $script:result | Should -BeOfType [System.Security.SecureString]
+            }
+
+            It 'Should return secure string containing the expected token' {
+                $script:result | Convert-CosmosDbSecureStringToString | Should -Be $script:testEntraIdToken
+            }
+
+            It 'Should call expected mocks' {
+                Assert-MockCalled -CommandName Get-AzAccessToken -Exactly -Times 1 `
+                    -ParameterFilter {
+                        $AsSecureString -and
+                        $ResourceUrl -eq 'https://cosmos.azure.cn'
+                    }
             }
         }
     }

--- a/tests/Unit/CosmosDB.utils.Tests.ps1
+++ b/tests/Unit/CosmosDB.utils.Tests.ps1
@@ -1856,45 +1856,6 @@ console.log("done");
             }
         }
 
-        Context 'When called with context parameter and ApiVersion is overridden' {
-            $InvokeWebRequest_parameterfilter = {
-                $Method -eq 'Get' -and `
-                    $ContentType -eq 'application/json' -and `
-                    $Headers['x-ms-version'] -eq '2018-12-31' -and `
-                    $Uri -eq ('{0}dbs/{1}/{2}' -f $script:testContext.BaseUri, $script:testContext.Database, 'users')
-            }
-
-            Mock `
-                -CommandName Invoke-WebRequest `
-                -MockWith $InvokeWebRequest_mockwith
-
-            $script:result = $null
-
-            It 'Should not throw exception' {
-                $invokeCosmosDbRequestparameters = @{
-                    Context      = $script:testContext
-                    Method       = 'Get'
-                    ResourceType = 'users'
-                    ApiVersion   = '2018-12-31'
-                    Verbose      = $true
-                }
-
-                { $script:result = (Invoke-CosmosDbRequest @invokeCosmosDbRequestparameters).Content | ConvertFrom-Json } | Should -Not -Throw
-            }
-
-            It 'Should return expected result' {
-                $script:result._count | Should -Be 1
-            }
-
-            It 'Should call expected mocks' {
-                Assert-MockCalled `
-                    -CommandName Invoke-WebRequest `
-                    -ParameterFilter $InvokeWebRequest_parameterfilter `
-                    -Exactly -Times 1
-                Assert-MockCalled -CommandName Get-Date -Exactly -Times 1
-            }
-        }
-
         Context 'When called with context parameter and Get method but System.Net.WebException exception is thrown' {
             $InvokeWebRequest_parameterfilter = {
                 $Method -eq 'Get' -and `

--- a/tests/Unit/CosmosDB.utils.Tests.ps1
+++ b/tests/Unit/CosmosDB.utils.Tests.ps1
@@ -1958,6 +1958,49 @@ console.log("done");
             }
         }
 
+        Context 'When called with context parameter and Headers includes x-ms-version' {
+            $InvokeWebRequest_parameterfilter = {
+                $Method -eq 'Get' -and `
+                    $ContentType -eq 'application/json' -and `
+                    $Headers['x-ms-version'] -eq '2020-07-15' -and `
+                    $Headers['x-ms-documentdb-query-enablecrosspartition'] -eq 'true' -and `
+                    $Uri -eq ('{0}dbs/{1}/{2}' -f $script:testContext.BaseUri, $script:testContext.Database, 'users')
+            }
+
+            Mock `
+                -CommandName Invoke-WebRequest `
+                -MockWith $InvokeWebRequest_mockwith
+
+            $script:result = $null
+
+            It 'Should not throw exception' {
+                $invokeCosmosDbRequestparameters = @{
+                    Context      = $script:testContext
+                    Method       = 'Get'
+                    ResourceType = 'users'
+                    Headers      = @{
+                        'x-ms-version'                            = '2018-12-31'
+                        'x-ms-documentdb-query-enablecrosspartition' = 'true'
+                    }
+                    Verbose      = $true
+                }
+
+                { $script:result = (Invoke-CosmosDbRequest @invokeCosmosDbRequestparameters).Content | ConvertFrom-Json } | Should -Not -Throw
+            }
+
+            It 'Should return expected result' {
+                $script:result._count | Should -Be 1
+            }
+
+            It 'Should call expected mocks' {
+                Assert-MockCalled `
+                    -CommandName Invoke-WebRequest `
+                    -ParameterFilter $InvokeWebRequest_parameterfilter `
+                    -Exactly -Times 1
+                Assert-MockCalled -CommandName Get-Date -Exactly -Times 1
+            }
+        }
+
         Context 'When called with context parameter and Get method but System.Net.WebException exception is thrown' {
             $InvokeWebRequest_parameterfilter = {
                 $Method -eq 'Get' -and `


### PR DESCRIPTION
## Summary

Closes #528

Removes all legacy non-partitioned collection support from the module, enforces a mandatory partition key on collection creation, and drops two obsolete parameters that only existed to serve non-partitioned scenarios. Also fixes a CI build failure caused by an invalid GitVersion verbosity setting and a hard-coded GitVersion 5.x pin.

---

## Breaking Changes

### `New-CosmosDbCollection` — `PartitionKey` is now mandatory

`-PartitionKey` was previously optional, allowing creation of legacy non-partitioned collections (unsupported by Azure Cosmos DB since 2020). It is now a required parameter.

```powershell
# Before (no longer works)
New-CosmosDbCollection -Context $ctx -Id 'myCollection'

# After
New-CosmosDbCollection -Context $ctx -Id 'myCollection' -PartitionKey 'id'
```

### `Get-CosmosDbDocument` / `Get-CosmosDbDocumentJson` — `-PartitionKeyRangeId` removed

Used exclusively for cross-partition fan-out on legacy non-partitioned collections. Removed from both cmdlets.

### `Invoke-CosmosDbRequest` — `-ApiVersion` removed

The Cosmos DB REST API version is now pinned internally to `2020-07-15`. The override parameter is removed.

---

## Other Changes

- Removed string resources `NonPartitionedCollectionWarning`, `ErrorNewCollectionParitionKeyOfferRequired`, `ErrorNewCollectionParitionKeyAutoscaleRequired`
- Updated unit tests for all affected cmdlets; removed `ApiVersion` override test context
- Updated PlatyPS docs for `New-CosmosDbCollection`, `Get-CosmosDbDocument`, `Get-CosmosDbDocumentJson`, `Invoke-CosmosDbRequest`
- Added `CHANGELOG.md` entry under `[Unreleased]`

---

## CI Fix

The build job was failing with `Error parsing Infinity value` in `ConvertFrom-Json`.

Root causes fixed:
1. `verbosity: None` in `GitVersion.yml` is not a valid value — changed to `verbosity: Quiet`
2. CI was pinned to GitVersion 5.x with no output filtering — updated to `6.*` and added the same log-line filter + `SemVer` fallback used in `.build-local.ps1`

---

## Testing

- All unit tests pass via `.build-local.ps1 -Tasks test -PesterScript tests/Unit`
- Build succeeds via `.build-local.ps1 -Tasks build`
